### PR TITLE
Login with console authentication if available

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -34,7 +34,7 @@ module ManageIQ::Providers
     end
 
     def remote_console_vmrc_acquire_ticket
-      vim = connect
+      vim = connect(:auth_type => :console)
       ticket = vim.acquireCloneTicket
 
       # The ticket received is valid for 30 seconds, but we can't disconnect the

--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -33,6 +33,14 @@ module ManageIQ::Providers
       @description ||= "VMware vCenter".freeze
     end
 
+    def supported_auth_types
+      %w(default console)
+    end
+
+    def supports_authentication?(authtype)
+      supported_auth_types.include?(authtype.to_s)
+    end
+
     def remote_console_vmrc_acquire_ticket
       vim = connect(:auth_type => :console)
       ticket = vim.acquireCloneTicket


### PR DESCRIPTION
Allow different credentials for connecting to a vmware console.
Passing :console will fallback to standard credentials if they are missing.