### PR TITLE
Fix issue provisioning to a VM Network from a DVS

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/network.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/network.rb
@@ -52,7 +52,11 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration::Netw
     add_device_config_spec(vmcs, operation) do |vdcs|
       vdcs.device = vnicDev || create_vlan_device(network)
       _log.info "Setting target network device to Device Name:<#{network[:network]}>  Device:<#{vdcs.device.inspect}>"
-      vdcs.device.backing.deviceName = network[:network]
+
+      vdcs.device.backing = VimHash.new('VirtualEthernetCardNetworkBackingInfo') do |vecnbi|
+        vecnbi.deviceName = network[:network]
+      end
+
       #
       # Manually assign MAC address to target VM.
       #
@@ -108,9 +112,6 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration::Netw
         con.allowGuestControl = get_config_spec_value(network, 'true', nil, [:connectable, :allowguestcontrol])
         con.startConnected    = get_config_spec_value(network, 'true', nil, [:connectable, :startconnected])
         con.connected         = get_config_spec_value(network, 'true', nil, [:connectable, :connected])
-      end
-      vDev.backing = VimHash.new('VirtualEthernetCardNetworkBackingInfo') do |bck|
-        bck.deviceName = network[:network]
       end
     end
   end


### PR DESCRIPTION
When provisioning a VM from a template that has a NIC on a DV Portgroup to a regular VM network the NIC backing isn't reset, just the network name is set but the rest of the dvportgroup settings are still there.  This causes the new NIC to be put on the populated
portgroup port and the provision will fail.

![screenshot from 2017-02-10 15-31-54](https://cloud.githubusercontent.com/assets/12851112/22843389/538bdaf8-efa7-11e6-8daa-52ac51663ba4.png)
