### PR TITLE
Decrypt and validate credentials in raw_connect 

### DIFF
--- a/app/models/manageiq/providers/vmware/manager_auth_mixin.rb
+++ b/app/models/manageiq/providers/vmware/manager_auth_mixin.rb
@@ -8,21 +8,18 @@ module ManageIQ::Providers::Vmware::ManagerAuthMixin
     raise MiqException::MiqHostError, "No credentials defined" if missing_credentials?(auth_type)
 
     options[:auth_type] = auth_type
-    begin
+
+    self.class.connection_rescue_block do
       case auth_type.to_s
       when 'default' then
         with_provider_connection(options) do |vcd|
-          vcd.organizations.all
+          self.class.validate_connection(vcd)
         end
       when 'amqp' then
         verify_amqp_credentials(options)
       else
         raise "Invalid Vmware vCloud Authentication Type: #{auth_type.inspect}"
       end
-    rescue => err
-      miq_exception = translate_exception(err)
-      _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
-      raise miq_exception
     end
 
     true
@@ -39,26 +36,11 @@ module ManageIQ::Providers::Vmware::ManagerAuthMixin
     self.class.raw_connect(server, port, username, password)
   end
 
-  def translate_exception(err)
-    case err
-    when Fog::Compute::VcloudDirector::Unauthorized
-      MiqException::MiqInvalidCredentialsError.new "Login failed due to a bad username or password."
-    when Excon::Errors::Timeout
-      MiqException::MiqUnreachableError.new "Login attempt timed out"
-    when Excon::Errors::SocketError
-      MiqException::MiqHostError.new "Socket error: #{err.message}"
-    when MiqException::MiqInvalidCredentialsError, MiqException::MiqHostError
-      err
-    else
-      MiqException::MiqHostError.new "Unexpected response returned from system: #{err.message}"
-    end
-  end
-
   module ClassMethods
-    def raw_connect(server, port, username, password)
+    def raw_connect(server, port, username, password, validate = false)
       params = {
         :vcloud_director_username      => username,
-        :vcloud_director_password      => password,
+        :vcloud_director_password      => MiqPassword.try_decrypt(password),
         :vcloud_director_host          => server,
         :vcloud_director_show_progress => false,
         :port                          => port,
@@ -67,7 +49,36 @@ module ManageIQ::Providers::Vmware::ManagerAuthMixin
         }
       }
 
-      Fog::Compute::VcloudDirector.new(params)
+      connect = Fog::Compute::VcloudDirector.new(params)
+      connection_rescue_block { validate_connection(connect) } if validate
+      connect
+    end
+
+    def validate_connection(connection)
+      connection.organizations.all
+    end
+
+    def connection_rescue_block
+      yield
+    rescue => err
+      miq_exception = translate_exception(err)
+      _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
+      raise miq_exception
+    end
+
+    def translate_exception(err)
+      case err
+      when Fog::Compute::VcloudDirector::Unauthorized
+        MiqException::MiqInvalidCredentialsError.new "Login failed due to a bad username or password."
+      when Excon::Errors::Timeout
+        MiqException::MiqUnreachableError.new "Login attempt timed out"
+      when Excon::Errors::SocketError
+        MiqException::MiqHostError.new "Socket error: #{err.message}"
+      when MiqException::MiqInvalidCredentialsError, MiqException::MiqHostError
+        err
+      else
+        MiqException::MiqHostError.new "Unexpected response returned from system: #{err.message}"
+      end
     end
   end
 end


### PR DESCRIPTION
The UI is moving towards validating credentials on the queue to allow for validating credentials in separate zones utilizing the `raw_connect` class method, rather than needing to create a temporary EMS for validation.

 For many of the providers, `raw_connect` ensures the credentials are correct. This updates `raw_connect` to not only return a connection but also be able to validate (it will *not* validate by default).

Because credentials are going to be stored on the queue, it also needs to be able to decrypt them. This uses `MiqPassword.try_decrypt` so that it can accept both unencrypted and encrypted credentials.

PR with greater detail: https://github.com/ManageIQ/manageiq-ui-classic/pull/1580