### PR TITLE
Don't update ems attributes in refresh parser

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -11,6 +11,7 @@ module ManageIQ::Providers
         uids = {}
         result = {:uid_lookup => uids}
 
+        result[:ems] = about_inv_to_hashes(inv[:about])
         result[:storages], uids[:storages] = storage_inv_to_hashes(inv[:storage])
         result[:clusters], uids[:clusters] = cluster_inv_to_hashes(inv[:cluster])
         result[:storage_profiles], uids[:storage_profiles] = storage_profile_inv_to_hashes(inv[:storage_profile], uids[:storages], inv[:storage_profile_datastore])
@@ -38,6 +39,13 @@ module ManageIQ::Providers
         set_default_rps(result)
 
         result
+      end
+
+      def self.about_inv_to_hashes(about)
+        {
+          :api_version => about['apiVersion'],
+          :uid_ems     => about['instanceUuid']
+        }
       end
 
       def self.storage_inv_to_hashes(inv)

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser/filter.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser/filter.rb
@@ -14,6 +14,7 @@ class ManageIQ::Providers::Vmware::InfraManager
 
         host_data = host_inv_by_host(target)
         unless host_data.nil?
+          filtered_data[:about] = ems_inv_by_about_inv
           filtered_data[:host] = host_data
           filtered_data[:storage] = storage_inv_by_host_inv(host_data)
           filtered_data[:vm] = vm_data = vm_inv_by_host_inv(host_data)
@@ -32,6 +33,7 @@ class ManageIQ::Providers::Vmware::InfraManager
         filtered_data = Hash.new { |h, k| h[k] = {} }
         vm_data = vm_inv_by_vm(target)
         unless vm_data.nil?
+          filtered_data[:about] = ems_inv_by_about_inv
           filtered_data[:vm] = vm_data
           filtered_data[:host] = host_inv_by_vm_inv(vm_data)
           filtered_data[:storage] = storage_inv_by_host_inv(filtered_data[:host])
@@ -50,6 +52,8 @@ class ManageIQ::Providers::Vmware::InfraManager
         unless folder_data.nil?
           _, target_data = folder_data.first
           if folder_children(target_data).blank?
+            filtered_data[:about] = ems_inv_by_about_inv
+
             inv_by_folder_inv(folder_data, filtered_data)
           else
             filtered_data = @vc_data
@@ -93,6 +97,10 @@ class ManageIQ::Providers::Vmware::InfraManager
 
       _type, target = RefreshParser.inv_target_by_mor(mor, @vc_data)
       target.nil? ? nil : {mor => target}
+    end
+
+    def ems_inv_by_about_inv
+      @vc_data[:about]
     end
 
     ### Collection methods by Host inv

--- a/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
@@ -20,7 +20,6 @@ module ManageIQ::Providers
       end
 
       def collect_inventory_for_targets(ems, targets)
-        Benchmark.realtime_block(:get_ems_data) { get_ems_data(ems) }
         Benchmark.realtime_block(:get_vc_data) { get_vc_data(ems) }
 
         Benchmark.realtime_block(:get_vc_data_ems_customization_specs) { get_vc_data_ems_customization_specs(ems) } if targets.include?(ems)
@@ -52,14 +51,6 @@ module ManageIQ::Providers
         _log.debug "#{log_header} Parsing VC inventory...Complete"
 
         hashes
-      end
-
-      def save_inventory(ems, target, hashes)
-        Benchmark.realtime_block(:db_save_inventory) do
-          # TODO: really wanna kill this @ems_data instance var
-          ems.update_attributes(@ems_data) unless @ems_data.nil?
-          EmsRefresh.save_ems_inventory(ems, hashes, target)
-        end
       end
 
       def post_refresh(ems, start_time)
@@ -99,6 +90,8 @@ module ManageIQ::Providers
 
         retrieve_from_vc(ems, cleanup_callback) do
           @vc_data = Hash.new { |h, k| h[k] = {} }
+
+          @vc_data[:about] = get_ems_data(ems)
 
           accessors.each do |type, accessor|
             _log.info("#{log_header} Retrieving #{type.to_s.titleize} inventory...")
@@ -183,16 +176,13 @@ module ManageIQ::Providers
       def get_ems_data(ems)
         log_header = format_ems_for_logging(ems)
 
-        cleanup_callback = proc { @ems_data = nil }
+        _log.info("#{log_header} Retrieving EMS information...")
+        about = @vi.about
+        _log.info("#{log_header} Retrieving EMS information...Complete")
 
-        retrieve_from_vc(ems, cleanup_callback) do
-          _log.info("#{log_header} Retrieving EMS information...")
-          about = @vi.about
-          @ems_data = {:api_version => about['apiVersion'], :uid_ems => about['instanceUuid']}
-          _log.info("#{log_header} Retrieving EMS information...Complete")
-        end
+        EmsRefresh.log_inv_debug_trace(about, "#{_log.prefix} #{log_header} ext_management_system_inv:")
 
-        EmsRefresh.log_inv_debug_trace(@ems_data, "#{_log.prefix} #{log_header} ext_management_system_inv:")
+        about
       end
 
       MAX_RETRIES = 5

--- a/spec/tools/vim_data/miq_vim_inventory/about.yml
+++ b/spec/tools/vim_data/miq_vim_inventory/about.yml
@@ -1,0 +1,61 @@
+--- !ruby/hash-with-ivars:VimHash
+elements:
+  name: !ruby/string:VimString
+    str: VMware vCenter Server
+    xsiType: :SOAP::SOAPString
+    vimType: 
+  fullName: !ruby/string:VimString
+    str: VMware vCenter Server 4.1.0 build-5318154
+    xsiType: :SOAP::SOAPString
+    vimType: 
+  vendor: !ruby/string:VimString
+    str: VMware, Inc.
+    xsiType: :SOAP::SOAPString
+    vimType: 
+  version: !ruby/string:VimString
+    str: 6.5.0
+    xsiType: :SOAP::SOAPString
+    vimType: 
+  build: !ruby/string:VimString
+    str: '5318154'
+    xsiType: :SOAP::SOAPString
+    vimType: 
+  localeVersion: !ruby/string:VimString
+    str: INTL
+    xsiType: :SOAP::SOAPString
+    vimType: 
+  localeBuild: !ruby/string:VimString
+    str: '000'
+    xsiType: :SOAP::SOAPString
+    vimType: 
+  osType: !ruby/string:VimString
+    str: linux-x64
+    xsiType: :SOAP::SOAPString
+    vimType: 
+  productLineId: !ruby/string:VimString
+    str: vpx
+    xsiType: :SOAP::SOAPString
+    vimType: 
+  apiType: !ruby/string:VimString
+    str: VirtualCenter
+    xsiType: :SOAP::SOAPString
+    vimType: 
+  apiVersion: !ruby/string:VimString
+    str: '4.1'
+    xsiType: :SOAP::SOAPString
+    vimType: 
+  instanceUuid: !ruby/string:VimString
+    str: EF53782F-6F1A-4471-B338-72B27774AFDD
+    xsiType: :SOAP::SOAPString
+    vimType: 
+  licenseProductName: !ruby/string:VimString
+    str: VMware VirtualCenter Server
+    xsiType: :SOAP::SOAPString
+    vimType: 
+  licenseProductVersion: !ruby/string:VimString
+    str: '4.1'
+    xsiType: :SOAP::SOAPString
+    vimType: 
+ivars:
+  :@xsiType: :AboutInfo
+  :@vimType: 

--- a/spec/tools/vim_data/vim_data_test_helper.rb
+++ b/spec/tools/vim_data/vim_data_test_helper.rb
@@ -53,13 +53,6 @@ end
 class FakeMiqVimHandle < FakeMiqVimHandleBase
   DATA_DIR = "miq_vim_inventory"
 
-  def about
-    {
-      "apiVersion"   => "4.1",
-      "instanceUuid" => "EF53782F-6F1A-4471-B338-72B27774AFDD"
-    }
-  end
-
   def method_missing(m, *args)
     m = m.to_s
     byMor = (m[-5..-1] == "ByMor" && m[-6, 1] != "s")


### PR DESCRIPTION
Parse EMS attributes and send to save_ems_inventory instead of updating directly in the refresh_parser and finally kill the `@ems_data` variable.

~~Depends: https://github.com/ManageIQ/manageiq/pull/15252~~