### PR TITLE
Handle all DVPortGroups in the VMware Provision Workflow

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
@@ -139,7 +139,6 @@ class ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow < ManageIQ::P
       end
       dvlans.each do |l, v|
         vlans["dvs_#{l}"] = "#{l} (#{v.sort.uniq.join('/')})"
-        vlans.delete(l)
       end
     end
     return vlans, hosts


### PR DESCRIPTION
Move setting the dvportgroups into the vmware provision workflow so
that we don't delete a vlan name collision

~~Requires: https://github.com/ManageIQ/manageiq/pull/14292~~

https://bugzilla.redhat.com/show_bug.cgi?id=1430709