### PR TITLE
Allow changing the device type of an existing vnic

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/network.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/network.rb
@@ -50,7 +50,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration::Netw
   def build_config_spec_vlan(network, vnicDev, vmcs)
     operation = vnicDev.nil? ? VirtualDeviceConfigSpecOperation::Add : VirtualDeviceConfigSpecOperation::Edit
     add_device_config_spec(vmcs, operation) do |vdcs|
-      vdcs.device = vnicDev || create_vlan_device(network)
+      vdcs.device = edit_vlan_device(network, vnicDev) || create_vlan_device(network)
       _log.info "Setting target network device to Device Name:<#{network[:network]}>  Device:<#{vdcs.device.inspect}>"
 
       vdcs.device.backing = VimHash.new('VirtualEthernetCardNetworkBackingInfo') do |vecnbi|
@@ -79,7 +79,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration::Netw
 
     operation = vnicDev.nil? ? VirtualDeviceConfigSpecOperation::Add : VirtualDeviceConfigSpecOperation::Edit
     add_device_config_spec(vmcs, operation) do |vdcs|
-      vdcs.device = vnicDev || create_vlan_device(network)
+      vdcs.device = edit_vlan_device(network, vnicDev) || create_vlan_device(network)
       _log.info "Setting target network device to Device Name:<#{network[:network]}>  Device:<#{vdcs.device.inspect}>"
 
       #
@@ -114,6 +114,16 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration::Netw
         con.connected         = get_config_spec_value(network, 'true', nil, [:connectable, :connected])
       end
     end
+  end
+
+  def edit_vlan_device(network, vnic)
+    # If a device type was provided override the type of the existing vnic
+    device_type = get_config_spec_value(network, nil, nil, [:devicetype])
+    if device_type && vnic.xsiType != device_type
+      vnic.xsiType = device_type
+    end
+
+    vnic
   end
 
   def find_dvs_by_name(vim, dvs_name)

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
@@ -93,6 +93,23 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
         expect(vmcs["deviceChange"][0]["device"]["backing"].xsiType).to eq("VirtualEthernetCardNetworkBackingInfo")
       end
 
+      it "should change the device type of existing network cards" do
+        requested_networks = [{:network => "Enterprise", :devicetype => "VirtualVmxnet3"}]
+        template_networks  = [
+          VimHash.new("VirtualE1000")  do |vnic|
+            vnic.backing = VimHash.new("VirtualEthernetCardNetworkBackingInfo")
+          end
+        ]
+
+        allow(@vm_prov).to receive(:normalize_network_adapter_settings).and_return(requested_networks)
+        allow(@vm_prov).to receive(:get_network_adapters).and_return(template_networks)
+
+        vmcs = VimHash.new("VirtualMachineConfigSpec")
+        @vm_prov.build_config_network_adapters(vmcs)
+
+        expect(vmcs.deviceChange[0].device.xsiType).to eq("VirtualVmxnet3")
+      end
+
       it "eligible_hosts" do
         host = FactoryGirl.create(:host, :ext_management_system => @ems)
         host_struct = [MiqHashStruct.new(:id => host.id, :evm_object_class => host.class.base_class.name.to_sym)]


### PR DESCRIPTION
When creating a new vNIC we use the provided `:devicetype` from the provision request, but if using an existing vNIC from the template we don't change it.  This will edit the existing vNIC's xsiType to match the devicetype that was requested.

https://bugzilla.redhat.com/show_bug.cgi?id=1421182