### PR TITLE
vm restart guest check fixed

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/operations/guest.rb
@@ -4,7 +4,13 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations::Guest
   included do
     supports :reboot_guest do
       unsupported_reason_add(:reboot_guest, unsupported_reason(:control)) unless supports_control?
-      unsupported_reason_add(:reboot_guest, _("The VM is not powered on")) unless current_state == "on"
+      if current_state == "on"
+        if tools_status == 'toolsNotInstalled'
+          unsupported_reason_add(:reboot_guest, _("The VM tools is not installed"))
+        end
+      else
+        unsupported_reason_add(:reboot_guest, _("The VM is not powered on"))
+      end
     end
 
     supports :shutdown_guest do


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1455595
## Before
Guest restart is displayed as doable even when tools is not installed

## After
Guest restart is not allowed when tools is not installed