### PR TITLE
Queue initial refresh if the Broker is available

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
@@ -3,6 +3,10 @@ class ManageIQ::Providers::Vmware::InfraManager::RefreshWorker::Runner < ManageI
 
   def do_before_work_loop
     # Override Standard EmsRefreshWorker's method of queueing up a Refresh
+    # if the VimBrokerWorker isn't available yet.
     # This will be done by the VimBrokerWorker, when he is ready.
+    #
+    # If the VimBrokerWorker is running already then queue up an initial refresh
+    super if MiqVimBrokerWorker.available?
   end
 end


### PR DESCRIPTION
If the MiqVimBrokerWorker is starting up then it will queue a refresh when it finishes priming the cache.  
If the broker is already running when the RefreshWorker starts then we need to queue our own initial
refresh.

This fixes the situation where adding any VMware provider after the first doesn't automatically queue a refresh.

https://bugzilla.redhat.com/show_bug.cgi?id=1439387