### PR TITLE
add after block for spec contamination

### DIFF
--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -1083,5 +1083,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       described_class.init_console
       expect(described_class.instance_variable_get(:@initialized_console)).to be_truthy
     end
+
+    after { described_class.instance_variable_set(:@initialized_console, nil) }
   end
 end


### PR DESCRIPTION
Adding an `after(:each)` block to ensure that the test is not contaminating
the specs.

@miq-bot assign fryguy