### PR TITLE
Enable refresh new target spec test

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/event_parser.rb
@@ -125,11 +125,6 @@ module ManageIQ::Providers::Vmware::InfraManager::EventParser
     result
   end
 
-  def self.obj_update_to_hash(event)
-    hash, = parse_new_target(event)
-    hash
-  end
-
   def self.parse_new_target(event)
     obj_type = event[:objType]
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -188,13 +188,13 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     expect(vm.host).to eq(vm2.host)
   end
 
-  xit 'handles refresh of new target without deleting other inventory' do
+  it 'handles refresh of new target without deleting other inventory' do
     EmsRefresh.refresh(@ems)
     @ems.reload
 
     # This is an existing folder so we can confirm the counts for
     # other inventory don't change
-    hash, klass, find = @ems.class::EventParser.obj_update_to_hash(:objType => 'Folder', :mor => 'group-v12223')
+    hash, klass, find = @ems.class::EventParser.parse_new_target(:objType => 'Folder', :mor => 'group-v12223')
     EmsRefresh.refresh_new_target(@ems.id, hash, klass, find)
 
     assert_table_counts


### PR DESCRIPTION
Now that https://github.com/ManageIQ/manageiq/pull/14247 is merged we can enable the `refresh_new_target` spec test for the vmware refresher as well as delete the compatibility method `EventParser.obj_update_to_hash` which was only called by the vim_broker and removed here https://github.com/ManageIQ/manageiq/pull/14247/files#diff-a651af8dd48c191490be1598bebf9a84L165