### PR TITLE
Removed supports_snapshots? methods defined independently without using supportsFeatureMixin plugin

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm.rb
@@ -26,9 +26,6 @@ class ManageIQ::Providers::Vmware::InfraManager::Vm < ManageIQ::Providers::Infra
     true
   end
 
-  def supports_snapshots?
-    true
-  end
-
+  supports :snapshots
   supports :quick_stats
 end


### PR DESCRIPTION
Removed instance where supports_snapshots? method was defined without using supportsFeatureMixin.