### PR TITLE
Update for new refresh_new_target arguments

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/event_parser.rb
@@ -126,6 +126,11 @@ module ManageIQ::Providers::Vmware::InfraManager::EventParser
   end
 
   def self.obj_update_to_hash(event)
+    hash, = parse_new_target(event)
+    hash
+  end
+
+  def self.parse_new_target(event)
     obj_type = event[:objType]
 
     method = "#{obj_type.downcase}_update_to_hash"

--- a/app/models/manageiq/providers/vmware/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/event_parser.rb
@@ -134,13 +134,16 @@ module ManageIQ::Providers::Vmware::InfraManager::EventParser
 
   def self.folder_update_to_hash(event)
     mor = event[:mor]
-    {
+    klass = 'EmsFolder'
+    hash = {
       :folder => {
-        :type        => 'EmsFolder',
+        :type        => klass,
         :ems_ref     => mor,
         :ems_ref_obj => mor,
         :uid_ems     => mor
       }
     }
+
+    return hash, klass, :uid_ems => mor
   end
 end

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -188,6 +188,18 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     expect(vm.host).to eq(vm2.host)
   end
 
+  it 'handles refresh of new target without deleting other inventory' do
+    EmsRefresh.refresh(@ems)
+    @ems.reload
+
+    # This is an existing folder so we can confirm the counts for
+    # other inventory don't change
+    hash, klass, find = @ems.class::EventParser.obj_update_to_hash(:objType => 'Folder', :mor => 'group-v12223')
+    EmsRefresh.refresh_new_target(@ems.id, hash, klass, find)
+
+    assert_table_counts
+  end
+
   it 'link_inventory handles folder deletion' do
     EmsRefresh.refresh(@ems)
     @ems.reload

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -188,7 +188,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     expect(vm.host).to eq(vm2.host)
   end
 
-  it 'handles refresh of new target without deleting other inventory' do
+  xit 'handles refresh of new target without deleting other inventory' do
     EmsRefresh.refresh(@ems)
     @ems.reload
 


### PR DESCRIPTION
Move to `EventParser::parse_new_target` for consistency with ovirt and return the needed arguments for `refresh_new_target` in https://github.com/ManageIQ/manageiq/pull/14247