### PR TITLE
remove monkey patch for console refresh pt2

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
@@ -10,7 +10,7 @@ module ManageIQ::Providers
       # Development helper method for setting up the selector specs for VC
       def self.init_console(*_)
         return @initialized_console unless @initialized_console.nil?
-        klass = use_vim_broker ? MiqVimBroker : MiqVimInventory
+        klass = ManageIQ::Providers::Vmware::InfraManager.use_vim_broker? ? MiqVimBroker : MiqVimInventory
         klass.cacheScope = :cache_scope_ems_refresh
         klass.setSelector(parent::SelectorSpec::VIM_SELECTOR_SPEC)
         @initialized_console = true

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -1076,4 +1076,12 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       }
     )
   end
+
+  context '.init_console' do
+    it "works" do
+      described_class.instance_variable_set(:@initialized_console, nil)
+      described_class.init_console
+      expect(described_class.instance_variable_get(:@initialized_console)).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
This adds a test for the console init code

This fixes an invalid variable referenced by the code introduced in #145 

- link https://github.com/ManageIQ/manageiq/pull/16561
@miq-bot assign agrare