### PR TITLE
Move detect_discovered_hypervisor to Vmware::InfraManager::Host

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/host.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/host.rb
@@ -67,5 +67,30 @@ class ManageIQ::Providers::Vmware::InfraManager::Host < ::Host
     end
   end
 
+  def detect_discovered_hypervisor(_ost, ipaddr)
+    find_method = :find_by_ipaddress
+
+    self.name        = "VMware ESX Server (#{ipaddr})"
+    self.ipaddress   = ipaddr
+    self.vmm_vendor  = "vmware"
+    self.vmm_product = "Esx"
+    if has_credentials?(:ws)
+      begin
+        with_provider_connection(:ip => ipaddr) do |vim|
+          _log.info("VIM Information for ESX Host with IP Address: [#{ipaddr}], Information: #{vim.about.inspect}")
+          self.vmm_product     = vim.about['name'].dup.split(' ').last
+          self.vmm_version     = vim.about['version']
+          self.vmm_buildnumber = vim.about['build']
+          self.name            = "#{vim.about['name']} (#{ipaddr})"
+        end
+      rescue => err
+        _log.warn("Cannot connect to ESX Host with IP Address: [#{ipaddr}], Username: [#{authentication_userid(:ws)}] because #{err.message}")
+      end
+    end
+    self.type = %w(esx esxi).include?(vmm_product.to_s.downcase) ? "ManageIQ::Providers::Vmware::InfraManager::HostEsx" : "ManageIQ::Providers::Vmware::InfraManager::Host"
+
+    find_method
+  end
+
   supports :quick_stats
 end


### PR DESCRIPTION
Move the ESX specifics out of `::Host#detect_discovered_hypervisor`