### PR TITLE
Fix update driven refresh initialization

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
@@ -6,7 +6,8 @@ class ManageIQ::Providers::Vmware::InfraManager::RefreshWorker::Runner < ManageI
     # This will be done by the VimBrokerWorker, when he is ready.
 
     if Settings.prototype.ems_vmware.update_driven_refresh
-      @collector = ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector.new(@ems)
+      ems = @emss.first
+      @collector = ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector.new(ems)
       @collector_thread = start_inventory_collector(@collector)
     end
   end


### PR DESCRIPTION
The change in the base RefreshWorker::Runner (https://github.com/ManageIQ/manageiq/commit/984a3a28b5cbda57b7691cdf34eb2f7afc960bce) to allow an array of EMSes
caused issues in this case where we were using the @ems var directly in
the runner for update driven refresh.