### PR TITLE
Rbvmomi inventory collector

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -9,6 +9,7 @@ module ManageIQ::Providers
     require_nested :Refresher
     require_nested :Host
     require_nested :HostEsx
+    require_nested :Inventory
     require_nested :Provision
     require_nested :ProvisionViaPxe
     require_nested :ProvisionWorkflow

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory.rb
@@ -1,3 +1,4 @@
 class ManageIQ::Providers::Vmware::InfraManager::Inventory < ManagerRefresh::Inventory
+  require_nested :Collector
   require_nested :Persister
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -1,0 +1,58 @@
+require 'rbvmomi/vim'
+
+class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
+  include Vmdb::Logging
+
+  attr_reader :ems, :exit_requested
+  private     :ems, :exit_requested
+
+  def initialize(ems)
+    @ems            = ems
+    @exit_requested = false
+  end
+
+  def run
+    until exit_requested
+      vim = connect(ems.address, ems.authentication_userid, ems.authentication_password)
+
+      begin
+        wait_for_updates(vim)
+      rescue RbVmomi::Fault
+        vim.serviceContent.sessionManager.Logout
+        vim = nil
+      end
+    end
+
+    _log.info("Exiting...")
+  ensure
+    vim.serviceContent.sessionManager.Logout unless vim.nil?
+  end
+
+  def stop
+    _log.info("Exit request received...")
+    @exit_requested = true
+  end
+
+  def connect(host, username, password)
+    _log.info("Connecting to #{username}@#{host}...")
+
+    vim_opts = {
+      :ns       => 'urn:vim25',
+      :host     => host,
+      :ssl      => true,
+      :insecure => true,
+      :path     => '/sdk',
+      :port     => 443,
+      :user     => username,
+      :password => password,
+    }
+
+    vim = RbVmomi::VIM.connect(vim_opts)
+
+    _log.info("Connected")
+    vim
+  end
+
+  def wait_for_updates(vim)
+  end
+end

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -1,6 +1,7 @@
 require 'rbvmomi/vim'
 
 class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
+  include PropertyCollector
   include Vmdb::Logging
 
   attr_reader :ems, :exit_requested
@@ -54,5 +55,108 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
   end
 
   def wait_for_updates(vim)
+    property_filter = create_property_filter(vim)
+
+    # Return if we don't receive any updates for 10 seconds break
+    # so that we can check if we are supposed to exit
+    options = RbVmomi::VIM.WaitOptions(:maxWaitSeconds => 10)
+
+    # Send the "special initial data version" i.e. an empty string
+    # so that we get all inventory back in the first update set
+    version = ""
+
+    _log.info("Refreshing initial inventory...")
+
+    initial = true
+    until exit_requested
+      update_set = vim.propertyCollector.WaitForUpdatesEx(:version => version, :options => options)
+      next if update_set.nil?
+
+      # Save the new update set version
+      version = update_set.version
+
+      property_filter_update_set = update_set.filterSet
+      next if property_filter_update_set.blank?
+
+      property_filter_update_set.each do |property_filter_update|
+        next if property_filter_update.filter != property_filter
+
+        object_update_set = property_filter_update.objectSet
+        next if object_update_set.blank?
+
+        process_object_update_set(object_update_set)
+      end
+
+      next if update_set.truncated
+
+      next unless initial
+
+      _log.info("Refreshing initial inventory...Complete")
+      initial = false
+    end
+  ensure
+    property_filter.DestroyPropertyFilter unless property_filter.nil?
+  end
+
+  def process_object_update_set(object_update_set)
+    _log.info("Processing #{object_update_set.count} updates...")
+
+    object_update_set.each do |object_update|
+      process_object_update(object_update)
+    end
+
+    _log.info("Processing #{object_update_set.count} updates...Complete")
+  end
+
+  def process_object_update(object_update)
+    managed_object = object_update.obj
+
+    case object_update.kind
+    when "enter"
+      process_object_update_enter(managed_object, object_update.changeSet)
+    when "modify"
+      process_object_update_modify(managed_object, object_update.changeSet)
+    when "leave"
+      process_object_update_leave(managed_object)
+    end
+  end
+
+  def process_object_update_enter(obj, change_set, missing_set = [])
+    process_object_update_modify(obj, change_set, missing_set)
+  end
+
+  def process_object_update_modify(_obj, change_set, _missing_set = [])
+    props = {}
+
+    change_set.each do |property_change|
+      next if property_change.nil?
+
+      case property_change.op
+      when 'add'
+        process_property_change_add(props, property_change)
+      when 'remove', 'indirectRemove'
+        process_property_change_remove(props, property_change)
+      when 'assign'
+        process_property_change_assign(props, property_change)
+      end
+    end
+  end
+
+  def process_object_update_leave(_obj)
+  end
+
+  def process_property_change_add(props, property_change)
+    name = property_change.name
+
+    props[name] = [] if props[name].nil?
+    props[name] << property_change.val
+  end
+
+  def process_property_change_remove(props, property_change)
+    props.delete(property_change.name)
+  end
+
+  def process_property_change_assign(props, property_change)
+    props[property_change.name] = property_change.val
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -1,5 +1,3 @@
-require 'rbvmomi/vim'
-
 class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
   include InventoryCache
   include PropertyCollector
@@ -21,7 +19,10 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
 
       begin
         wait_for_updates(vim)
-      rescue RbVmomi::Fault
+      rescue RbVmomi::Fault => err
+        _log.err("Caught exception #{err.message}")
+        _log.log_backtrace(err)
+      ensure
         vim.serviceContent.sessionManager.Logout
         vim = nil
       end
@@ -50,6 +51,8 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
       :user     => username,
       :password => password,
     }
+
+    require 'rbvmomi/vim'
 
     vim = RbVmomi::VIM.connect(vim_opts)
 

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -3,14 +3,12 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
   include PropertyCollector
   include Vmdb::Logging
 
-  attr_accessor :inventory_cache
-  attr_reader   :ems, :exit_requested
-  private       :ems, :exit_requested, :inventory_cache
+  attr_reader :ems, :exit_requested
+  private     :ems, :exit_requested
 
   def initialize(ems)
     @ems             = ems
     @exit_requested  = false
-    @inventory_cache = initialize_inventory_cache
   end
 
   def run
@@ -38,6 +36,8 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
     @exit_requested = true
   end
 
+  private
+
   def connect(host, username, password)
     _log.info("Connecting to #{username}@#{host}...")
 
@@ -63,9 +63,9 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
   def wait_for_updates(vim)
     property_filter = create_property_filter(vim)
 
-    # Return if we don't receive any updates for 10 seconds break
+    # Return if we don't receive any updates for 60 seconds break
     # so that we can check if we are supposed to exit
-    options = RbVmomi::VIM.WaitOptions(:maxWaitSeconds => 10)
+    options = RbVmomi::VIM.WaitOptions(:maxWaitSeconds => 60)
 
     # Send the "special initial data version" i.e. an empty string
     # so that we get all inventory back in the first update set
@@ -161,7 +161,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
   def process_property_change_add(props, property_change)
     name = property_change.name
 
-    props[name] = [] if props[name].nil?
+    props[name] ||= []
     props[name] << property_change.val
   end
 

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector/inventory_cache.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector/inventory_cache.rb
@@ -1,9 +1,12 @@
 class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
   module InventoryCache
-    def initialize_inventory_cache
-      Hash.new do |h, k|
-        h[k] = Hash.new { |h1, k1| h1[k1] = {} }
-      end
+    private
+
+    def inventory_cache
+      @inventory_cache ||=
+        Hash.new do |h, k|
+          h[k] = Hash.new { |h1, k1| h1[k1] = Hash.new }
+        end
     end
 
     INVENTORY_CACHE_PROPERTIES = {

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector/inventory_cache.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector/inventory_cache.rb
@@ -1,0 +1,36 @@
+class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
+  module InventoryCache
+    def initialize_inventory_cache
+      Hash.new do |h, k|
+        h[k] = Hash.new { |h1, k1| h1[k1] = {} }
+      end
+    end
+
+    INVENTORY_CACHE_PROPERTIES = {
+      "VirtualMachine" => %w(
+        summary.config.template
+        summary.config.name
+        summary.config.uuid
+        summary.config.vmPathName
+      ),
+      "Host"           => %w(
+        config.network.dnsConfig.hostName
+        summary.config.product.name
+      ),
+      "Datastore"      => %w(
+        summary.name
+        summary.url
+      )
+    }.freeze
+
+    def update_inventory_cache(obj_type, obj_ref, props)
+      properties_to_cache = INVENTORY_CACHE_PROPERTIES[obj_type]
+      return if properties_to_cache.blank?
+
+      cache = inventory_cache[obj_type][obj_ref]
+      properties_to_cache.each do |prop_key|
+        cache[prop_key] = props[prop_key]
+      end
+    end
+  end
+end

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector/property_collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector/property_collector.rb
@@ -1,0 +1,259 @@
+module ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector::PropertyCollector
+  EmsRefreshPropMap = {
+    :VirtualMachine              => [
+      "availableField",
+      "config.cpuAffinity.affinitySet",
+      "config.cpuHotAddEnabled",
+      "config.cpuHotRemoveEnabled",
+      "config.defaultPowerOps.standbyAction",
+      "config.hardware.device",
+      "config.hardware.numCoresPerSocket",
+      "config.hotPlugMemoryIncrementSize",
+      "config.hotPlugMemoryLimit",
+      "config.memoryHotAddEnabled",
+      "config.version",
+      "datastore",
+      "guest.net",
+      "resourceConfig.cpuAllocation.expandableReservation",
+      "resourceConfig.cpuAllocation.limit",
+      "resourceConfig.cpuAllocation.reservation",
+      "resourceConfig.cpuAllocation.shares.level",
+      "resourceConfig.cpuAllocation.shares.shares",
+      "resourceConfig.memoryAllocation.expandableReservation",
+      "resourceConfig.memoryAllocation.limit",
+      "resourceConfig.memoryAllocation.reservation",
+      "resourceConfig.memoryAllocation.shares.level",
+      "resourceConfig.memoryAllocation.shares.shares",
+      "snapshot",
+      "summary.vm",
+      "summary.config.annotation",
+      "summary.config.ftInfo.instanceUuids",
+      "summary.config.guestFullName",
+      "summary.config.guestId",
+      "summary.config.memorySizeMB",
+      "summary.config.name",
+      "summary.config.numCpu",
+      "summary.config.template",
+      "summary.config.uuid",
+      "summary.config.vmPathName",
+      "summary.customValue",
+      "summary.guest.hostName",
+      "summary.guest.ipAddress",
+      "summary.guest.toolsStatus",
+      "summary.runtime.bootTime",
+      "summary.runtime.connectionState",
+      "summary.runtime.host",
+      "summary.runtime.powerState",
+      "summary.storage.unshared",
+      "summary.storage.committed",
+    ],
+    :ComputeResource             => [
+      "name",
+      "host",
+      "parent",
+      "resourcePool",
+    ],
+    :ClusterComputeResource      => [
+      "configuration.dasConfig.admissionControlPolicy",
+      "configuration.dasConfig.admissionControlEnabled",
+      "configuration.dasConfig.enabled",
+      "configuration.dasConfig.failoverLevel",
+      "configuration.drsConfig.defaultVmBehavior",
+      "configuration.drsConfig.enabled",
+      "configuration.drsConfig.vmotionRate",
+      "summary.effectiveCpu",
+      "summary.effectiveMemory",
+      "host",
+      "name",
+      "parent",
+      "resourcePool",
+    ],
+    :ResourcePool                => [
+      "name",
+      "parent",
+      "resourcePool",
+      "summary.config.cpuAllocation.expandableReservation",
+      "summary.config.cpuAllocation.limit",
+      "summary.config.cpuAllocation.reservation",
+      "summary.config.cpuAllocation.shares.level",
+      "summary.config.cpuAllocation.shares.shares",
+      "summary.config.memoryAllocation.expandableReservation",
+      "summary.config.memoryAllocation.limit",
+      "summary.config.memoryAllocation.reservation",
+      "summary.config.memoryAllocation.shares.level",
+      "summary.config.memoryAllocation.shares.shares",
+      "vm",
+    ],
+    :Folder                      => [
+      "childEntity",
+      "name",
+      "parent",
+    ],
+    :Datacenter                  => [
+      "datastoreFolder",
+      "hostFolder",
+      "name",
+      "networkFolder",
+      "parent",
+      "vmFolder",
+    ],
+    :HostSystem                  => [
+      "config.adminDisabled",
+      "config.consoleReservation.serviceConsoleReserved",
+      "config.hyperThread.active",
+      "config.network.consoleVnic",
+      "config.network.dnsConfig.domainName",
+      "config.network.dnsConfig.hostName",
+      "config.network.ipRouteConfig.defaultGateway",
+      "config.network.pnic",
+      "config.network.portgroup",
+      "config.network.vnic",
+      "config.network.vswitch",
+      "config.service.service",
+      "config.storageDevice.hostBusAdapter",
+      "config.storageDevice.scsiLun",
+      "config.storageDevice.scsiTopology.adapter",
+      "datastore",
+      "hardware.systemInfo.otherIdentifyingInfo",
+      "name",
+      "summary.host",
+      "summary.config.name",
+      "summary.config.product.build",
+      "summary.config.product.name",
+      "summary.config.product.osType",
+      "summary.config.product.vendor",
+      "summary.config.product.version",
+      "summary.config.vmotionEnabled",
+      "summary.hardware.cpuMhz",
+      "summary.hardware.cpuModel",
+      "summary.hardware.memorySize",
+      "summary.hardware.model",
+      "summary.hardware.numCpuCores",
+      "summary.hardware.numCpuPkgs",
+      "summary.hardware.numNics",
+      "summary.hardware.vendor",
+      "summary.quickStats.overallCpuUsage",
+      "summary.quickStats.overallMemoryUsage",
+      "summary.runtime.connectionState",
+      "summary.runtime.inMaintenanceMode",
+    ],
+    :Datastore                   => [
+      "info",
+      "host",
+      "capability.directoryHierarchySupported",
+      "capability.perFileThinProvisioningSupported",
+      "capability.rawDiskMappingsSupported",
+      "summary.accessible",
+      "summary.capacity",
+      "summary.datastore",
+      "summary.freeSpace",
+      "summary.maintenanceMode",
+      "summary.multipleHostAccess",
+      "summary.name",
+      "summary.type",
+      "summary.uncommitted",
+      "summary.url",
+      "parent",
+    ],
+    :StoragePod                  => [
+      "summary.capacity",
+      "summary.freeSpace",
+      "summary.name",
+      "childEntity",
+      "parent",
+    ],
+    :DistributedVirtualPortgroup => [
+      "summary.name",
+      "config.key",
+      "config.distributedVirtualSwitch",
+      "config.name",
+      "parent",
+      "host",
+      "tag",
+    ],
+    :DistributedVirtualSwitch    => [
+      "config.uplinkPortgroup",
+      "config.defaultPortConfig",
+      "config.numPorts",
+      "summary.name",
+      "summary.uuid",
+      "summary.host",
+      "summary.hostMember",
+      "parent",
+    ]
+  }.freeze
+
+  def create_property_filter(vim)
+    root_folder = vim.serviceContent.rootFolder
+
+    root_folder_object_spec = RbVmomi::VIM.ObjectSpec(
+      :obj => root_folder, :selectSet => select_set
+    )
+
+    spec = RbVmomi::VIM.PropertyFilterSpec(
+      :objectSet => [root_folder_object_spec],
+      :propSet   => prop_set
+    )
+
+    vim.propertyCollector.CreateFilter(:spec => spec, :partialUpdates => true)
+  end
+
+  def prop_set
+    EmsRefreshPropMap.collect do |type, props|
+      RbVmomi::VIM.PropertySpec(
+        :type    => type,
+        :all     => props.nil?,
+        :pathSet => props
+      )
+    end
+  end
+
+  def select_set
+    [
+      RbVmomi::VIM.TraversalSpec(
+        :name => 'tsFolder', :type => 'Folder', :path => 'childEntity',
+        :selectSet => [
+          RbVmomi::VIM.SelectionSpec(:name => 'tsFolder'),
+          RbVmomi::VIM.SelectionSpec(:name => 'tsDcToDsFolder'),
+          RbVmomi::VIM.SelectionSpec(:name => 'tsDcToHostFolder'),
+          RbVmomi::VIM.SelectionSpec(:name => 'tsDcToNetworkFolder'),
+          RbVmomi::VIM.SelectionSpec(:name => 'tsDcToVmFolder'),
+          RbVmomi::VIM.SelectionSpec(:name => 'tsCrToHost'),
+          RbVmomi::VIM.SelectionSpec(:name => 'tsCrToRp'),
+          RbVmomi::VIM.SelectionSpec(:name => 'tsRpToRp'),
+          RbVmomi::VIM.SelectionSpec(:name => 'tsRpToVm')
+        ]
+      ),
+      RbVmomi::VIM.TraversalSpec(
+        :name => 'tsDcToDsFolder', :type => 'Datacenter', :path => 'datastoreFolder',
+        :selectSet => [RbVmomi::VIM.SelectionSpec(:name => 'tsFolder')]
+      ),
+      RbVmomi::VIM.TraversalSpec(
+        :name => 'tsDcToHostFolder', :type => 'Datacenter', :path => 'hostFolder',
+        :selectSet => [RbVmomi::VIM.SelectionSpec(:name => 'tsFolder')]
+      ),
+      RbVmomi::VIM.TraversalSpec(
+        :name => 'tsDcToNetworkFolder', :type => 'Datacenter', :path => 'networkFolder',
+        :selectSet => [RbVmomi::VIM.SelectionSpec(:name => 'tsFolder')]
+      ),
+      RbVmomi::VIM.TraversalSpec(
+        :name => 'tsDcToVmFolder', :type => 'Datacenter', :path => 'vmFolder',
+        :selectSet => [RbVmomi::VIM.SelectionSpec(:name => 'tsFolder')]
+      ),
+      RbVmomi::VIM.TraversalSpec(
+        :name => 'tsCrToHost', :type => 'ComputeResource', :path => 'host',
+      ),
+      RbVmomi::VIM.TraversalSpec(
+        :name => 'tsCrToRp', :type => 'ComputeResource', :path => 'resourcePool',
+        :selectSet => [RbVmomi::VIM.SelectionSpec(:name => 'tsRpToRp')]
+      ),
+      RbVmomi::VIM.TraversalSpec(
+        :name => 'tsRpToRp', :type => 'ResourcePool', :path => 'resourcePool',
+        :selectSet => [RbVmomi::VIM.SelectionSpec(:name => 'tsRpToRp')]
+      ),
+      RbVmomi::VIM.TraversalSpec(
+        :name => 'tsRpToVm', :type => 'ResourcePool', :path => 'vm',
+      ),
+    ]
+  end
+end

--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("fog-vcloud-director", ["~> 0.1.8"])
   s.add_dependency "vmware_web_service",      "~>0.1.1"
+  s.add_dependency "rbvmomi",                 "~>1.11.3"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -1,0 +1,110 @@
+describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
+  let(:ems) { FactoryGirl.create(:ems_vmware_with_authentication) }
+  let(:collector) { described_class.new(ems) }
+
+  context "#process_object_update" do
+    let(:root_folder)     { RbVmomi::VIM::Folder(nil, "group-d1") }
+    let(:datacenter)      { RbVmomi::VIM::Datacenter(nil, "datacenter-1") }
+    let(:virtual_machine) { RbVmomi::VIM::VirtualMachine(nil, "vm-1") }
+
+    context "enter" do
+      it "Folder" do
+        object_update = RbVmomi::VIM::ObjectUpdate(
+          :obj       => root_folder,
+          :kind      => "enter",
+          :changeSet => [
+            RbVmomi::VIM::PropertyChange(:name => "childEntity", :op => "assign", :val => [datacenter]),
+            RbVmomi::VIM::PropertyChange(:name => "name",        :op => "assign", :val => "Datacenters"),
+            RbVmomi::VIM::PropertyChange(:name => "parent",      :op => "assign"),
+          ]
+        )
+
+        props = collector.process_object_update(object_update)
+
+        expect(props).to have_attributes(
+          "name"        => "Datacenters",
+          "parent"      => nil,
+          "childEntity" => [datacenter]
+        )
+      end
+
+      it "VirtualMachine" do
+        object_update = virtual_machine_enter_object_update
+
+        props = collector.process_object_update(object_update)
+        expect(props).to have_attributes(
+          "summary.config.uuid"       => "eaf4991e-ab31-4f86-9ec0-aeb5d5a27c33",
+          "summary.config.name"       => "vm1",
+          "summary.config.vmPathName" => "[datastore1] vm1/vm1.vmx",
+          "summary.config.template"   => false,
+        )
+      end
+    end
+
+    context "modify" do
+      context "Change the name of an existing vm" do
+        before do
+          object_update = virtual_machine_enter_object_update
+          collector.process_object_update(object_update)
+        end
+
+        it "Returns the changed name" do
+          object_update = RbVmomi::VIM::ObjectUpdate(
+            :obj       => virtual_machine,
+            :kind      => "modify",
+            :changeSet => [
+              RbVmomi::VIM::PropertyChange(:name => "summary.config.name", :op => "assign", :val => "vm2"),
+            ]
+          )
+
+          props = collector.process_object_update(object_update)
+          expect(props).to have_attributes(
+            "summary.config.name" => "vm2"
+          )
+        end
+
+        it "Merges the cached properties with the name change" do
+          object_update = RbVmomi::VIM::ObjectUpdate(
+            :obj       => virtual_machine,
+            :kind      => "modify",
+            :changeSet => [
+              RbVmomi::VIM::PropertyChange(:name => "summary.config.name", :op => "assign", :val => "vm2"),
+            ]
+          )
+
+          props = collector.process_object_update(object_update)
+          expect(props).to have_attributes(
+            "summary.config.uuid"       => "eaf4991e-ab31-4f86-9ec0-aeb5d5a27c33",
+            "summary.config.name"       => "vm2",
+            "summary.config.vmPathName" => "[datastore1] vm1/vm1.vmx",
+            "summary.config.template"   => false,
+          )
+        end
+      end
+    end
+
+    def virtual_machine_enter_object_update
+      RbVmomi::VIM::ObjectUpdate(
+        :obj       => virtual_machine,
+        :kind      => "enter",
+        :changeSet => [
+          RbVmomi::VIM::PropertyChange(:name => "summary.config.uuid",
+                                       :op   => "assign",
+                                       :val  => "eaf4991e-ab31-4f86-9ec0-aeb5d5a27c33"),
+          RbVmomi::VIM::PropertyChange(:name => "summary.config.name",
+                                       :op   => "assign",
+                                       :val  => "vm1"),
+          RbVmomi::VIM::PropertyChange(:name => "summary.config.vmPathName",
+                                       :op   => "assign",
+                                       :val  => "[datastore1] vm1/vm1.vmx"),
+          RbVmomi::VIM::PropertyChange(:name => "summary.runtime.powerState",
+                                       :op   => "assign",
+                                       :val  => "poweredOff"),
+          RbVmomi::VIM::PropertyChange(:name => "summary.config.template",
+                                       :op   => "assign",
+                                       :val  => false),
+        ]
+      )
+    end
+  end
+end

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -1,8 +1,10 @@
+require 'rbvmomi/vim'
+
 describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
   let(:ems) { FactoryGirl.create(:ems_vmware_with_authentication) }
   let(:collector) { described_class.new(ems) }
 
-  context "#process_object_update" do
+  context "#process_object_update (private)" do
     let(:root_folder)     { RbVmomi::VIM::Folder(nil, "group-d1") }
     let(:datacenter)      { RbVmomi::VIM::Datacenter(nil, "datacenter-1") }
     let(:virtual_machine) { RbVmomi::VIM::VirtualMachine(nil, "vm-1") }
@@ -19,7 +21,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
           ]
         )
 
-        props = collector.process_object_update(object_update)
+        props = collector.send(:process_object_update, object_update)
 
         expect(props).to have_attributes(
           "name"        => "Datacenters",
@@ -31,7 +33,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
       it "VirtualMachine" do
         object_update = virtual_machine_enter_object_update
 
-        props = collector.process_object_update(object_update)
+        props = collector.send(:process_object_update, object_update)
         expect(props).to have_attributes(
           "summary.config.uuid"       => "eaf4991e-ab31-4f86-9ec0-aeb5d5a27c33",
           "summary.config.name"       => "vm1",
@@ -45,7 +47,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
       context "Change the name of an existing vm" do
         before do
           object_update = virtual_machine_enter_object_update
-          collector.process_object_update(object_update)
+          collector.send(:process_object_update, object_update)
         end
 
         it "Returns the changed name" do
@@ -57,7 +59,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
             ]
           )
 
-          props = collector.process_object_update(object_update)
+          props = collector.send(:process_object_update, object_update)
           expect(props).to have_attributes(
             "summary.config.name" => "vm2"
           )
@@ -72,7 +74,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
             ]
           )
 
-          props = collector.process_object_update(object_update)
+          props = collector.send(:process_object_update, object_update)
           expect(props).to have_attributes(
             "summary.config.uuid"       => "eaf4991e-ab31-4f86-9ec0-aeb5d5a27c33",
             "summary.config.name"       => "vm2",


### PR DESCRIPTION
Add an inventory collection strategy that uses `WaitForUpdates` instead of events and `RetrieveProperties` through the broker.  This uses the [RbVmomi](https://github.com/vmware/rbvmomi) gem from VMware.