### PR TITLE
Remove unused storage_id uid key lookup

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -42,7 +42,7 @@ module ManageIQ::Providers
 
       def self.storage_inv_to_hashes(inv)
         result = []
-        result_uids = {:storage_id => {}}
+        result_uids = {}
         return result, result_uids if inv.nil?
 
         inv.each do |mor, storage_inv|
@@ -77,7 +77,6 @@ module ManageIQ::Providers
 
           result << new_result
           result_uids[mor] = new_result
-          result_uids[:storage_id][uid] = new_result
         end
         return result, result_uids
       end


### PR DESCRIPTION
`result_uids[:storage_id]` was used to find storage by location in the
host parsing, the need for this was removed in
e54ca90819ba2785ea60f830ea046509154b17a6 / https://github.com/ManageIQ/manageiq/pull/8633 and there are no other callers so this can be removed.