### PR TITLE
Decode the dvSwitch and dvPortgroup name

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -524,7 +524,7 @@ module ManageIQ::Providers
           unless dvportgroup_uid_ems.key?(uid)
             dvportgroup_uid_ems[uid] = {
               :uid_ems           => uid,
-              :name              => spec['name'],
+              :name              => URI.decode(spec['name']),
               :tag               => spec.fetch_path('defaultPortConfig', 'vlan', 'vlanId').to_s,
 
               :allow_promiscuous => security_policy.fetch_path('allowPromiscuous', 'value').to_s.casecmp('true') == 0,

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -447,6 +447,7 @@ module ManageIQ::Providers
         dvswitch_inv.to_miq_a.each do |data|
           config = data.fetch('config', {})
           uid = data['MOR']
+          name              = config['name'] || data.fetch_path('summary', 'name')
           security_policy   = config.fetch('defaultPortConfig', {}).fetch('securityPolicy', {})
           allow_promiscuous = security_policy.fetch_path('allowPromiscuous', 'value')
           forged_transmits  = security_policy.fetch_path('forgedTransmits', 'value')
@@ -454,7 +455,7 @@ module ManageIQ::Providers
 
           dvswitch_uid_ems[uid] || dvswitch_uid_ems[uid] = {
             :uid_ems           => uid,
-            :name              => config['name'] || data.fetch_path('summary', 'name'),
+            :name              => URI.decode(name),
             :ports             => config['numPorts'] || 0,
 
             :allow_promiscuous => allow_promiscuous.nil? ? nil : allow_promiscuous.to_s.casecmp('true') == 0,

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -32,6 +32,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     assert_specific_storage
     assert_specific_storage_cluster
     assert_specific_storage_profile
+    assert_specific_dvportgroup
     assert_specific_host
     assert_specific_vm
     assert_cpu_layout
@@ -349,6 +350,13 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
 
     expect(@storage_profile.storages).to include(@storage)
     expect(@storage.storage_profiles).to include(@storage_profile)
+  end
+
+  def assert_specific_dvportgroup
+    # Check that a dvPortgroup with a slash in the name is decoded from
+    # %2f to / by the RefreshParser
+    dvpg = Lan.find_by(:uid_ems => 'dvportgroup-122')
+    expect(dvpg.name).to eq('DC1 / DVPG1')
   end
 
   def assert_specific_host

--- a/spec/tools/vim_data/miq_vim_inventory/dvPortgroupsByMor.yml
+++ b/spec/tools/vim_data/miq_vim_inventory/dvPortgroupsByMor.yml
@@ -171,7 +171,7 @@
           xsiType: :SOAP::SOAPString
           vimType: 
         name: !ruby/string:VimString
-          str: DC1_DVPG1
+          str: DC1 %2f DVPG1
           xsiType: :SOAP::SOAPString
           vimType: 
       ivars:
@@ -180,7 +180,7 @@
     summary: !ruby/hash-with-ivars:VimHash
       elements:
         name: !ruby/string:VimString
-          str: DC1_DVPG1
+          str: DC1 %2f DVPG1
           xsiType: :SOAP::SOAPString
           vimType: 
       ivars:


### PR DESCRIPTION
If dvSwitch and dvPortgroup names have a `'/'` in the name VMware will encode these as `'%2f'`
This will decode these names in the `RefreshParser` similar to what is done with VM names.

Before:
![screenshot from 2017-01-24 15-27-44](https://cloud.githubusercontent.com/assets/12851112/22265616/c8f8e2f0-e24a-11e6-9424-491c9b877988.png)

After:
![screenshot from 2017-01-24 15-30-31](https://cloud.githubusercontent.com/assets/12851112/22265623/ccb9adfc-e24a-11e6-8f86-fd2671a74c52.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1411527