### PR TITLE
Properly update network hash when the first array element is nil

### DIFF
--- a/spec/models/manageiq/providers/vmware/infra_manager/provision/configuration/network_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision/configuration/network_spec.rb
@@ -1,0 +1,55 @@
+describe ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration::Network do
+  describe '#normalize_network_adapter_settings' do
+    let(:miq_provision) { FactoryGirl.build(:miq_provision_vmware, :options => options) }
+
+    shared_examples_for 'normalize_network_adapter_settings' do
+      it 'updates network options' do
+        miq_provision.normalize_network_adapter_settings
+
+        expect(miq_provision.options).to include(network_options)
+      end
+    end
+
+    context 'adds default adapter into networks hash' do
+      let(:options) { {:vlan => %w(network network), :mac_address => 'aa:bb:cc:dd:ee:ff'} }
+      let(:network_options)  { {:networks=>[{:network => 'network', :mac_address => 'aa:bb:cc:dd:ee:ff'}]} }
+
+      it_behaves_like 'normalize_network_adapter_settings'
+    end
+
+    context 'adds default adapter into networks hash' do
+      let(:options) { {:vlan => %w(dvs_network network)} }
+      let(:network_options)  { {:networks => [{:network => 'network', :is_dvs => true}]} }
+
+      it_behaves_like 'normalize_network_adapter_settings'
+    end
+
+    context 'adds default adapter into networks hash' do
+      let(:options) { {:vlan => %w(network network), :networks => []} }
+      let(:network_options)  { {:networks=>[{:network=>'network'}]} }
+
+      it_behaves_like 'normalize_network_adapter_settings'
+    end
+
+    context 'adds default adapter into networks hash' do
+      let(:options) { {:vlan => %w(network network), :networks => [nil]} }
+      let(:network_options)  { {:networks=>[{:network=>'network'}]} }
+
+      it_behaves_like 'normalize_network_adapter_settings'
+    end
+
+    context 'adds default adapter into networks hash' do
+      let(:options) { {:networks => [{:network => 'network'}]} }
+      let(:network_options) { {:vlan => %w(network network)} }
+
+      it_behaves_like 'normalize_network_adapter_settings'
+    end
+
+    context 'adds default adapter into networks hash' do
+      let(:options) { {:networks => [{:network => 'network', :is_dvs => true}]} }
+      let(:network_options) { {:vlan => %w(dvs_network network)} }
+
+      it_behaves_like 'normalize_network_adapter_settings'
+    end
+  end
+end


### PR DESCRIPTION
When calling `set_network_adapter(idx, config_hash)` from automate it is common to set additional adapters beyond what was selected from the provisioning dialogs.  

If a caller passes `set_network_adapter(1, <config_hash>)` the `:network` option hash will contain a `nil` in the first array element.  For example the previous call would create the following array: `options[:networks] = [nil, <config_hash>]`

The first array element is meant to be populated with the dialog network selection, but was instead causing an `undefined method '[]' for nil:NilClass)]` error.

With this change the code ensures that `options[:networks]` is an array and populates the first element with the dialog network settings if it is blank.

Refactor and add tests for normalize_network_adapter_settings

https://bugzilla.redhat.com/show_bug.cgi?id=1508069