### PR TITLE
Add vm_acquire_ticket for webmks console types

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -404,6 +404,11 @@ module ManageIQ::Providers
     end
     alias_method :vm_remote_console_acquire_ticket, :vm_acquire_ticket
 
+    def vm_acquire_webmks_ticket(vm, options = {})
+      vm_acquire_ticket(vm, options.merge(:ticket_type => 'webmks'))
+    end
+    alias_method :vm_remote_console_acquire_webmks_ticket, :vm_acquire_webmks_ticket
+
     def vm_add_miq_alarm(vm, _options = {})
       result = nil
       vm.with_provider_object do |vim_vm|

--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -399,6 +399,11 @@ module ManageIQ::Providers
     end
     alias_method :vm_remote_console_mks_acquire_ticket, :vm_acquire_mks_ticket
 
+    def vm_acquire_ticket(vm, options = {})
+      invoke_vim_ws(:acquireTicket, vm, options[:user_event], options[:ticket_type])
+    end
+    alias_method :vm_remote_console_acquire_ticket, :vm_acquire_ticket
+
     def vm_add_miq_alarm(vm, _options = {})
       result = nil
       vm.with_provider_object do |vim_vm|


### PR DESCRIPTION
Add a method to acquire a webmks ticket for a VMware vm using the `VirtualMachine#AcquireTicket` method

Depends on: https://github.com/ManageIQ/manageiq-gems-pending/pull/59

https://github.com/ManageIQ/manageiq/issues/13798