### PR TITLE
Add a simple event history script

### DIFF
--- a/tools/event_history.rb
+++ b/tools/event_history.rb
@@ -41,15 +41,17 @@ connect_opts = {
 
 vim = RbVmomi::VIM.connect connect_opts
 
-eventCollector = vim.serviceContent.eventManager.CreateCollectorForEvents(
-  :filter => RbVmomi::VIM::EventFilterSpec.new(:eventTypeId => filter_events)
-)
+begin
+  eventCollector = vim.serviceContent.eventManager.CreateCollectorForEvents(
+    :filter => RbVmomi::VIM::EventFilterSpec.new(:eventTypeId => filter_events)
+  )
 
-eventCollector.RewindCollector()
-until (events = eventCollector.ReadNextEvents(:maxCount => 100)).empty?
-  events.each do |event|
-    puts "#{event.class.name} ID: #{event.key} Chain ID: #{event.chainId} Time: #{event.createdTime} #{event.fullFormattedMessage}"
+  eventCollector.RewindCollector()
+  until (events = eventCollector.ReadNextEvents(:maxCount => 100)).empty?
+    events.each do |event|
+      puts "#{event.class.name} ID: #{event.key} Chain ID: #{event.chainId} Time: #{event.createdTime} #{event.fullFormattedMessage}"
+    end
   end
+ensure
+  eventCollector.DestroyCollector() if eventCollector
 end
-
-eventCollector.DestroyCollector()

--- a/tools/event_history.rb
+++ b/tools/event_history.rb
@@ -1,0 +1,31 @@
+require 'rbvmomi'
+
+#TODO parse command line args
+ems = ManageIQ::Providers::Vmware::InfraManager.first
+host = ems.hostname
+user = ems.authentication_userid(:default)
+password = ems.authentication_password(:default)
+filter_events = ['TaskEvent', 'VmBeingDeployedEvent', 'VmDeployedEvent']
+
+connect_opts = {
+  :host => host,
+  :user => user,
+  :password => password,
+  :insecure => true
+}
+
+vim = RbVmomi::VIM.connect connect_opts
+
+eventCollector = vim.serviceContent.eventManager.CreateCollectorForEvents(
+  :filter => RbVmomi::VIM::EventFilterSpec.new(:eventTypeId => filter_events)
+)
+
+eventCollector.RewindCollector()
+until (events = eventCollector.ReadNextEvents(:maxCount => 100)).empty?
+  events.each do |event|
+    next if event.kind_of?(RbVmomi::VIM::TaskEvent) && event.info.name != 'CloneVM_Task'
+    puts "#{event.class.name} ID: #{event.key} Chain ID: #{event.chainId} Time: #{event.createdTime} VM: #{event.vm.vm}: #{event.fullFormattedMessage}"
+  end
+end
+
+eventCollector.DestroyCollector()


### PR DESCRIPTION
Add a little utility to print the events from the VC event history, takes arguments for which ems you want to use and which events you want to include

Example from a support case:
`rails r plugins/manageiq-providers-vmware/tools/event_history.rb --ems=dev-vc65 --events=VmBeingDeployedEvent,VmDeployedEvent,TaskEvent`