### PR TITLE
Lookup SCSI Controller Device Type from Hardware [Depends manageiq-gems-pending/148]

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
@@ -92,10 +92,16 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure
 
       if options[:disk_remove] || options[:disk_add]
         with_provider_object do |vim_obj|
-          options[:disk_remove].each { |d| remove_disk_config_spec(vim_obj, vmcs, d) } if options[:disk_remove]
-          add_disks(vim_obj, vmcs, options[:disk_add]) if options[:disk_add]
+          remove_disks(vim_obj, vmcs, options[:disk_remove]) if options[:disk_remove]
+          add_disks(vim_obj, vmcs, options[:disk_add])       if options[:disk_add]
         end
       end
+    end
+  end
+
+  def remove_disks(vim_obj, vmcs, disks)
+    disks.each do |disk|
+      remove_disk_config_spec(vim_obj, vmcs, disk)
     end
   end
 

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
@@ -92,7 +92,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure
 
       if options[:disk_remove] || options[:disk_add]
         with_provider_object do |vim_obj|
-          hardware = vim_obj.send(:getHardware)
+          hardware = vim_obj.getHardware
 
           remove_disks(vim_obj, vmcs, hardware, options[:disk_remove]) if options[:disk_remove]
           add_disks(vim_obj, vmcs, hardware, options[:disk_add])       if options[:disk_add]
@@ -108,8 +108,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure
   end
 
   def add_disks(vim_obj, vmcs, hardware, disks)
-    available_units         = vim_obj.send(:available_scsi_units, hardware)
-    available_scsi_buses    = vim_obj.send(:available_scsi_buses, hardware)
+    available_units         = vim_obj.available_scsi_units(hardware)
+    available_scsi_buses    = vim_obj.available_scsi_buses(hardware)
     new_scsi_controller_key = -99
 
     disks.each do |d|
@@ -159,7 +159,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure
   def get_new_scsi_controller_device_type(vim_obj, hardware)
     default_scsi_type = 'VirtualLsiLogicController'
 
-    scsi_controllers = vim_obj.send(:getScsiControllers, hardware)
+    scsi_controllers = vim_obj.getScsiControllers(hardware)
 
     last_scsi_controller = scsi_controllers.sort_by { |c| c["key"].to_i }.last
     device_type = last_scsi_controller.try(:xsiType) || default_scsi_type
@@ -234,7 +234,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure
     raise "remove_disk_config_spec: disk filename is required." unless options[:disk_name]
 
     options.reverse_merge!(:delete_backing => false)
-    controller_key, key = vim_obj.send(:getDeviceKeysByBacking, options[:disk_name], hardware)
+    controller_key, key = vim_obj.getDeviceKeysByBacking(options[:disk_name], hardware)
     raise "remove_disk_config_spec: no virtual device associated with: #{options[:disk_name]}" unless key
 
     add_device_config_spec(vmcs, VirtualDeviceConfigSpecOperation::Remove) do |vdcs|

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
@@ -275,7 +275,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
 
   context '#add_disks' do
     let(:vim)  { double("vim object") }
-    let(:vmcs) { double("VirtualMachineConfigSpec").as_null_object }
+    let(:vmcs) { VimHash.new("VirtualMachineConfigSpec") }
     let(:hardware) do
       {
         "device"   => [],
@@ -383,6 +383,60 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
         expect(vm).to receive(:add_disk_config_spec).with(vmcs, expected_disk).once
 
         vm.add_disks(vim, vmcs, hardware, disks)
+      end
+    end
+
+    context '#add_scsi_controller' do
+      let(:disk)           { {:disk_size_in_mb => 1024} }
+      let(:lsi_scsi_ctrlr) { VimHash.new("VirtualLsiLogicController") { |ctrlr| ctrlr.key = 1000 } }
+      let(:pv_scsi_ctrlr)  { VimHash.new("ParaVirtualSCSIController") { |ctrlr| ctrlr.key = 1001 } }
+
+      context 'with no existing controllers' do
+        before do
+          allow(vim).to receive(:getScsiControllers).and_return([])
+          allow(vim).to receive(:available_scsi_units).and_return([])
+          allow(vim).to receive(:available_scsi_buses).and_return([0, 1, 2, 3])
+        end
+
+        it 'adds an LSI Logic Controller' do
+          vm.add_disks(vim, vmcs, hardware, [disk])
+          expect(vmcs.deviceChange.count).to eq(2)
+
+          new_ctrlr = vmcs.deviceChange.first.device
+          expect(new_ctrlr.xsiType).to eq('VirtualLsiLogicController')
+        end
+      end
+
+      context 'with an existing PV SCSI Controller' do
+        before do
+          allow(vim).to receive(:getScsiControllers).and_return([pv_scsi_ctrlr])
+          allow(vim).to receive(:available_scsi_units).and_return([])
+          allow(vim).to receive(:available_scsi_buses).and_return([1, 2, 3])
+        end
+
+        it 'adds a new pv scsi controller' do
+          vm.add_disks(vim, vmcs, hardware, [disk])
+          expect(vmcs.deviceChange.count).to eq(2)
+
+          new_ctrlr = vmcs.deviceChange.first.device
+          expect(new_ctrlr.xsiType).to eq('ParaVirtualSCSIController')
+        end
+      end
+
+      context 'with two existing controllers' do
+        before do
+          allow(vim).to receive(:getScsiControllers).and_return([lsi_scsi_ctrlr, pv_scsi_ctrlr])
+          allow(vim).to receive(:available_scsi_units).and_return([])
+          allow(vim).to receive(:available_scsi_buses).and_return([2, 3])
+        end
+
+        it 'adds a new controller with the same type as the last one' do
+          vm.add_disks(vim, vmcs, hardware, [disk])
+          expect(vmcs.deviceChange.count).to eq(2)
+
+          new_ctrlr = vmcs.deviceChange.first.device
+          expect(new_ctrlr.xsiType).to eq('ParaVirtualSCSIController')
+        end
       end
     end
   end

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
@@ -204,8 +204,13 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
       @vim_obj  = double('provider object', :getDeviceKeysByBacking => [900, 1])
       @filename = "[datastore] vm_name/abc.vmdk"
       @options  = {:disk_name => @filename}
+      @hardware = {
+        "device"   => [],
+        "memoryMB" => vm.hardware.memory_mb,
+        "numCPU"   => vm.hardware.cpu_total_cores
+      }
     end
-    subject { vm.remove_disk_config_spec(@vim_obj, @vmcs, @options).first }
+    subject { vm.remove_disk_config_spec(@vim_obj, @vmcs, @hardware, @options).first }
 
     it 'with default options' do
       expect(subject["operation"]).to eq("remove")
@@ -271,6 +276,13 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
   context '#add_disks' do
     let(:vim)  { double("vim object") }
     let(:vmcs) { double("VirtualMachineConfigSpec").as_null_object }
+    let(:hardware) do
+      {
+        "device"   => [],
+        "memoryMB" => vm.hardware.memory_mb,
+        "numCPU"   => vm.hardware.cpu_total_cores
+      }
+    end
 
     context 'add 1 disk' do
       let(:disk) { {:disk_size_in_mb => 1024} }
@@ -281,16 +293,16 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
 
         expect(vm).not_to receive(:add_scsi_controller)
         expect(vm).to receive(:add_disk_config_spec).with(vmcs, disk).once
-        vm.add_disks(vim, vmcs, [disk])
+        vm.add_disks(vim, vmcs, hardware, [disk])
       end
 
       it 'with no controller key' do
         allow(vim).to receive(:available_scsi_units).and_return([])
-        allow(vim).to receive(:available_scsi_buses).and_return([1, 2, 3])
+        allow(vim).to receive(:available_scsi_buses).and_return([0, 1, 2, 3])
 
-        expect(vm).to receive(:add_scsi_controller).with(vmcs, 1, -99).once
+        expect(vm).to receive(:add_scsi_controller).with(vim, vmcs, hardware, 0, -99).once
         expect(vm).to receive(:add_disk_config_spec).with(vmcs, disk).once
-        vm.add_disks(vim, vmcs, [disk])
+        vm.add_disks(vim, vmcs, hardware, [disk])
       end
     end
 
@@ -310,7 +322,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
         expect(vm).to receive(:add_disk_config_spec).with(vmcs, expected_disks[0]).once
         expect(vm).to receive(:add_disk_config_spec).with(vmcs, expected_disks[1]).once
 
-        vm.add_disks(vim, vmcs, disks)
+        vm.add_disks(vim, vmcs, hardware, disks)
       end
 
       it 'with 2 non-consecutive controller units' do
@@ -326,7 +338,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
         expect(vm).to receive(:add_disk_config_spec).with(vmcs, expected_disks[0]).once
         expect(vm).to receive(:add_disk_config_spec).with(vmcs, expected_disks[1]).once
 
-        vm.add_disks(vim, vmcs, disks)
+        vm.add_disks(vim, vmcs, hardware, disks)
       end
 
       it 'with 1 free controller unit' do
@@ -338,11 +350,11 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
           disks[1].merge(:controller_key => -99,  :unit_number => 0)
         ]
 
-        expect(vm).to receive(:add_scsi_controller).with(vmcs, 1, -99).once
+        expect(vm).to receive(:add_scsi_controller).with(vim, vmcs, hardware, 1, -99).once
         expect(vm).to receive(:add_disk_config_spec).with(vmcs, expected_disks[0]).once
         expect(vm).to receive(:add_disk_config_spec).with(vmcs, expected_disks[1]).once
 
-        vm.add_disks(vim, vmcs, disks)
+        vm.add_disks(vim, vmcs, hardware, disks)
       end
 
       it 'with 1 free unit on second controller' do
@@ -354,11 +366,11 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
           disks[1].merge(:controller_key => -99,  :unit_number => 0)
         ]
 
-        expect(vm).to receive(:add_scsi_controller).with(vmcs, 2, -99).once
+        expect(vm).to receive(:add_scsi_controller).with(vim, vmcs, hardware, 2, -99).once
         expect(vm).to receive(:add_disk_config_spec).with(vmcs, expected_disks[0]).once
         expect(vm).to receive(:add_disk_config_spec).with(vmcs, expected_disks[1]).once
 
-        vm.add_disks(vim, vmcs, disks)
+        vm.add_disks(vim, vmcs, hardware, disks)
       end
 
       it 'with 1 free unit on the last scsi controller' do
@@ -370,7 +382,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
         expect(vm).not_to receive(:add_scsi_controller)
         expect(vm).to receive(:add_disk_config_spec).with(vmcs, expected_disk).once
 
-        vm.add_disks(vim, vmcs, disks)
+        vm.add_disks(vim, vmcs, hardware, disks)
       end
     end
   end


### PR DESCRIPTION
When creating a new SCSI controller we used to always default to `VirtualLsiLogicController`, this isn't ideal since some operating systems depend on a certain type of controller.

This change will lookup the type from the most recent scsi controller when adding a new one

Depends on: https://github.com/ManageIQ/manageiq-gems-pending/pull/148

Here are some screenshots of adding a new controller when the first controller is of type LSI SAS:
Before:
![screenshot from 2017-05-03 12-24-05](https://cloud.githubusercontent.com/assets/12851112/25670719/9b49c988-2ffb-11e7-8510-f37fc405b50b.png)

After:
![screenshot from 2017-05-03 12-15-06](https://cloud.githubusercontent.com/assets/12851112/25670726/9e72c9a2-2ffb-11e7-9ff4-742b1ca7fdd9.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1445874