### PR TITLE
Fix wrong number of arguments error when opening MKS console

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
@@ -39,7 +39,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole
   # MKS
   #
 
-  def remote_console_mks_acquire_ticket
+  def remote_console_mks_acquire_ticket(_userid = nil, _originating_server = nil)
     validate_remote_console_acquire_ticket("mks", :check_if_running => false)
     ext_management_system.vm_remote_console_mks_acquire_ticket(self)
   end


### PR DESCRIPTION
When opening a MKS console there is currently a 'Console access failed: wrong number of arguments (given 2, expected 0)'.  This error is only reproducible after a missing route is fixed in https://github.com/ManageIQ/manageiq-ui-classic/pull/463

https://bugzilla.redhat.com/show_bug.cgi?id=1410376