### PR TITLE
Fix RefreshWorker before_exit arguments

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
@@ -12,7 +12,7 @@ class ManageIQ::Providers::Vmware::InfraManager::RefreshWorker::Runner < ManageI
     end
   end
 
-  def before_exit
+  def before_exit(_message, _exit_code)
     if Settings.prototype.ems_vmware.update_driven_refresh
       stop_inventory_collector(@collector)
 


### PR DESCRIPTION
The before_exit method takes two arguments, message and exit code.  The
method in the vmware refresh_worker didn't take any arguments and led to
this exception when shutting down:

```
MIQ(ManageIQ::Providers::Vmware::InfraManager::RefreshWorker::Runner) ID [25] PID [9366] GUID [4e2d7762-cbb8-486f-aeb7-fb441c08aaea] Error in before_exit: wrong number of arguments (given 2, expected 0)
```

This would only cause an issue if you were using the update driven
refresh (not default) and in that case the thread would be terminated
instead of cleanly shut down.