### PR TITLE
Fix the parent collections for hardwares/disks

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/inventory_collections.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/inventory_collections.rb
@@ -41,5 +41,15 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::InventoryCollections
       attributes = {:model_class => ManageIQ::Providers::Vmware::InfraManager::HostEsx}
       super(attributes.merge(extra_attributes))
     end
+
+    def hardwares(extra_attributes = {})
+      attributes = {:parent_inventory_collections => [:vms_and_templates]}
+      super(attributes.merge(extra_attributes))
+    end
+
+    def disks(extra_attributes = {})
+      attributes = {:parent_inventory_collections => [:vms_and_templates]}
+      super(attributes.merge(extra_attributes))
+    end
   end
 end


### PR DESCRIPTION
VMware has the vms_and_templates inventory collection not vms +
miq_templates so we need to update the hardware and disks accordingly
otherwise we get the error:

```
[RuntimeError]: Can't find InventoryCollection vms from InventoryCollection:<Disk>
```