### PR TITLE
Skip clusters with invalid configuration

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -1300,6 +1300,8 @@ module ManageIQ::Providers
           mor = data['MOR'] # Use the MOR directly from the data since the mor as a key may be corrupt
 
           config = data["configuration"]
+          next if config.nil?
+
           das_config = config["dasConfig"]
           drs_config = config["drsConfig"]
 


### PR DESCRIPTION
If a cluster doesn't have a valid configuration skip it, otherwise the refresh will fail with the following error:
```
[----] E, [2017-03-28T10:04:08.508023 #29777:107b13c] ERROR -- : MIQ(ManageIQ::Providers::Vmware::InfraManager::Refresher#refresh) EMS: [VMWare], id: [10000000000004] Refresh failed
[----] E, [2017-03-28T10:04:08.509412 #29777:107b13c] ERROR -- : [NoMethodError]: undefined method `[]' for nil:NilClass  Method:[rescue in block in refresh]
[----] E, [2017-03-28T10:04:08.509604 #29777:107b13c] ERROR -- : /var/www/miq/vmdb/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb:1296:in `block in cluster_inv_to_hashes'
/var/www/miq/vmdb/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb:1292:in `each'
/var/www/miq/vmdb/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb:1292:in `cluster_inv_to_hashes'
/var/www/miq/vmdb/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb:15:in `ems_inv_to_hashes'
/var/www/miq/vmdb/app/models/manageiq/providers/vmware/infra_manager/refresher.rb:48:in `block in parse_targeted_inventory'
```

https://bugzilla.redhat.com/show_bug.cgi?id=1436853