### PR TITLE
[WIP] Rearch metrics collection

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/metrics_capture.rb
@@ -1,419 +1,396 @@
 class ManageIQ::Providers::Vmware::InfraManager::MetricsCapture < ManageIQ::Providers::BaseManager::MetricsCapture
-  VIM_INTERVAL_NAME_BY_MIQ_INTERVAL_NAME = {'hourly' => 'Past Month'}
-  MIQ_INTERVAL_NAME_BY_VIM_INTERVAL_NAME = VIM_INTERVAL_NAME_BY_MIQ_INTERVAL_NAME.invert
+  include RbvmomiConnectMixin
 
-  #
-  # MiqVimPerfHistory methods (with caching)
-  #
+  attr_accessor :perf_counters_to_collect, :perf_counters_by_id
+  def initialize(ems, options = {})
+    super ems
 
-  cache_with_timeout(:perf_history_results,
-                     -> { ::Settings.performance.vim_cache_ttl.to_i_with_method }
-                    ) { Hash.new }
+    @options = options
 
-  def self.intervals(ems, vim_hist)
-    phr = perf_history_results
-    results = phr.fetch_path(:intervals, ems.id)
-    return results unless results.nil?
+    @collect_interval   = options[:collect_interval] || 60
+    @query_size         = options[:perf_query_size] || 250
+    @format             = options[:format] || "csv"
+    @interval           = options[:interval] || "20"
+    @interval_name      = capture_interval_to_interval_name(interval)
 
-    log_header = "EMS: [#{ems.hostname}]"
-    begin
-      results = vim_hist.intervals
-    rescue Handsoap::Fault, StandardError => err
-      _log.error("#{log_header} The following error occurred: [#{err}]")
-      raise
-    end
-
-    _log.debug("#{log_header} Available sampling intervals: [#{results.length}]")
-    phr.store_path(:intervals, ems.id, results)
+    @perf_counters_to_collect = []
+    @perf_counters_by_id = {}
   end
 
-  def self.realtime_interval(ems, vim_hist, mor)
-    phr = perf_history_results
-    results = phr.fetch_path(:realtime_interval, ems.id, mor)
-    return results unless results.nil?
+  def perf_counters_to_collect
+    perf_counter_names = METRIC_CAPTURE_COUNTERS
 
-    log_header = "EMS: [#{ems.hostname}]"
+    all_counters = perf_counter_info
 
-    begin
-      summary = vim_hist.queryProviderSummary(mor)
-    rescue Handsoap::Fault, StandardError => err
-      _log.error("#{log_header} The following error occurred: [#{err}]")
-      raise
+    hash = perf_counters_by_name(all_counters)
+    perf_counters_to_collect = perf_counter_names.map do |counter_name|
+      hash[counter_name]
     end
 
-    if summary.kind_of?(Hash) && summary['currentSupported'].to_s == "true"
-      interval = summary['refreshRate'].to_s
-      _log.debug("#{log_header} Found realtime interval: [#{interval}] for mor: [#{mor}]")
-    else
-      interval = nil
-      _log.debug("#{log_header} Realtime is not supported for mor: [#{mor}], summary: [#{summary.inspect}]")
-    end
-
-    phr.store_path(:realtime_interval, ems.id, mor, interval)
-  end
-
-  def self.hourly_interval(ems, vim_hist)
-    phr = perf_history_results
-    results = phr.fetch_path(:hourly_interval, ems.id)
-    return results unless results.nil?
-
-    log_header = "EMS: [#{ems.hostname}]"
-
-    # Using the reporting value of 'hourly', get the vim interval 'Past Month'
-    #   and look for that in the intervals data
-    vim_interval = VIM_INTERVAL_NAME_BY_MIQ_INTERVAL_NAME['hourly']
-
-    intervals = self.intervals(ems, vim_hist)
-
-    interval = intervals.detect { |i| i['name'].to_s.downcase == vim_interval.downcase }
-    if interval.nil?
-      _log.debug("#{log_header} Unable to find hourly interval [#{vim_interval}] in intervals: #{intervals.collect { |i| i['name'] }.inspect}")
-    else
-      interval = interval['samplingPeriod'].to_s
-      _log.debug("#{log_header} Found hourly interval: [#{interval}] for vim interval: [#{vim_interval}]")
-    end
-
-    phr.store_path(:hourly_interval, ems.id, interval)
-  end
-
-  def self.counter_info_by_counter_id(ems, vim_hist)
-    phr = perf_history_results
-    results = phr.fetch_path(:counter_info_by_id, ems.id)
-    return results unless results.nil?
-
-    log_header = "EMS: [#{ems.hostname}]"
-    begin
-      counter_info = vim_hist.id2Counter
-    rescue Handsoap::Fault, StandardError => err
-      _log.error("#{log_header} The following error occurred: [#{err}]")
-      raise
-    end
-
-    # TODO: Move this to some generic parsing class, such as
-    # ManageIQ::Providers::Vmware::InfraManager::RefreshParser
-    results = counter_info.each_with_object({}) do |(id, c), h|
-      group    = c.fetch_path('groupInfo', 'key').to_s.downcase
-      name     = c.fetch_path('nameInfo', 'key').to_s.downcase
-      rollup   = c['rollupType'].to_s.downcase
-      stats    = c['statsType'].to_s.downcase
-      unit_key = c.fetch_path('unitInfo', 'key').to_s.downcase
-
-      h[id] = {
-        :counter_key => "#{group}_#{name}_#{stats}_#{rollup}",
-        :group       => group,
-        :name        => name,
-        :rollup      => rollup,
-        :stats       => stats,
-        :unit_key    => unit_key,
-        :precision   => (unit_key == 'percent') ? 0.01 : 1,
-      }
-    end
-
-    phr.store_path(:counter_info_by_id, ems.id, results)
-  end
-
-  def self.avail_metrics_for_entity(ems, vim_hist, mor, interval, interval_name)
-    return {} if interval.nil?
-
-    phr = perf_history_results
-    results = phr.fetch_path(:avail_metrics_for_entity, ems.id, mor, interval)
-    return results unless results.nil?
-
-    log_header = "EMS: [#{ems.hostname}]"
-    begin
-      avail_metrics = vim_hist.availMetricsForEntity(mor, :intervalId => interval)
-    rescue Handsoap::Fault, StandardError => err
-      _log.error("#{log_header} The following error occurred: [#{err}]")
-      raise
-    end
-
-    info = counter_info_by_counter_id(ems, vim_hist)
-
-    results = avail_metrics.to_miq_a.each_with_object({}) do |metric, h|
-      counter = info[metric["counterId"]]
-      next if counter.nil?
-
-      # Filter the metrics for only the cols we will use
-      next unless Metric::Capture.capture_cols.include?(counter[:counter_key].to_sym)
-
-      vim_key      = metric["counterId"].to_s
-      instance     = metric["instance"].to_s
-      full_vim_key = "#{vim_key}_#{instance}"
-
-      h[full_vim_key] = {
-        :counter_key           => counter[:counter_key],
-        :rollup                => counter[:rollup],
-        :precision             => counter[:precision],
-        :unit_key              => counter[:unit_key],
-        :vim_key               => vim_key,
-        :instance              => instance,
-        :capture_interval      => interval.to_s,
-        :capture_interval_name => interval_name.to_s
-      }
-    end
-
-    phr.store_path(:avail_metrics_for_entity, ems.id, mor, interval, results)
-  end
-
-  #
-  # Processing/Converting methods
-  #
-
-  def self.preprocess_data(data, counter_values_by_mor_and_ts = {})
-    # First process the results into a format we can consume
-    processed_res = perf_raw_data_to_hashes(data)
-    return unless processed_res.kind_of?(Array)
-
-    # Next process each of the those results
-    processed_res.each do |res|
-      full_vim_key = "#{res[:counter_id]}_#{res[:instance]}"
-      _log.debug("Processing [#{res[:results].length / 2}] results for MOR: [#{res[:mor]}], instance: [#{res[:instance]}], capture interval [#{res[:interval]}], counter vim key: [#{res[:counter_id]}]")
-
-      hashes = perf_vim_data_to_hashes(res[:results])
-      next if hashes.nil?
-      hashes.each { |h| counter_values_by_mor_and_ts.store_path(res[:mor], h[:timestamp], full_vim_key, h[:counter_value]) }
+    perf_counters_to_collect.each do |counter|
+      perf_counters_by_id[counter.key] = counter
     end
   end
 
-  def self.perf_vim_data_to_hashes(vim_data)
-    ret = []
-    meth = nil
+  def perf_collect_metrics(start_time, end_time = nil)
+    _log.info("Collecting performance counters...")
 
-    # The data is organized in an array such as [timestamp1, value1, timestamp2, value2, ...]
-    vim_data.to_miq_a.each_slice(2) do |t, v|
-      if t.kind_of?(String) # VimString
-        t = t.to_s
-      else
-        _log.warn("Discarding unexpected time value in results: ts: [#{t.class.name}] [#{t}], value: #{v}")
-        next
+    perf_query_options = {
+      :interval   => interval,
+      :format     => format,
+      :start_time => start_time,
+      :end_time   => end_time
+    }
+
+    _log.info("Capturing targets...")
+    targets = capture_targets(target_options)
+    _log.info("Capturing targets...Complete - Count [#{targets.count}]")
+
+    _log.info("Collecting metrics...")
+    entity_metrics = []
+    targets.each_slice(query_size) do |vms|
+      entity_metrics.concat(perf_query(perf_counters_to_collect, vms, perf_query_options))
+    end
+    _log.info("Collecting metrics...Complete")
+
+    _log.info("Parsing metrics...")
+    metrics_payload = entity_metrics.collect do |metric|
+      counters       = {}
+      counter_values = Hash.new { |h, k| h[k] = {} }
+
+      processed_res = parse_metric(metric)
+      processed_res.each do |res|
+        full_vim_key = "#{res[:counter_id]}_#{res[:instance]}"
+
+        counter_info = perf_counters_by_id[res[:counter_id]]
+
+        counters[full_vim_key] = {
+          :counter_key           => perf_counter_key(counter_info),
+          :rollup                => counter_info.rollupType,
+          :precision             => counter_info.unitInfo.key == "percent" ? 0.1 : 1,
+          :unit_key              => counter_info.unitInfo.key,
+          :vim_key               => res[:counter_id].to_s,
+          :instance              => res[:instance],
+          :capture_interval      => res[:interval],
+          :capture_interval_name => capture_interval_to_interval_name(res[:interval]),
+        }
+
+        Array(res[:results]).each_slice(2) do |timestamp, value|
+          counter_values[timestamp][full_vim_key] = value
+        end
       end
-      ret << {:timestamp => t, :counter_value => v}
+
+      {
+        :ems_id         => target.id,
+        :ems_ref        => metric.entity._ref,
+        :ems_klass      => vim_entity_to_miq_model(metric.entity),
+        :interval_name  => interval_name,
+        :start_range    => start_time,
+        :end_range      => end_time,
+        :counters       => counters,
+        :counter_values => counter_values
+      }
     end
-    ret
+    _log.info("Parsing metrics...Complete")
+
+    _log.info("Collecting performance counters...Complete")
+
+    metrics_payload
   end
 
-  def self.perf_raw_data_to_hashes(data)
-    # Query perf with single instance single entity
-    return [{:results => data}] if single_instance_and_entity?(data)
+  private
 
-    # Query perf composite or Query perf with multiple instances, single entity
-    return process_entity(data) if composite_or_multi_instance_and_single_entity?(data)
+  attr_reader :collect_interval, :query_size, :options
+  attr_reader :format, :interval, :interval_name
 
-    # Query perf multi (multiple entities, instance(s))
-    return data.collect { |base| process_entity(base) }.flatten if single_or_multi_instance_and_multi_entity?(data)
+  METRIC_CAPTURE_COUNTERS = [
+    :cpu_usage_rate_average,
+    :cpu_usagemhz_rate_average,
+    :mem_usage_absolute_average,
+    :disk_usage_rate_average,
+    :net_usage_rate_average,
+    :sys_uptime_absolute_latest,
+    :cpu_ready_delta_summation,
+    :cpu_system_delta_summation,
+    :cpu_wait_delta_summation,
+    :cpu_used_delta_summation,
+    :mem_vmmemctl_absolute_average,
+    :mem_vmmemctltarget_absolute_average,
+    :mem_swapin_absolute_average,
+    :mem_swapout_absolute_average,
+    :mem_swapped_absolute_average,
+    :mem_swaptarget_absolute_average,
+    :disk_devicelatency_absolute_average,
+    :disk_kernellatency_absolute_average,
+    :disk_queuelatency_absolute_average
+  ].freeze
+
+  def connection
+    @connection ||= connect(ems_options)
   end
 
-  def self.single_instance_and_entity?(data)
-    data.respond_to?(:first) && data.first.kind_of?(DateTime)
+  def capture_interval_to_interval_name(interval)
+    case interval
+    when "20"
+      "realtime"
+    else
+      "hourly"
+    end
   end
 
-  def self.composite_or_multi_instance_and_single_entity?(data)
-    data.respond_to?(:has_key?) && data.key?('entity')
+  def vim_entity_to_miq_model(entity)
+    case entity.class.wsdl_name
+    when "VirtualMachine"
+      "Vm"
+    when "HostSystem"
+      "Host"
+    when "ClusterComputeResource"
+      "EmsCluster"
+    when "Datastore"
+      "Storage"
+    when "ResourcePool"
+      "ResourcePool"
+    end
   end
 
-  def self.single_or_multi_instance_and_multi_entity?(data)
-    !single_instance_and_entity?(data) && data.respond_to?(:first)
+  def perf_counter_key(counter)
+    group  = counter.groupInfo.key.downcase
+    name   = counter.nameInfo.key.downcase
+    rollup = counter.rollupType.downcase
+    stats  = counter.statsType.downcase
+
+    "#{group}_#{name}_#{stats}_#{rollup}".to_sym
   end
 
-  def self.process_entity(data, parent = nil)
-    mor = data['entity']
+  def perf_counters_by_name(all_perf_counters)
+    all_perf_counters.to_a.each_with_object({}) do |counter, hash|
+      hash[perf_counter_key(counter)] = counter
+    end
+  end
 
-    # Set up the common attributes for each value in the result array
+  def perf_counter_info
+    spec_set = [
+      RbVmomi::VIM.PropertyFilterSpec(
+        :objectSet => [
+          RbVmomi::VIM.ObjectSpec(
+            :obj => connection.serviceContent.perfManager,
+          )
+        ],
+        :propSet   => [
+          RbVmomi::VIM.PropertySpec(
+            :type    => connection.serviceContent.perfManager.class.wsdl_name,
+            :pathSet => ["perfCounter"]
+          )
+        ],
+      )
+    ]
+    options = RbVmomi::VIM.RetrieveOptions()
+
+    result = connection.propertyCollector.RetrievePropertiesEx(
+      :specSet => spec_set, :options => options
+    )
+
+    return if result.nil? || result.objects.nil?
+
+    object_content = result.objects.detect { |oc| oc.obj == connection.serviceContent.perfManager }
+    return if object_content.nil?
+
+    perf_counters = object_content.propSet.to_a.detect { |prop| prop.name == "perfCounter" }
+    Array(perf_counters.try(:val))
+  end
+
+  def perf_query(perf_counters, entities, interval: "20", start_time: nil, end_time: nil, format: "normal", max_sample: nil)
+    format = RbVmomi::VIM.PerfFormat(format)
+
+    metrics = perf_counters.map do |counter|
+      RbVmomi::VIM::PerfMetricId(:counterId => counter.key, :instance  => "*")
+    end
+
+    perf_query_spec_set = entities.collect do |entity|
+      RbVmomi::VIM::PerfQuerySpec(
+        :entity     => entity,
+        :intervalId => interval,
+        :format     => format,
+        :metricId   => metrics,
+        :startTime  => start_time,
+        :endTime    => end_time,
+        :maxSample  => max_sample,
+      )
+    end
+
+    entity_metrics = connection.serviceContent.perfManager.QueryPerf(:querySpec => perf_query_spec_set)
+
+    entity_metrics
+  end
+
+  def capture_targets(target_options = {})
+    select_set = []
+    prop_set   = []
+    targets    = []
+
+    unless target_options[:exclude_vms]
+      select_set.concat(vm_traversal_specs)
+      prop_set << vm_prop_spec
+    end
+
+    unless target_options[:exclude_hosts]
+      select_set.concat(host_traversal_specs)
+      prop_set << host_prop_spec
+    end
+
+    selection_spec_names = select_set.collect { |selection_spec| selection_spec.name }
+    select_set << child_entity_traversal_spec(selection_spec_names)
+
+    object_spec = RbVmomi::VIM.ObjectSpec(
+      :obj       => connection.rootFolder,
+      :selectSet => select_set
+    )
+
+    filter_spec = RbVmomi::VIM.PropertyFilterSpec(
+      :objectSet => [object_spec],
+      :propSet   => prop_set
+    )
+
+    options = RbVmomi::VIM.RetrieveOptions()
+
+    result = connection.propertyCollector.RetrievePropertiesEx(
+      :specSet => [filter_spec], :options => options
+    )
+
+    while result
+      token = result.token
+
+      result.objects.each do |object_content|
+        case object_content.obj
+        when RbVmomi::VIM::VirtualMachine
+          vm_props = Array(object_content.propSet)
+          next if vm_props.empty?
+
+          vm_power_state = vm_props.detect { |prop| prop.name == "runtime.powerState" }
+          next if vm_power_state.nil?
+
+          next unless vm_power_state.val == "poweredOn"
+        when RbVmomi::VIM::HostSystem
+          host_props = Array(object_content.propSet)
+          next if host_props.empty?
+
+          host_connection_state = host_props.detect { |prop| prop.name == "runtime.connectionState" }
+          next if host_connection_state.nil?
+
+          next unless host_connection_state.val == "connected"
+        end
+
+        targets << object_content.obj
+      end
+
+      break if token.nil?
+
+      result = connection.propertyCollector.ContinueRetrievePropertiesEx(:token => token)
+    end
+
+    targets
+  end
+
+  def datacenter_folder_traversal_spec(path)
+    RbVmomi::VIM.TraversalSpec(
+      :name => "tsDatacenter#{path}",
+      :type => "Datacenter",
+      :path => path,
+      :skip => false,
+      :selectSet => [
+        RbVmomi::VIM.SelectionSpec(:name => "tsFolder")
+      ]
+    )
+  end
+
+  def vm_traversal_specs
+    [datacenter_folder_traversal_spec("vmFolder")]
+  end
+
+  def compute_resource_to_host_traversal_spec
+    RbVmomi::VIM.TraversalSpec(
+      :name => "tsComputeResourceToHost",
+      :type => "ComputeResource",
+      :path => "host",
+      :skip => false,
+    )
+  end
+
+  def host_traversal_specs
+    [
+      datacenter_folder_traversal_spec("hostFolder"),
+      compute_resource_to_host_traversal_spec
+    ]
+  end
+
+  def child_entity_traversal_spec(selection_spec_names = [])
+    select_set = selection_spec_names.map do |name|
+      RbVmomi::VIM.SelectionSpec(:name => name)
+    end
+
+    RbVmomi::VIM.TraversalSpec(
+      :name => 'tsFolder',
+      :type => 'Folder',
+      :path => 'childEntity',
+      :skip => false,
+      :selectSet => select_set,
+    )
+  end
+
+  def vm_prop_spec
+    RbVmomi::VIM.PropertySpec(
+      :type    => "VirtualMachine",
+      :pathSet => ["runtime.powerState"],
+    )
+  end
+
+  def host_prop_spec
+    RbVmomi::VIM.PropertySpec(
+      :type    => "HostSystem",
+      :pathSet => ["runtime.connectionState"],
+    )
+  end
+
+  def parse_metric(metric)
     base = {
-      :mor      => mor,
+      :mor      => metric.entity._ref,
       :children => []
     }
-    base[:parent] = parent unless parent.nil?
 
-    if data.key?('childEntity')
-      raise 'composite is not supported yet'
-      #      child_ar  = Array.new
-      #      data['childEntity'].to_miq_a.each do |c|
-      #        child_data = process_entity(c, mor)
-      #        child_ar << child_data
-      #        base[:children] << child_data[:mor]
-      #      end
-    end
+    samples = CSV.parse(metric.sampleInfoCSV.to_s).first.to_a
 
-    values = data['value'].to_miq_a
-    samples = data['sampleInfo'].to_miq_a
-
-    ret = []
-    values.each do |v|
-      id, v = v.values_at('id', 'value')
+    metric.value.to_a.collect do |value|
+      id = value.id
+      val = CSV.parse(value.value.to_s).first.to_a
 
       nh = {}.merge!(base)
-      nh[:counter_id] = id['counterId']
-      nh[:instance]   = id['instance']
+      nh[:counter_id] = id.counterId
+      nh[:instance]   = id.instance
 
       nh[:results] = []
-      samples.each_with_index do |s, i|
-        nh[:interval] ||= s['interval']
-        nh[:results] << s['timestamp']
-        nh[:results] << v[i].to_i
+      samples.each_slice(2).with_index do |(interval, timestamp), i|
+        nh[:interval] ||= interval
+        nh[:results] << timestamp
+        nh[:results] << val[i].to_i
       end
 
-      ret << nh
-    end
-    ret
-  end
-
-  #
-  # Connect / Disconnect / Intialize methods
-  #
-
-  def perf_init_vim
-    @perf_resource = "Resource: [#{target.class.name}], id: [#{target.id}]"
-    ems = target.ext_management_system
-    raise "#{@perf_resource} is not connected to an EMS" if ems.nil?
-
-    @perf_intervals = {}
-    @perf_ems       = "EMS: [#{ems.hostname}]"
-
-    begin
-      @perf_vim = target.ext_management_system.connect
-      @perf_vim_hist = @perf_vim.getVimPerfHistory
-    rescue => err
-      _log.error("#{@perf_resource} Failed to initialize performance history from #{@perf_ems}: [#{err}]")
-      perf_release_vim
-      raise
+      nh
     end
   end
 
-  def perf_release_vim
-    @perf_vim_hist.release if @perf_vim_hist rescue nil
-    @perf_vim.disconnect   if @perf_vim      rescue nil
-    @perf_vim_hist = @perf_vim = nil
+  def ems_options
+    {
+      :ems      => @target,
+      :host     => @target.address,
+      :user     => @target.authentication_userid,
+      :password => @target.authentication_password,
+    }
   end
 
-  #
-  # Capture methods
-  #
-
-  def perf_collect_metrics(interval_name, start_time = nil, end_time = nil)
-    objects = target.to_miq_a
-    log_header = "[#{interval_name}] for: [#{target.class.name}], [#{target.id}], [#{target.name}]"
-
-    require 'httpclient'
-
-    begin
-      Benchmark.realtime_block(:vim_connect) { perf_init_vim }
-
-      objects_by_mor   = objects.each_with_object({}) { |o, h| h[o.ems_ref_obj] = o }
-      interval_by_mor, = Benchmark.realtime_block(:capture_intervals)  { perf_capture_intervals(objects_by_mor.keys, interval_name) }
-      counters_by_mor, = Benchmark.realtime_block(:capture_counters)   { perf_capture_counters(interval_by_mor) }
-      query_params,    = Benchmark.realtime_block(:build_query_params) { perf_build_query_params(interval_by_mor, counters_by_mor, start_time, end_time) }
-      counter_values_by_mor_and_ts = perf_query(query_params, interval_name)
-
-      return counters_by_mor, counter_values_by_mor_and_ts
-    rescue HTTPClient::ReceiveTimeoutError => err
-      attempts ||= 0
-      msg = "#{log_header} Timeout Error during metrics data collection: [#{err}], class: [#{err.class}]"
-      if attempts < 3
-        attempts += 1
-        _log.warn("#{msg}...Retry attempt [#{attempts}]")
-        _log.warn("#{log_header}   Timings before retry: #{Benchmark.current_realtime.inspect}")
-        perf_release_vim
-        retry
-      end
-
-      _log.error("#{msg}...Failed after [#{attempts}] retry attempts")
-      _log.error("#{log_header}   Timings at time of error: #{Benchmark.current_realtime.inspect}")
-      raise MiqException::MiqCommunicationsTimeoutError, err.message
-    rescue Timeout::Error
-      _log.error("#{log_header} Timeout Error during metrics data collection")
-      _log.error("#{log_header}   Timings at time of error: #{Benchmark.current_realtime.inspect}")
-      raise MiqException::MiqTimeoutError, err.message
-    rescue Errno::ECONNREFUSED => err
-      _log.error("#{log_header} Communications Error during metrics data collection: [#{err}], class: [#{err.class}]")
-      _log.error("#{log_header}   Timings at time of error: #{Benchmark.current_realtime.inspect}")
-      raise MiqException::MiqConnectionRefusedError, err.message
-    rescue Exception => err
-      _log.error("#{log_header} Unhandled exception during metrics data collection: [#{err}], class: [#{err.class}]")
-      _log.error("#{log_header}   Timings at time of error: #{Benchmark.current_realtime.inspect}")
-      _log.log_backtrace(err)
-      raise
-    ensure
-      perf_release_vim
-    end
-  end
-
-  def perf_capture_intervals(mors, interval_name)
-    interval_by_mor = {}
-    mors.each do |mor|
-      interval = case interval_name
-                 when 'realtime' then self.class.realtime_interval(target.ext_management_system, @perf_vim_hist, mor)
-                 when 'hourly'   then self.class.hourly_interval(target.ext_management_system, @perf_vim_hist)
-                 end
-
-      @perf_intervals[interval] = interval_name
-      interval_by_mor[mor] = interval
-    end
-
-    _log.debug("Mapping of MOR to Intervals: #{interval_by_mor.inspect}")
-    interval_by_mor
-  end
-
-  def perf_capture_counters(interval_by_mor)
-    _log.info("Capturing counters...")
-
-    counters_by_mor = {}
-
-    # Query Vim for all of the available metrics and their associated counter info
-    interval_by_mor.each do |mor, interval|
-      counters_by_mor[mor] = self.class.avail_metrics_for_entity(target.ext_management_system, @perf_vim_hist, mor, interval, @perf_intervals[interval.to_s])
-    end
-
-    _log.info("Capturing counters...Complete")
-    counters_by_mor
-  end
-
-  def perf_build_query_params(interval_by_mor, counters_by_mor, start_time, end_time)
-    _log.info("Building query parameters...")
-
-    params = []
-    interval_by_mor.each do |mor, interval|
-      counters = counters_by_mor[mor]
-      next if counters.empty?
-
-      st, et = Metric::Helper.sanitize_start_end_time(interval, @perf_intervals[interval.to_s], start_time, end_time)
-
-      param = {
-        :entity     => mor,
-        :intervalId => interval,
-        :startTime  => st,
-        :endTime    => et,
-        :metricId   => counters.values.collect { |counter| {:counterId => counter[:vim_key], :instance => counter[:instance]} }
-      }
-      _log.debug("Adding query params: #{param.inspect}")
-      params << param
-    end
-
-    _log.info("Building query parameters...Complete")
-
-    params
-  end
-
-  def perf_query(params, interval_name)
-    counter_values_by_mor_and_ts = {}
-    return counter_values_by_mor_and_ts if params.blank?
-
-    Benchmark.current_realtime[:num_vim_queries] = params.length
-    _log.debug("Total item(s) to be requested: [#{params.length}], #{params.inspect}")
-
-    query_size = Metric::Capture.concurrent_requests(interval_name)
-    vim_trips = 0
-    params.each_slice(query_size) do |query|
-      vim_trips += 1
-
-      _log.debug("Starting request for [#{query.length}] item(s), #{query.inspect}")
-      data, = Benchmark.realtime_block(:vim_execute_time) { @perf_vim_hist.queryPerfMulti(query) }
-      _log.debug("Finished request for [#{query.length}] item(s)")
-
-      Benchmark.realtime_block(:perf_processing) { self.class.preprocess_data(data, counter_values_by_mor_and_ts) }
-    end
-    Benchmark.current_realtime[:num_vim_trips] = vim_trips
-
-    counter_values_by_mor_and_ts
+  def target_options
+    {
+      :exclude_hosts => @options[:exclude_hosts],
+      :exclude_vms   => @options[:exclude_vms],
+    }
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/metrics_capture.rb
@@ -56,7 +56,7 @@ class ManageIQ::Providers::Vmware::InfraManager::MetricsCapture < ManageIQ::Prov
     _log.info("Parsing metrics...")
     metrics_payload = entity_metrics.collect do |metric|
       counters       = {}
-      counter_values = Hash.new { |h, k| h[k] = {} }
+      counter_values = {}
 
       processed_res = parse_metric(metric)
       processed_res.each do |res|
@@ -76,6 +76,7 @@ class ManageIQ::Providers::Vmware::InfraManager::MetricsCapture < ManageIQ::Prov
         }
 
         Array(res[:results]).each_slice(2) do |timestamp, value|
+          counter_values[timestamp] ||= {}
           counter_values[timestamp][full_vim_key] = value
         end
       end

--- a/app/models/manageiq/providers/vmware/infra_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/metrics_collector_worker.rb
@@ -1,8 +1,6 @@
 class ManageIQ::Providers::Vmware::InfraManager::MetricsCollectorWorker < ManageIQ::Providers::BaseManager::MetricsCollectorWorker
   require_nested :Runner
 
-  self.default_queue_name = "vmware"
-
   def friendly_name
     @friendly_name ||= "C&U Metrics Collector for vCenter"
   end

--- a/app/models/manageiq/providers/vmware/infra_manager/metrics_collector_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/metrics_collector_worker/runner.rb
@@ -1,3 +1,17 @@
 class ManageIQ::Providers::Vmware::InfraManager::MetricsCollectorWorker::Runner < ManageIQ::Providers::BaseManager::MetricsCollectorWorker::Runner
-  self.require_vim_broker = true
+  def after_initialize
+    @ems = ExtManagementSystem.find(@cfg[:ems_id])
+    do_exit("Unable to find instance for EMS ID [#{@cfg[:ems_id]}].", 1) if @ems.nil?
+    do_exit("EMS ID [#{@cfg[:ems_id]}] failed authentication check.", 1) unless @ems.authentication_check.first
+
+    @metrics_capture = @ems.class::MetricsCapture.new(@ems)
+    @metrics_capture.perf_counters_to_collect
+    @start_time = Time.now - 5.minutes
+  end
+
+  def do_work
+    metrics = @metrics_capture.perf_collect_metrics(@start_time)
+
+    @start_time = Time.now
+  end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/metrics_collector_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/metrics_collector_worker/runner.rb
@@ -13,5 +13,16 @@ class ManageIQ::Providers::Vmware::InfraManager::MetricsCollectorWorker::Runner 
     metrics = @metrics_capture.perf_collect_metrics(@start_time)
 
     @start_time = Time.now
+
+    MiqQueue.put(
+      :class_name => @ems.class.name,
+      :method_name => "perf_save_metrics",
+      :instance_id => @ems.id,
+      :zone        => @ems.my_zone,
+      :role        => 'ems_metrics_processor',
+      :queue_name  => 'ems_metrics_processor',
+      :priority    => MiqQueue::NORMAL_PRIORITY,
+      :data        => metrics,
+    )
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/rbvmomi_connect_mixin.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/rbvmomi_connect_mixin.rb
@@ -1,0 +1,30 @@
+module ManageIQ::Providers::Vmware::InfraManager::RbvmomiConnectMixin
+  def connect(options = {})
+    options[:ssl]      ||= true
+    options[:insecure] ||= true
+
+    opts = rbvmomi_vim_connect_opts(options)
+
+    RbVmomi::VIM.new(opts).tap do |vim|
+      vim.rev = vim.serviceContent.about.apiVersion
+      vim.serviceContent.sessionManager.Login(
+        :userName => options[:user],
+        :password => options[:password],
+      )
+    end
+  end
+
+  private
+
+  def rbvmomi_vim_connect_opts(options)
+    {
+      :ns       => "urn:vim25",
+      :host     => options[:host],
+      :ssl      => options[:ssl],
+      :insecure => options[:insecure],
+      :path     => "/sdk",
+      :port     => 443,
+      :rev      => "6.5",
+    }
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -29,6 +29,8 @@
     :update_driven_refresh: false
 :workers:
   :worker_base:
+    :ems_metrics_collector_worker:
+      :ems_metrics_collector_worker_vmware: {}
     :event_catcher:
       :event_catcher_vmware:
         :flooding_monitor_enabled: true
@@ -42,8 +44,6 @@
         :amqp_heartbeat: 30
         :amqp_recovery_attempts: 4
     :queue_worker_base:
-      :ems_metrics_collector_worker:
-        :ems_metrics_collector_worker_vmware: {}
       :ems_refresh_worker:
         :ems_refresh_worker_vmware: {}
         :ems_refresh_worker_vmware_cloud: {}


### PR DESCRIPTION
Depends on: https://github.com/ManageIQ/manageiq/pull/15979

This replaces the standard queueing of metrics collection going through the queue and instead just "pushes" metrics that have been captured and parsed to the metrics_processor_worker over the queue.