### PR TITLE
Don't allow memory snapshot for powered off vms

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/operations.rb
@@ -2,4 +2,5 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations
   extend ActiveSupport::Concern
 
   include_concern 'Guest'
+  include_concern 'Snapshot'
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/operations/snapshot.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/operations/snapshot.rb
@@ -1,0 +1,7 @@
+module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations::Snapshot
+  extend ActiveSupport::Concern
+
+  def snapshotting_memory_allowed?
+    current_state == 'on'
+  end
+end

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm_spec.rb
@@ -81,6 +81,25 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm do
     end
   end
 
+  context "snapshotting_memory_allowed?" do
+    context "when powered on" do
+      let(:power_state) {{:raw_power_state => power_state_on}}
+
+      it "is allowed" do
+        vm.update_attributes(power_state)
+        expect(vm.snapshotting_memory_allowed?).to be_truthy
+      end
+    end
+
+    context "when powered off" do
+      let(:power_state) {{:raw_power_state => power_state_suspended}}
+      it "is not allowed" do
+        vm.update_attributes(power_state)
+        expect(vm.snapshotting_memory_allowed?).to be_falsy
+      end
+    end
+  end
+
   context "vim" do
     let(:ems) { FactoryGirl.create(:ems_vmware) }
     let(:provider_object) do


### PR DESCRIPTION
If a VM is powered off don't show the snapshot memory checkbox on the UI.

Corresponding RHV PR: https://github.com/ManageIQ/manageiq/pull/12678

https://bugzilla.redhat.com/show_bug.cgi?id=1432060