### PR TITLE
Fix the issue where dvs_ prefix is removed from :vlan in provision's options hash.

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
@@ -150,9 +150,9 @@ class ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow < ManageIQ::P
 
     _log.info("Filtering hosts with the following network: <#{vlan_name}>")
     shared = !vlan_name.match(/dvs_/).nil?
-    vlan_name.sub!(/^dvs_/, '') if shared
+    vlan_search_name = shared ? vlan_name.sub(/^dvs_/, '') : vlan_name
     MiqPreloader.preload(all_hosts, :lans => :switches)
-    all_hosts.select { |h| h.lans.any? { |lan| lan.name == vlan_name && !lan.switch.shared.blank? == shared } }
+    all_hosts.select { |h| h.lans.any? { |lan| lan.name == vlan_search_name && !lan.switch.shared.blank? == shared } }
   end
 
   def allowed_storage_profiles(_options = {})

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_workflow_spec.rb
@@ -270,6 +270,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
           @host2.switches = [s22]
           workflow.instance_variable_set(:@values, :src_vm_id => @src_vm.id, :vlan => ["dvs_#{@lan22.name}", @lan22.name])
           expect(workflow.allowed_hosts_obj).to match_array([@host2])
+          expect(workflow.instance_variable_get(:@values)[:vlan]).to match_array(["dvs_#{@lan22.name}", @lan22.name])
         end
       end
     end


### PR DESCRIPTION
Fix the VM Provisioning issue with auto replacement in selected dvPortGroup network.
Issue was introduced in https://github.com/ManageIQ/manageiq-providers-vmware/pull/78.

https://bugzilla.redhat.com/show_bug.cgi?id=1482270

@miq-bot assign @agrare 
@miq-bot add_label bug, fine/yes