### PR TITLE
Add VMware inventory collections

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::Vmware::InfraManager::Inventory < ManagerRefresh::Inventory
+  require_nested :Persister
+end

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/inventory_collections.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/inventory_collections.rb
@@ -1,0 +1,45 @@
+class ManageIQ::Providers::Vmware::InfraManager::Inventory::InventoryCollections < ManagerRefresh::InventoryCollectionDefault::InfraManager
+  class << self
+    def customization_specs(extra_attributes = {})
+      attributes = {
+        :model_class    => ::CustomizationSpec,
+        :association    => :customization_specs,
+        :manager_ref    => [:name],
+        :builder_params => {
+          :ems_id => ->(persister) { persister.manager.id },
+        },
+      }
+
+      attributes.merge!(extra_attributes)
+    end
+
+    def vms_and_templates(extra_attributes = {})
+      attributes = {
+        :model_class    => ::VmOrTemplate,
+        :association    => :vms_and_templates,
+        :builder_params => {
+          :ems_id => ->(persister) { persister.manager.id },
+        },
+      }
+
+      attributes.merge!(extra_attributes)
+    end
+
+    def storage_profiles(extra_attributes = {})
+      attributes = {
+        :model_class    => ::StorageProfile,
+        :association    => :storage_profiles,
+        :builder_params => {
+          :ems_id => ->(persister) { persister.manager.id },
+        },
+      }
+
+      attributes.merge!(extra_attributes)
+    end
+
+    def hosts(extra_attributes = {})
+      attributes = {:model_class => ManageIQ::Providers::Vmware::InfraManager::HostEsx}
+      super(attributes.merge(extra_attributes))
+    end
+  end
+end

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
@@ -1,0 +1,42 @@
+class ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister < ManagerRefresh::Inventory::Persister
+  def initialize_inventory_collections
+    add_inventory_collections(
+      default_inventory_collections, inventory_collection_names, inventory_collection_options
+    )
+  end
+
+  def default_inventory_collections
+    ManageIQ::Providers::Vmware::InfraManager::Inventory::InventoryCollections
+  end
+
+  def inventory_collection_names
+    %i(
+      custom_attributes
+      customization_specs
+      disks
+      ems_clusters
+      ems_folders
+      guest_devices
+      hardwares
+      hosts
+      host_hardwares
+      host_networks
+      host_storages
+      host_switches
+      host_operating_systems
+      lans
+      networks
+      operating_systems
+      resource_pools
+      snapshots
+      storages
+      storage_profiles
+      switches
+      vms_and_templates
+    )
+  end
+
+  def inventory_collection_options
+    {}
+  end
+end


### PR DESCRIPTION
This adds `InventoryCollections` for VMware InfraManager which include most of the default `InfraManager` inventory collections from https://github.com/ManageIQ/manageiq/pull/15441 plus ones that are VMware specific (e.g. storage_profiles)