### PR TITLE
Fix Selector Spec test after removing with_constants

### DIFF
--- a/spec/models/manageiq/providers/vmware/infra_manager/selector_spec_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/selector_spec_spec.rb
@@ -1,40 +1,40 @@
 describe ManageIQ::Providers::Vmware::InfraManager::SelectorSpec do
   it ".selected_property?" do
-    ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.with_constants(
-      :VIM_SELECTOR_SPEC => {
-        :ems_refresh_vm => [
-          "config.extraConfig[*].key",
-          "config.hardware.device[*].backing.compatibilityMode",
-          "summary.guest.hostName",
-          "summary.runtime.powerState"
-        ]
-      }
-    ) do
-      expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "summary.runtime.powerState")).to be_truthy
-      expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "summary.runtime")).to be_truthy
-      expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "summary")).to be_truthy
+    selector_spec = {
+      :ems_refresh_vm => [
+        "config.extraConfig[*].key",
+        "config.hardware.device[*].backing.compatibilityMode",
+        "summary.guest.hostName",
+        "summary.runtime.powerState"
+      ]
+    }
 
-      expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "summary.runtime.power")).to be_falsey
-      expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "summary.run")).to be_falsey
-      expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "sum")).to be_falsey
+    stub_const('ManageIQ::Providers::Vmware::InfraManager::SelectorSpec::VIM_SELECTOR_SPEC', selector_spec)
 
-      expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "config.hardware.device[2000].backing.compatibilityMode"))
-        .to be_truthy
-      expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "config.hardware.device[2000].backing")).to be_truthy
-      expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "config.hardware.device[2000]")).to be_truthy
-      expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "config.hardware.device")).to be_truthy
+    expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "summary.runtime.powerState")).to be_truthy
+    expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "summary.runtime")).to be_truthy
+    expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "summary")).to be_truthy
 
-      expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "config.hardware.device[2000].back")).to be_falsey
-      expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "config.hardware.dev")).to be_falsey
+    expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "summary.runtime.power")).to be_falsey
+    expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "summary.run")).to be_falsey
+    expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "sum")).to be_falsey
 
-      expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "config.extraConfig[\"vmsafe.enable\"].key")).to be_truthy
-      expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "config.extraConfig[\"vmsafe.enable\"]")).to be_truthy
-      expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "config.extraConfig")).to be_truthy
+    expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "config.hardware.device[2000].backing.compatibilityMode"))
+      .to be_truthy
+    expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "config.hardware.device[2000].backing")).to be_truthy
+    expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "config.hardware.device[2000]")).to be_truthy
+    expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "config.hardware.device")).to be_truthy
 
-      expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "summary.guest")).to be_truthy
-      expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "summary.guest.disk")).to be_falsey
+    expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "config.hardware.device[2000].back")).to be_falsey
+    expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "config.hardware.dev")).to be_falsey
 
-      expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:other, "does.not.matter")).to be_falsey
-    end
+    expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "config.extraConfig[\"vmsafe.enable\"].key")).to be_truthy
+    expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "config.extraConfig[\"vmsafe.enable\"]")).to be_truthy
+    expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "config.extraConfig")).to be_truthy
+
+    expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "summary.guest")).to be_truthy
+    expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:vm, "summary.guest.disk")).to be_falsey
+
+    expect(ManageIQ::Providers::Vmware::InfraManager::SelectorSpec.selected_property?(:other, "does.not.matter")).to be_falsey
   end
 end


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/14943 Removed `with_constants` which was used by the selector spec test, causing the VMware spec tests to fail [ref](https://travis-ci.org/ManageIQ/manageiq-providers-vmware/jobs/228495500#L570-L586)

This moves to using `stub_const` instead of `with_constants`