### PR TITLE
Comment out GlobalVars to prevent it from breaking the rubocop config

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -1,2 +1,2 @@
-GlobalVars:
-  AllowedVariables:
+# GlobalVars:
+#   AllowedVariables:


### PR DESCRIPTION
Fixes:
```
$ rubocop -d app/models/manageiq/providers/openstack/inventory/collector/cloud_manager.rb 
For /home/bdunne/projects/redhat/manageiq-providers-openstack: configuration from /home/bdunne/projects/redhat/manageiq-providers-openstack/.rubocop.yml
configuration from /home/bdunne/projects/redhat/manageiq-providers-openstack/.rubocop-https---raw-githubusercontent-com-ManageIQ-guides-master--rubocop-base-yml
Default configuration from /home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/config/default.yml
Inheriting configuration from /home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/config/enabled.yml
Inheriting configuration from /home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/config/disabled.yml
Inheriting configuration from /home/bdunne/projects/redhat/manageiq-providers-openstack/.rubocop_local.yml
Inspecting 1 file
Scanning /home/bdunne/projects/redhat/manageiq-providers-openstack/app/models/manageiq/providers/openstack/inventory/collector/cloud_manager.rb
An error occurred while Style/GlobalVars cop was inspecting /home/bdunne/projects/redhat/manageiq-providers-openstack/app/models/manageiq/providers/openstack/inventory/collector/cloud_manager.rb:127:4.
undefined method `map' for nil:NilClass
Did you mean?  tap
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/cop/style/global_vars.rb:47:in `user_vars'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/cop/style/global_vars.rb:51:in `allowed_var?'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/cop/style/global_vars.rb:65:in `check'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/cop/style/global_vars.rb:55:in `on_gvar'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/cop/commissioner.rb:43:in `block (2 levels) in on_gvar'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/cop/commissioner.rb:102:in `with_cop_error_handling'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/cop/commissioner.rb:42:in `block in on_gvar'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/cop/commissioner.rb:41:in `each'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/cop/commissioner.rb:41:in `on_gvar'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/ast/traversal.rb:101:in `block in on_send'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/ast/traversal.rb:99:in `each'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/ast/traversal.rb:99:in `each_with_index'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/ast/traversal.rb:99:in `on_send'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/cop/commissioner.rb:47:in `on_send'
(eval):2:in `block in on_begin'
(eval):2:in `each'
(eval):2:in `on_begin'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/cop/commissioner.rb:47:in `on_begin'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/ast/traversal.rb:159:in `block in on_case'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/ast/traversal.rb:158:in `each'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/ast/traversal.rb:158:in `on_case'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/cop/commissioner.rb:47:in `on_resbody'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/ast/traversal.rb:159:in `block in on_case'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/ast/traversal.rb:158:in `each'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/ast/traversal.rb:158:in `on_case'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/cop/commissioner.rb:47:in `on_rescue'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/ast/traversal.rb:95:in `on_def'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/cop/commissioner.rb:47:in `on_def'
(eval):2:in `block in on_begin'
(eval):2:in `each'
(eval):2:in `on_begin'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/cop/commissioner.rb:47:in `on_begin'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/ast/traversal.rb:88:in `on_class'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/cop/commissioner.rb:47:in `on_class'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/ast/traversal.rb:12:in `walk'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/cop/commissioner.rb:60:in `investigate'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/cop/team.rb:121:in `investigate'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/cop/team.rb:109:in `offenses'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/cop/team.rb:51:in `inspect_file'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/runner.rb:248:in `inspect_file'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/runner.rb:195:in `block in do_inspection_loop'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/runner.rb:227:in `block in iterate_until_no_changes'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/runner.rb:220:in `loop'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/runner.rb:220:in `iterate_until_no_changes'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/runner.rb:191:in `do_inspection_loop'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/runner.rb:101:in `block in file_offenses'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/runner.rb:111:in `file_offense_cache'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/runner.rb:99:in `file_offenses'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/runner.rb:90:in `process_file'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/runner.rb:68:in `block in each_inspected_file'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/runner.rb:65:in `each'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/runner.rb:65:in `reduce'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/runner.rb:65:in `each_inspected_file'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/runner.rb:57:in `inspect_files'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/runner.rb:36:in `run'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/cli.rb:72:in `execute_runner'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/lib/rubocop/cli.rb:27:in `run'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/bin/rubocop:13:in `block in <top (required)>'
/home/bdunne/.rubies/ruby-2.3.3/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'
/home/bdunne/.gem/ruby/2.3.3/gems/rubocop-0.47.1/bin/rubocop:12:in `<top (required)>'
/home/bdunne/.gem/ruby/2.3.3/bin/rubocop:22:in `load'
/home/bdunne/.gem/ruby/2.3.3/bin/rubocop:22:in `<top (required)>'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:74:in `load'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:74:in `kernel_load'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:27:in `run'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.14.6/lib/bundler/cli.rb:335:in `exec'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.14.6/lib/bundler/cli.rb:20:in `dispatch'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.14.6/lib/bundler/cli.rb:11:in `start'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.14.6/exe/bundle:32:in `block in <top (required)>'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.14.6/lib/bundler/friendly_errors.rb:121:in `with_friendly_errors'
/home/bdunne/.gem/ruby/2.3.3/gems/bundler-1.14.6/exe/bundle:24:in `<top (required)>'
/home/bdunne/.gem/ruby/2.3.3/bin/bundle:22:in `load'
/home/bdunne/.gem/ruby/2.3.3/bin/bundle:22:in `<main>'
.

1 file inspected, no offenses detected

1 error occurred:
An error occurred while Style/GlobalVars cop was inspecting /home/bdunne/projects/redhat/manageiq-providers-openstack/app/models/manageiq/providers/openstack/inventory/collector/cloud_manager.rb:127:4.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
Mention the following information in the issue report:
0.47.1 (using Parser 2.4.0.0, running on ruby 2.3.3 x86_64-linux)
Finished in 0.1919306210038485 seconds
```