### PR TITLE
Configurably use the RbVmomi Inventory Collector

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
@@ -4,5 +4,39 @@ class ManageIQ::Providers::Vmware::InfraManager::RefreshWorker::Runner < ManageI
   def do_before_work_loop
     # Override Standard EmsRefreshWorker's method of queueing up a Refresh
     # This will be done by the VimBrokerWorker, when he is ready.
+
+    if Settings.prototype.ems_vmware.update_driven_refresh
+      @collector = ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector.new(@ems)
+      @collector_thread = start_inventory_collector(@collector)
+    end
+  end
+
+  def before_exit
+    if Settings.prototype.ems_vmware.update_driven_refresh
+      stop_inventory_collector(@collector)
+
+      # The WaitOptions for WaitForUpdatesEx call sets maxWaitSeconds to 60 seconds
+      @collector_thread.join(60.seconds) # TODO: make this configurable
+    end
+  end
+
+  def start_inventory_collector(collector)
+    thread = Thread.new do
+      begin
+        collector.run
+      rescue => err
+        _log.error("Inventory collector aborted because [#{err.message}]")
+        _log.log_backtrace(err)
+        Thread.exit
+      end
+    end
+
+    _log.info("Started inventory collector")
+
+    thread
+  end
+
+  def stop_inventory_collector(collector)
+    collector.stop
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,6 +24,9 @@
     :user:
 #:log:
 #  :level_vim: warn
+:prototype:
+  :ems_vmware:
+    :update_driven_refresh: false
 :workers:
   :worker_base:
     :event_catcher:


### PR DESCRIPTION
If `update_driven_refresh` is set in config then run the RbVmomi inventory collector as a thread in the RefreshWorker.

Still left to do:
- [x] Don't use the core refresh worker or the refresh prop map in the broker - handled by https://github.com/ManageIQ/manageiq/pull/15579
- [ ] Disable normal targeted refreshes resulting from events - Need a follow-up PR to handle full refresh requests, targeted ones will be dropped.

~~Depends: https://github.com/ManageIQ/manageiq-providers-vmware/pull/72~~

Comparison of traditional refresh (VimBroker with refresh cache scope, core refresh worker, refresh worker) vs update driven refresh (VimBroker with core cache scope, RbVmomi refresh worker from this PR):

![chart](https://user-images.githubusercontent.com/12851112/28545680-f28c715c-7095-11e7-82c4-652b4762a615.png)
Interactive chart: https://docs.google.com/a/redhat.com/spreadsheets/d/1uidsYBvoSN0HZfXf098Q61u9sfrbgsUZ8XHpBXPNMLc/pubchart?oid=697977625&format=interactive

"Classic" refresh used `2.67GiB` and took 3.8 mins, update driven refresh used `1.25GiB` and took 2.15 mins so really high level it took half the time and half the memory.
In the latter case the `VimBroker` in core mode used `758MiB` and the Refresh Worker used `523MiB`.

Using batch refresh took the memory of the `RefreshWorker` down to `372.61MiB`