### PR TITLE
Use the dvportgroup config.key for the uid_ems

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -518,7 +518,7 @@ module ManageIQ::Providers
           switch = switch_uids[spec['distributedVirtualSwitch']]
           next if switch.nil?
 
-          uid = data['MOR']
+          uid = spec['key']
           security_policy = spec.fetch_path('defaultPortConfig', 'securityPolicy') || {}
 
           unless dvportgroup_uid_ems.key?(uid)

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -431,6 +431,14 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :computed_mac_changes       => nil
     )
 
+    # If a dvPortgroup has a different key than its MOR ensure
+    # that we use config.key as the uid_ems
+    dvslan = dvswitch.lans.find_by(:name => "DC1_DVPG1")
+    expect(dvslan).to have_attributes(
+      :uid_ems                    => 'dvportgroup-12222',
+      :name                       => 'DC1_DVPG1'
+    )
+
     switch = @host.switches.find_by(:name => "vSwitch0")
     expect(switch).to have_attributes(
       :uid_ems           => "vSwitch0",

--- a/spec/tools/vim_data/miq_vim_inventory/dvPortgroupsByMor.yml
+++ b/spec/tools/vim_data/miq_vim_inventory/dvPortgroupsByMor.yml
@@ -167,7 +167,7 @@
           xsiType: :ManagedObjectReference
           vimType: :VmwareDistributedVirtualSwitch
         key: !ruby/string:VimString
-          str: dvportgroup-122
+          str: dvportgroup-12222
           xsiType: :SOAP::SOAPString
           vimType: 
         name: !ruby/string:VimString


### PR DESCRIPTION
The dvportgroup MOR and key can be different and the key is what needs to be used when provisioning so use that as the uid_ems.

This can happen if you import a dvSwitch and check `Preserve original distributed switch and port identifiers`.

https://bugzilla.redhat.com/show_bug.cgi?id=1414975