### PR TITLE
Allow type of controller to be passed in disk opts

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
@@ -120,8 +120,11 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure
         new_scsi_bus_number = available_scsi_buses.shift
         break if new_scsi_bus_number.nil? # No more scsi controllers can be added
 
+        # Use the controller type passed in if it is available
+        new_scsi_type = d[:new_controller_type]
+
         # Add a new controller with this reconfig task
-        add_scsi_controller(vim_obj, vmcs, hardware, new_scsi_bus_number, new_scsi_controller_key)
+        add_scsi_controller(vim_obj, vmcs, hardware, new_scsi_type, new_scsi_bus_number, new_scsi_controller_key)
 
         # Add all units on the new controller as available
         new_scsi_units = scsi_controller_units(new_scsi_controller_key)
@@ -145,8 +148,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure
     end
   end
 
-  def add_scsi_controller(vim_obj, vmcs, hardware, bus_number, dev_key)
-    device_type = get_new_scsi_controller_device_type(vim_obj, hardware)
+  def add_scsi_controller(vim_obj, vmcs, hardware, device_type, bus_number, dev_key)
+    device_type ||= get_new_scsi_controller_device_type(vim_obj, hardware)
     add_device_config_spec(vmcs, VirtualDeviceConfigSpecOperation::Add) do |vdcs|
       vdcs.device = VimHash.new(device_type) do |dev|
         dev.sharedBus = VimString.new('noSharing', 'VirtualSCSISharing')

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
@@ -300,7 +300,19 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
         allow(vim).to receive(:available_scsi_units).and_return([])
         allow(vim).to receive(:available_scsi_buses).and_return([0, 1, 2, 3])
 
-        expect(vm).to receive(:add_scsi_controller).with(vim, vmcs, hardware, 0, -99).once
+        expect(vm).to receive(:add_scsi_controller).with(vim, vmcs, hardware, nil, 0, -99).once
+        expect(vm).to receive(:add_disk_config_spec).with(vmcs, disk).once
+        vm.add_disks(vim, vmcs, hardware, [disk])
+      end
+
+      it 'with a defined new controller type' do
+        sas_controller = 'VirtualLsiLogicSASController'
+        disk[:new_controller_type] = sas_controller
+
+        allow(vim).to receive(:available_scsi_units).and_return([])
+        allow(vim).to receive(:available_scsi_buses).and_return([0, 1, 2, 3])
+
+        expect(vm).to receive(:add_scsi_controller).with(vim, vmcs, hardware, sas_controller, 0, -99).once
         expect(vm).to receive(:add_disk_config_spec).with(vmcs, disk).once
         vm.add_disks(vim, vmcs, hardware, [disk])
       end
@@ -350,7 +362,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
           disks[1].merge(:controller_key => -99,  :unit_number => 0)
         ]
 
-        expect(vm).to receive(:add_scsi_controller).with(vim, vmcs, hardware, 1, -99).once
+        expect(vm).to receive(:add_scsi_controller).with(vim, vmcs, hardware, nil, 1, -99).once
         expect(vm).to receive(:add_disk_config_spec).with(vmcs, expected_disks[0]).once
         expect(vm).to receive(:add_disk_config_spec).with(vmcs, expected_disks[1]).once
 
@@ -366,7 +378,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
           disks[1].merge(:controller_key => -99,  :unit_number => 0)
         ]
 
-        expect(vm).to receive(:add_scsi_controller).with(vim, vmcs, hardware, 2, -99).once
+        expect(vm).to receive(:add_scsi_controller).with(vim, vmcs, hardware, nil, 2, -99).once
         expect(vm).to receive(:add_disk_config_spec).with(vmcs, expected_disks[0]).once
         expect(vm).to receive(:add_disk_config_spec).with(vmcs, expected_disks[1]).once
 


### PR DESCRIPTION
When adding a new disk when a new controller is needed we currently try
to use the same type of controller that is already on the VM or we have
a default that we use.  If a user wants to specify specifically what
type of controller they want there is no way to do that.  This adds the
option to the disk options hash to have the new scsi controller type
explicitly defined by the user.

https://bugzilla.redhat.com/show_bug.cgi?id=1428284