### PR TITLE
Split on comma instead of CSV.parse for metrics capture

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/metrics_capture.rb
@@ -1,5 +1,3 @@
-require "csv"
-
 class ManageIQ::Providers::Vmware::InfraManager::MetricsCapture < ManageIQ::Providers::BaseManager::MetricsCapture
   VIM_INTERVAL_NAME_BY_MIQ_INTERVAL_NAME = {'hourly' => 'Past Month'}
   MIQ_INTERVAL_NAME_BY_VIM_INTERVAL_NAME = VIM_INTERVAL_NAME_BY_MIQ_INTERVAL_NAME.invert
@@ -238,12 +236,12 @@ class ManageIQ::Providers::Vmware::InfraManager::MetricsCapture < ManageIQ::Prov
     end
 
     values = data['value'].to_miq_a
-    samples = CSV.parse(data['sampleInfoCSV'].to_s).first.to_miq_a
+    samples = data['sampleInfoCSV'].to_s.split(",")
 
     ret = []
     values.each do |v|
       id, v = v.values_at('id', 'value')
-      v = CSV.parse(v.to_s).first.to_miq_a
+      v = v.to_s.split(",")
 
       nh = {}.merge!(base)
       nh[:counter_id] = id['counterId']


### PR DESCRIPTION
Split on commas instead of the full `CSV.parse()` which is more general but also much slower.

There are two values that are returned in CSV, `sampleInfoCSV` and `value` defined here [EntityMetricCSV](https://www.vmware.com/support/developer/vc-sdk/visdk400pubs/ReferenceGuide/vim.PerformanceManager.EntityMetricCSV.html)

The [SampleInfo](https://www.vmware.com/support/developer/vc-sdk/visdk400pubs/ReferenceGuide/vim.PerformanceManager.SampleInfo.html) contains a `xsd:int` and a `xsd:dateTime` which looks like:
`sampleInfoCSV: 20,2011-08-12T20:33:20Z,20,2011-08-12T20:33:40Z,.....`
The [PerfMetricIntSeries](https://www.vmware.com/support/developer/vc-sdk/visdk400pubs/ReferenceGuide/vim.PerformanceManager.IntSeries.html) contains an array of `xsd:long` and looks like:
`value: 0,0,0,3,0,1273,1099,0,0,0,0,0,0,...`

Both of these should be safe to split on commas and save the overhead of `CSV.parse()`


Depends:

- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/90  Use CSV Format for Query Perf