### PR TITLE
Remove MirroredLogger Settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,7 +23,6 @@
     :user:
 #:log:
 #  :level_vim: warn
-#  :level_vim_in_evm: error
 :workers:
   :worker_base:
     :event_catcher:


### PR DESCRIPTION
Depends on the removal of the MirroredLogger in https://github.com/ManageIQ/manageiq/pull/15397