### PR TITLE
Route VMware vCD logs into its own file

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -1,2 +1,4 @@
-# GlobalVars:
-#   AllowedVariables:
+GlobalVars:
+  AllowedVariables:
+  # Loggers
+  - $vcloud_log

--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -60,24 +60,24 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
   def vm_start(vm, _options = {})
     vm.start
   rescue => err
-    _log.error "vm=[#{vm.name}, error: #{err}"
+    $vcloud_log.error("vm=[#{vm.name}, error: #{err}")
   end
 
   def vm_stop(vm, _options = {})
     vm.stop
   rescue => err
-    _log.error "vm=[#{vm.name}, error: #{err}"
+    $vcloud_log.error("vm=[#{vm.name}, error: #{err}")
   end
 
   def vm_suspend(vm, _options = {})
     vm.suspend
   rescue => err
-    _log.error "vm=[#{vm.name}], error: #{err}"
+    $vcloud_log.error("vm=[#{vm.name}], error: #{err}")
   end
 
   def vm_restart(vm, _options = {})
     vm.restart
   rescue => err
-    _log.error "vm=[#{vm.name}], error: #{err}"
+    $vcloud_log.error("vm=[#{vm.name}], error: #{err}")
   end
 end

--- a/app/models/manageiq/providers/vmware/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/event_catcher/stream.rb
@@ -41,7 +41,7 @@ class ManageIQ::Providers::Vmware::CloudManager::EventCatcher::Stream
   end
 
   def start
-    _log.debug("Opening amqp connection to #{@options}")
+    $vcloud_log.debug("Opening amqp connection to #{@options}")
     connection.start
     @channel = connection.create_channel
     initialize_queues(@channel)
@@ -76,7 +76,7 @@ class ManageIQ::Providers::Vmware::CloudManager::EventCatcher::Stream
       begin
         @queues[queue_name] = channel.queue(queue_name, :durable => true)
       rescue Bunny::AccessRefused => err
-        _log.warn("Could not start listening to queue '#{queue_name}' due to: #{err}")
+        $vcloud_log.warn("Could not start listening to queue '#{queue_name}' due to: #{err}")
       end
     end
   end
@@ -96,7 +96,7 @@ class ManageIQ::Providers::Vmware::CloudManager::EventCatcher::Stream
             end
           end
         rescue => e
-          _log.error("Exception receiving Rabbit (amqp)"\
+          $vcloud_log.error("Exception receiving Rabbit (amqp)"\
                      " event on #{queue_name} from #{@options[:hostname]}: #{e}")
         end
       end

--- a/app/models/manageiq/providers/vmware/cloud_manager/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/event_catcher_mixin.rb
@@ -45,15 +45,15 @@ module ManageIQ::Providers::Vmware::CloudManager::EventCatcherMixin
   def stop_event_monitor
     @event_monitor_handle.stop unless @event_monitor_handle.nil?
   rescue StandardException => err
-    _log.warn("Event Monitor Stop errored because [#{err.message}]")
-    _log.warn("Error details: [#{err.details}]")
-    _log.log_backtrace(err)
+    $vcloud_log.warn("Event Monitor Stop errored because [#{err.message}]")
+    $vcloud_log.warn("Error details: [#{err.details}]")
+    $vcloud_log.log_backtrace(err)
   ensure
     reset_event_monitor_handle
   end
 
   def queue_event(event)
-    _log.info "Caught event [#{event.type}]"
+    $vcloud_log.info("Caught event [#{event.type}]")
     event_hash = ManageIQ::Providers::Vmware::CloudManager::EventParser.event_to_hash(event, @cfg[:ems_id])
     EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
   end

--- a/app/models/manageiq/providers/vmware/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/orchestration_stack.rb
@@ -8,7 +8,7 @@ class ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack < ManageIQ::
       service.instantiate_template(create_options)
     end
   rescue => err
-    _log.error "stack=[#{stack_name}], error: #{err}"
+    $vcloud_log.error("stack=[#{stack_name}], error: #{err}")
     raise MiqException::MiqOrchestrationProvisionError, err.to_s, err.backtrace
   end
 
@@ -23,7 +23,7 @@ class ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack < ManageIQ::
       raw_stack.destroy
     end
   rescue => err
-    _log.error "stack=[#{name}], error: #{err}"
+    $vcloud_log.error("stack=[#{name}], error: #{err}")
     raise MiqException::MiqOrchestrationDeleteError, err.to_s, err.backtrace
   end
 
@@ -38,7 +38,7 @@ class ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack < ManageIQ::
   rescue MiqException::MiqOrchestrationStackNotExistError
     raise
   rescue => err
-    _log.error("stack=[#{name}], error: #{err}")
+    $vcloud_log.error("stack=[#{name}], error: #{err}")
     raise MiqException::MiqOrchestrationStatusError, err.to_s, err.backtrace
   end
 end

--- a/app/models/manageiq/providers/vmware/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/refresh_parser.rb
@@ -18,7 +18,7 @@ class ManageIQ::Providers::Vmware::CloudManager::RefreshParser < ManageIQ::Provi
   def ems_inv_to_hashes
     log_header = "MIQ(#{self.class.name}.#{__method__}) Collecting data for EMS name: [#{@ems.name}] id: [#{@ems.id}]"
 
-    $log.info("#{log_header}...")
+    $vcloud_log.info("#{log_header}...")
 
     get_ems
     get_orgs
@@ -28,7 +28,7 @@ class ManageIQ::Providers::Vmware::CloudManager::RefreshParser < ManageIQ::Provi
     get_vapp_templates
     get_images
 
-    $log.info("#{log_header}...Complete")
+    $vcloud_log.info("#{log_header}...Complete")
 
     @data
   end

--- a/app/models/manageiq/providers/vmware/manager_auth_mixin.rb
+++ b/app/models/manageiq/providers/vmware/manager_auth_mixin.rb
@@ -62,7 +62,7 @@ module ManageIQ::Providers::Vmware::ManagerAuthMixin
       yield
     rescue => err
       miq_exception = translate_exception(err)
-      _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
+      $vcloud_log.error("Error Class=#{err.class.name}, Message=#{err.message}")
       raise miq_exception
     end
 

--- a/app/models/manageiq/providers/vmware/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/network_manager/refresh_parser.rb
@@ -16,12 +16,12 @@ module ManageIQ::Providers
     def ems_inv_to_hashes
       log_header = "MIQ(#{self.class.name}.#{__method__}) Collecting data for EMS name: [#{@ems.name}] id: [#{@ems.id}]"
 
-      $log.info("#{log_header}...")
+      $vcloud_log.info("#{log_header}...")
 
       get_networks
       get_network_ports
 
-      $log.info("#{log_header}...Complete")
+      $vcloud_log.info("#{log_header}...Complete")
 
       @data
     end


### PR DESCRIPTION
With this commit we prevent a mess in evm.log which is caused by vmware cloud/network provider's logs. We start using the $vcloud_log logger for the latter.

@miq-bot add_label enhancement, gaprindashvili/yes, fine/yes
@miq-bot assign @blomquisg

Related issue: https://github.com/ManageIQ/manageiq/issues/16642
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1525201
Depends on: https://github.com/ManageIQ/manageiq/pull/16641 (merged)

/cc @gberginc 