### PR TITLE
Fix vmware spec tests

### DIFF
--- a/spec/models/manageiq/providers/vmware/infra_manager/metric_capture_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/metric_capture_spec.rb
@@ -1,4 +1,4 @@
-require Rails.root.join('spec/tools/vim_data/vim_data_test_helper')
+require ManageIQ::Providers::Vmware::Engine.root.join('spec/tools/vim_data/vim_data_test_helper.rb').to_s
 
 describe ManageIQ::Providers::Vmware::InfraManager::MetricsCapture do
   before(:each) do

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -1,4 +1,4 @@
-require Rails.root.join('spec/tools/vim_data/vim_data_test_helper')
+require ManageIQ::Providers::Vmware::Engine.root.join('spec/tools/vim_data/vim_data_test_helper.rb').to_s
 
 describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
   before(:each) do

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_storage_profile_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_storage_profile_spec.rb
@@ -1,4 +1,4 @@
-require Rails.root.join('spec/tools/vim_data/vim_data_test_helper')
+require ManageIQ::Providers::Vmware::Engine.root.join('spec/tools/vim_data/vim_data_test_helper.rb').to_s
 
 describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
   let(:zone) { EvmSpecHelper.create_guid_miq_server_zone[2] }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,10 +3,9 @@ if ENV['CI']
   SimpleCov.start
 end
 
-# Uncomment in case you use vcr cassettes
-#VCR.configure do |config|
-#  config.ignore_hosts 'codeclimate.com' if ENV['CI']
-#  config.cassette_library_dir = File.join(ManageIQ::Providers::Vmware::Engine.root, 'spec/vcr_cassettes')
-#end
+VCR.configure do |config|
+  config.ignore_hosts 'codeclimate.com' if ENV['CI']
+  config.cassette_library_dir = File.join(ManageIQ::Providers::Vmware::Engine.root, 'spec/vcr_cassettes')
+end
 
 Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }


### PR DESCRIPTION
Missed the big comment that said `# Uncomment in case you use vcr cassettes` and requires with `Rails.root` are no longer working so use the `Engine.root`