### PR TITLE
If there is no vnicDev passed in don't call edit_vlan_device

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/network.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/network.rb
@@ -50,7 +50,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration::Netw
   def build_config_spec_vlan(network, vnicDev, vmcs)
     operation = vnicDev.nil? ? VirtualDeviceConfigSpecOperation::Add : VirtualDeviceConfigSpecOperation::Edit
     add_device_config_spec(vmcs, operation) do |vdcs|
-      vdcs.device = edit_vlan_device(network, vnicDev) || create_vlan_device(network)
+      vdcs.device = vnicDev ? edit_vlan_device(network, vnicDev) : create_vlan_device(network)
+
       _log.info "Setting target network device to Device Name:<#{network[:network]}>  Device:<#{vdcs.device.inspect}>"
 
       vdcs.device.backing = VimHash.new('VirtualEthernetCardNetworkBackingInfo') do |vecnbi|
@@ -79,7 +80,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration::Netw
 
     operation = vnicDev.nil? ? VirtualDeviceConfigSpecOperation::Add : VirtualDeviceConfigSpecOperation::Edit
     add_device_config_spec(vmcs, operation) do |vdcs|
-      vdcs.device = edit_vlan_device(network, vnicDev) || create_vlan_device(network)
+      vdcs.device = vnicDev ? edit_vlan_device(network, vnicDev) : create_vlan_device(network)
       _log.info "Setting target network device to Device Name:<#{network[:network]}>  Device:<#{vdcs.device.inspect}>"
 
       #


### PR DESCRIPTION
If there is no vnicDev passed in to `build_config_spec_vlan` or `build_config_spec_dvs` then don't call `edit_vlan_device`

```
ERROR -- : Q-task_id([miq_provision_1000000001101]) MIQ(ManageIQ::Providers::Vmware::InfraManager::Provision#provision_error) [[NoMethodError]: undefined method `xsiType' for nil:NilClass] encountered during phase [start_clone_task]
ERROR -- : Q-task_id([miq_provision_1000000001101]) /opt/rh/cfme-gemset/bundler/gems/manageiq-providers-vmware-a1dd5cad9e94/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/network.rb:122:in `edit_vlan_device'
/opt/rh/cfme-gemset/bundler/gems/manageiq-providers-vmware-a1dd5cad9e94/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/network.rb:53:in `block in build_config_spec_vlan'
```
https://bugzilla.redhat.com/show_bug.cgi?id=1477256