### PR TITLE
enable broker in production, but not in dev

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,6 @@
 ---
 :development:
-  :use_vim_broker_in_console: false
+  :use_vim_broker_in_console: true
 :ems:
   :ems_vmware:
     :blacklisted_event_names: []

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,3 @@
+---
+:development:
+  :use_vim_broker_in_console: false


### PR DESCRIPTION
Followup on #145 We want the broker to be off by default in development.
It will be enabled in production environments

links
- https://github.com/ManageIQ/manageiq/pull/16561 miq change
- #145 original change
- #147 (fix)