### PR TITLE
remove monkey patch for console refresh

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -75,11 +75,8 @@ module ManageIQ::Providers
     end
 
     def self.use_vim_broker?
-      return false unless MiqVimBrokerWorker.has_required_role?
-      cfg = ::Settings.webservices.use_vim_broker
-      return true if cfg == "force"
-      return true if cfg && Sys::Platform::OS == :unix
-      false
+      return false if defined?(Rails::Console) && !::Settings.development.use_vim_broker_in_console
+      MiqVimBrokerWorker.has_required_role?
     end
 
     delegate :use_vim_broker?, :to => :class

--- a/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
@@ -8,11 +8,8 @@ module ManageIQ::Providers
       include InfraManager::RefreshParser::Filter
 
       # Development helper method for setting up the selector specs for VC
-      def self.init_console(use_vim_broker = false)
+      def self.init_console(*_)
         return @initialized_console unless @initialized_console.nil?
-        provider = parent
-        provider.instance_variable_set(:@__use_vim_broker, use_vim_broker)
-        def provider.use_vim_broker?; @__use_vim_broker; end
         klass = use_vim_broker ? MiqVimBroker : MiqVimInventory
         klass.cacheScope = :cache_scope_ems_refresh
         klass.setSelector(parent::SelectorSpec::VIM_SELECTOR_SPEC)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,6 @@
 ---
+:development:
+  :use_vim_broker_in_console: false
 :ems:
   :ems_vmware:
     :blacklisted_event_names: []
@@ -48,4 +50,3 @@
         :ems_refresh_worker_vmware: {}
         :ems_refresh_worker_vmware_cloud: {}
         :ems_refresh_worker_vmware_cloud_network: {}
-


### PR DESCRIPTION
Please merge ~~at the same time as~~ before https://github.com/ManageIQ/manageiq/pull/16561

We currently monkey patch `use_vim_broker?` when in the console.

This fixes the method itself to detect the console and act accordingly

To enable the broker in the console, developers can add to `development.local.yml`:

```
:development:
  :use_vim_broker_in_console: true
```

This setting will get added to the core repository, but currently behaves correctly with no change over there (didn't want the dependency)

the logic is: "if we are in the console and either they didn't specify what to do, or they specified they didn't want to run the broker - then let's not run the broker"

@miq-bot assign @agrare 