### PR TITLE
Validate deviceMode on a VirtualDisk Backing before reconfigure

### DIFF
--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
@@ -189,6 +189,13 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
       expect(subject.fetch_path("device", "backing", "diskMode")).to        eq("independent_nonpersistent")
       expect(subject.fetch_path("device", "backing", "fileName")).to        eq("[#{vm.storage.name}]")
     end
+
+    it 'with invalid diskMode' do
+      @options[:dependent]  = true
+      @options[:persistent] = false
+
+      expect { subject }.to raise_error(MiqException::MiqVmError, "Disk mode nonpersistent is not supported for virtual disk")
+    end
   end
 
   context '#remove_disk_config_spec' do


### PR DESCRIPTION
The user has the option of setting the disk mode when adding a disk during reconfigure, the possible options provided by VMware are: append, independent_nonpersistent, independent_persistent, nonpersistent, persistent, undoable [[ref](https://www.vmware.com/support/developer/vc-sdk/visdk400pubs/ReferenceGuide/vim.vm.device.VirtualDiskOption.DiskMode.html)]

However not all of these options are valid for all backing type.  Specifically the backing type that we use for new disks (`VirtualDiskFlatVer2Backing`) only supports `persistent`, `independnet_persistent`, and `independent_nonpersistent` [[ref](http://pubs.vmware.com/vsphere-60/index.jsp#com.vmware.wssdk.apiref.doc/vim.vm.device.VirtualDiskOption.FlatVer2BackingOption.html)]

> VirtualDiskFlatVer2BackingOption
> diskMode
> The disk mode. Valid disk modes are:
> persistent
> independent_persistent
> independent_nonpersistent
> 
> See VirtualDiskMode

This will validate before submitting the `ReconfigVM_Task` that a supported diskMode was selected by the user.

![screenshot from 2017-03-10 15-39-27](https://cloud.githubusercontent.com/assets/12851112/23813825/9ab81b86-05ae-11e7-8c3a-e81e3b466c61.png)

This should be followed up by a UI change to only display valid options to the user, currently it is possible for the user to select persistent, nonpersistent, independent_persistent, and independent_nonpersistent.


https://bugzilla.redhat.com/show_bug.cgi?id=1430374