### PR TITLE
Added supported_catalog_types

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -49,6 +49,10 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
     supported_auth_types.include?(authtype.to_s)
   end
 
+  def supported_catalog_types
+    %w(vmware)
+  end
+
   #
   # Operations
   #

--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -41,6 +41,10 @@ module ManageIQ::Providers
       supported_auth_types.include?(authtype.to_s)
     end
 
+    def supported_catalog_types
+      %w(vmware)
+    end
+
     def remote_console_vmrc_acquire_ticket
       vim = connect(:auth_type => :console)
       ticket = vim.acquireCloneTicket

--- a/spec/models/manageiq/providers/vmware/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager_spec.rb
@@ -97,4 +97,8 @@ describe ManageIQ::Providers::Vmware::CloudManager do
         MiqException::MiqInvalidCredentialsError, 'Login failed due to a bad username or password.')
     end
   end
+
+  it "#supported_catalog_types" do
+    expect(@ems.supported_catalog_types).to eq(%w(vmware))
+  end
 end

--- a/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
@@ -156,6 +156,13 @@ describe ManageIQ::Providers::Vmware::InfraManager do
     end
   end
 
+  context "catalog types" do
+    it "#supported_catalog_types" do
+      ems = FactoryGirl.create(:ems_vmware)
+      expect(ems.supported_catalog_types).to eq(%w(vmware))
+    end
+  end
+
   private
 
   def assert_event_catcher_restart_queued


### PR DESCRIPTION
For service catalog each provider needs to report the supported catalog types.

Needed for PR https://github.com/ManageIQ/manageiq/pull/16559