### PR TITLE
Fail request when vm migration fails

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm.rb
@@ -26,6 +26,10 @@ class ManageIQ::Providers::Vmware::InfraManager::Vm < ManageIQ::Providers::Infra
     true
   end
 
+  def migration_status
+    'success'
+  end
+
   supports :snapshots
   supports :quick_stats
 end


### PR DESCRIPTION
When vm migration fails it is not reflected in migration request status.
We use custom attribute to track migration state when migration is done
(error or ok) we need to remove the attribute. For vmware we need to make
sure that we always return that it is done.

BugUrl:
https://bugzilla.redhat.com/1478518