### PR TITLE
We need to reload Vm to get last_perf_capture_on

### DIFF
--- a/spec/models/manageiq/providers/vmware/infra_manager/metric_capture_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/metric_capture_spec.rb
@@ -96,7 +96,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::MetricsCapture do
 
           it "should have collected performances" do
             # Check Vm record was updated
-            expect(@vm.last_perf_capture_on.utc.iso8601).to eq("2011-08-12T21:33:00Z")
+            expect(@vm.reload.last_perf_capture_on.utc.iso8601).to eq("2011-08-12T21:33:00Z")
 
             # Check performances
             expect(Metric.count).to eq(180)


### PR DESCRIPTION
We need to reload Vm to get last_perf_capture_on, the new
postgre saving adapter is not modifying the passed Vm object,
since it's designed to work in batches.