### PR TITLE
Use methods for the different persister options

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
@@ -36,7 +36,28 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister < ManagerR
     )
   end
 
+  def complete
+    true
+  end
+
+  def saver_strategy
+    :default
+  end
+
+  def strategy
+    nil
+  end
+
+  def targeted
+    false
+  end
+
   def inventory_collection_options
-    {}
+    {
+      :complete       => complete,
+      :saver_strategy => saver_strategy,
+      :strategy       => strategy,
+      :targeted       => targeted,
+    }
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/persister/batch.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/persister/batch.rb
@@ -1,8 +1,9 @@
 class ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister::Batch < ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister
-  def inventory_collection_options
-    {
-      :complete => false,
-      :strategy => :local_db_find_missing_references,
-    }
+  def complete
+    false
+  end
+
+  def strategy
+    :local_db_find_missing_references
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/persister/targeted.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/persister/targeted.rb
@@ -1,8 +1,5 @@
 class ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister::Targeted < ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister
-  def inventory_collection_options
-    {
-      :targeted => true,
-      :strategy => :local_db_find_missing_references,
-    }
+  def targeted
+    true
   end
 end


### PR DESCRIPTION
Use methods that can be overridden by child classes to make the
persister options easier to build.