### PR TITLE
Decode slashes in more VMware inventory type names

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -1233,7 +1233,7 @@ module ManageIQ::Providers
             :ems_ref     => mor,
             :ems_ref_obj => mor,
             :uid_ems     => mor,
-            :name        => data["name"],
+            :name        => URI.decode(data["name"]),
             :child_uids  => child_mors,
             :hidden      => false
           }
@@ -1256,7 +1256,7 @@ module ManageIQ::Providers
             :ems_ref     => mor,
             :ems_ref_obj => mor,
             :uid_ems     => mor,
-            :name        => data["name"],
+            :name        => URI.decode(data["name"]),
             :child_uids  => child_mors,
             :hidden      => false
           }

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -1194,7 +1194,7 @@ module ManageIQ::Providers
           :uid_ems     => create_time_ems,
           :uid         => create_time.iso8601(6),
           :parent_uid  => parent_uid,
-          :name        => inv['name'],
+          :name        => URI.decode(inv['name']),
           :description => description,
           :create_time => create_time,
           :current     => inv['snapshot'] == current,
@@ -1314,7 +1314,7 @@ module ManageIQ::Providers
             :ems_ref                 => mor,
             :ems_ref_obj             => mor,
             :uid_ems                 => mor,
-            :name                    => data["name"],
+            :name                    => URI.decode(data["name"]),
             :effective_cpu           => effective_cpu,
             :effective_memory        => effective_memory,
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -269,12 +269,12 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
   end
 
   def assert_specific_cluster
-    @cluster = EmsCluster.find_by(:name => "Testing-Production Cluster")
+    @cluster = EmsCluster.find_by(:ems_id => @ems.id, :ems_ref => "domain-c871")
     expect(@cluster).to have_attributes(
       :ems_ref                 => "domain-c871",
       :ems_ref_obj             => VimString.new("domain-c871", :ClusterComputeResource, :ManagedObjectReference),
       :uid_ems                 => "domain-c871",
-      :name                    => "Testing-Production Cluster",
+      :name                    => "Testing/Production Cluster",
       :ha_enabled              => false,
       :ha_admit_control        => true,
       :ha_max_failures         => 1,
@@ -288,7 +288,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :ems_ref               => "resgroup-872",
       :ems_ref_obj           => VimString.new("resgroup-872", :ResourcePool, :ManagedObjectReference),
       :uid_ems               => "resgroup-872",
-      :name                  => "Default for Cluster / Deployment Role Testing-Production Cluster",
+      :name                  => "Default for Cluster / Deployment Role Testing/Production Cluster",
       :memory_reserve        => 102298,
       :memory_reserve_expand => true,
       :memory_limit          => 102298,
@@ -838,8 +838,8 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
         },
         [Datacenter, "Prod"]           => {
           [EmsFolder, "host", {:hidden => true}] => {
-            [EmsCluster, "Testing-Production Cluster"] => {
-              [ResourcePool, "Default for Cluster / Deployment Role Testing-Production Cluster",
+            [EmsCluster, "Testing/Production Cluster"] => {
+              [ResourcePool, "Default for Cluster / Deployment Role Testing/Production Cluster",
                {:is_default => true}] => {
                  [ResourcePool, "Citrix", {:is_default => false}]                      => {
                    [ManageIQ::Providers::Vmware::InfraManager::Vm, "Citrix 5"] => {}

--- a/spec/tools/vim_data/miq_vim_inventory/clusterComputeResourcesByMor.yml
+++ b/spec/tools/vim_data/miq_vim_inventory/clusterComputeResourcesByMor.yml
@@ -5,7 +5,7 @@
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
   name: !str:VimString 
-    str: Testing-Production Cluster
+    str: Testing%2fProduction Cluster
     "@vimType": 
     "@xsiType": :"xsd:string"
   resourcePool: !str:VimString 

--- a/spec/tools/vim_data/miq_vim_inventory/datacentersByMor.yml
+++ b/spec/tools/vim_data/miq_vim_inventory/datacentersByMor.yml
@@ -5,7 +5,7 @@
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
   name: !str:VimString 
-    str: New Datacenter
+    str: New %2f Datacenter
     "@vimType": 
     "@xsiType": :"xsd:string"
   hostFolder: !str:VimString 

--- a/spec/tools/vim_data/miq_vim_inventory/foldersByMor.yml
+++ b/spec/tools/vim_data/miq_vim_inventory/foldersByMor.yml
@@ -1077,6 +1077,32 @@
     str: group-v673
     "@vimType": :Folder
     "@xsiType": :ManagedObjectReference
+  childEntity: !seq:VimArray 
+    - !str:VimString 
+      str: group-v674
+      "@vimType": :Folder
+      "@xsiType": :ManagedObjectReference
+
+  __iv__@vimType: 
+  __iv__@xsiType: :ObjectContent
+
+? !str:VimString 
+  str: group-v674
+  "@vimType": :Folder
+  "@xsiType": :ManagedObjectReference
+: !map:VimHash 
+  name: !str:VimString 
+    str: Test %2f Folder
+    "@vimType": 
+    "@xsiType": :"xsd:string"
+  parent: !str:VimString 
+    str: datacenter-672
+    "@vimType": :Datacenter
+    "@xsiType": :ManagedObjectReference
+  MOR: !str:VimString 
+    str: group-v674
+    "@vimType": :Folder
+    "@xsiType": :ManagedObjectReference
   childEntity: !seq:VimArray []
 
   __iv__@vimType: 


### PR DESCRIPTION
Decode slashes in folder names, and all the other types while we're at it!

I found that there are a number of additional inventory types where we will get `%2f` back from the VIM API so just fixed them here:

1. Folders
2. Datacenters
3. Datastores
4. Clusters

https://bugzilla.redhat.com/show_bug.cgi?id=1393655