### PR TITLE
Bump vmware_web_service gem to 0.2.0

### DIFF
--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*"]
 
   s.add_dependency("fog-vcloud-director", ["~> 0.1.8"])
-  s.add_dependency "vmware_web_service",      "~>0.1.1"
+  s.add_dependency "vmware_web_service",      "~>0.2.0"
   s.add_dependency "rbvmomi",                 "~>1.11.3"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
This is needed for https://github.com/ManageIQ/manageiq-providers-vmware/pull/90