### PR TITLE
Fix OrchestrationTemplate spec failures

### DIFF
--- a/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_stack_spec.rb
@@ -1,6 +1,6 @@
 describe ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack do
   let(:ems) { FactoryGirl.create(:ems_vmware_cloud) }
-  let(:template) { FactoryGirl.create(:orchestration_template_vmware_cloud_with_content) }
+  let(:template) { FactoryGirl.create(:orchestration_template_vmware_cloud_in_xml) }
   let(:orchestration_stack) do
     FactoryGirl.create(:orchestration_stack_vmware_cloud,
                        :ext_management_system => ems,


### PR DESCRIPTION
Use the OrchestrationTemplate from the vmware factory now that the one
we were using from manageiq is gone.