### PR TITLE
Don't queue a refresh on RefreshWorker start

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
@@ -3,10 +3,6 @@ class ManageIQ::Providers::Vmware::InfraManager::RefreshWorker::Runner < ManageI
 
   def do_before_work_loop
     # Override Standard EmsRefreshWorker's method of queueing up a Refresh
-    # if the VimBrokerWorker isn't available yet.
     # This will be done by the VimBrokerWorker, when he is ready.
-    #
-    # If the VimBrokerWorker is running already then queue up an initial refresh
-    super if MiqVimBrokerWorker.available?
   end
 end


### PR DESCRIPTION
The refresh_worker is restarted every 2 hours, by queueing a full refresh everytime the refresh_worker starts this was causing a significant number more full refreshes than before.

This was originally done in https://github.com/ManageIQ/manageiq-providers-vmware/pull/41 so that when a user added additional EMSs an initial refresh would be queued, but that combined with us restarting the refresh worker every 2 hours caused many more full refreshes than intended.

https://bugzilla.redhat.com/show_bug.cgi?id=1469198