### PR TITLE
[WIP] Add ActiveSupport::Notifications

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/metrics_capture.rb
@@ -1,6 +1,8 @@
 require "csv"
 
 class ManageIQ::Providers::Vmware::InfraManager::MetricsCapture < ManageIQ::Providers::BaseManager::MetricsCapture
+  CACHE_HIT = {:hit => true}.freeze
+  CACHE_MISS= {:hit => false}.freeze
   VIM_INTERVAL_NAME_BY_MIQ_INTERVAL_NAME = {'hourly' => 'Past Month'}
   MIQ_INTERVAL_NAME_BY_VIM_INTERVAL_NAME = VIM_INTERVAL_NAME_BY_MIQ_INTERVAL_NAME.invert
 
@@ -15,103 +17,122 @@ class ManageIQ::Providers::Vmware::InfraManager::MetricsCapture < ManageIQ::Prov
   def self.intervals(ems, vim_hist)
     phr = perf_history_results
     results = phr.fetch_path(:intervals, ems.id)
-    return results unless results.nil?
-
-    log_header = "EMS: [#{ems.hostname}]"
-    begin
-      results = vim_hist.intervals
-    rescue Handsoap::Fault, StandardError => err
-      _log.error("#{log_header} The following error occurred: [#{err}]")
-      raise
+    if results
+      ActiveSupport::Notifications.instrument("metrics_capture.vmware.intervals", CACHE_HIT)
+      return results
     end
 
-    _log.debug("#{log_header} Available sampling intervals: [#{results.length}]")
-    phr.store_path(:intervals, ems.id, results)
+    ActiveSupport::Notifications.instrument("metrics_capture.vmware.intervals", CACHE_MISS) do
+      log_header = "EMS: [#{ems.hostname}]"
+      begin
+          results = vim_hist.intervals
+      rescue Handsoap::Fault, StandardError => err
+        _log.error("#{log_header} The following error occurred: [#{err}]")
+        raise
+      end
+
+      _log.debug("#{log_header} Available sampling intervals: [#{results.length}]")
+      phr.store_path(:intervals, ems.id, results)
+    end
   end
 
   def self.realtime_interval(ems, vim_hist, mor)
     phr = perf_history_results
     results = phr.fetch_path(:realtime_interval, ems.id, mor)
-    return results unless results.nil?
-
-    log_header = "EMS: [#{ems.hostname}]"
-
-    begin
-      summary = vim_hist.queryProviderSummary(mor)
-    rescue Handsoap::Fault, StandardError => err
-      _log.error("#{log_header} The following error occurred: [#{err}]")
-      raise
+    if results
+      ActiveSupport::Notifications.instrument("metrics_capture.vmware.realtime_intervals", CACHE_HIT)
+      return results
     end
 
-    if summary.kind_of?(Hash) && summary['currentSupported'].to_s == "true"
-      interval = summary['refreshRate'].to_s
-      _log.debug("#{log_header} Found realtime interval: [#{interval}] for mor: [#{mor}]")
-    else
-      interval = nil
-      _log.debug("#{log_header} Realtime is not supported for mor: [#{mor}], summary: [#{summary.inspect}]")
-    end
+    ActiveSupport::Notifications.instrument("metrics_capture.vmware.realtime_interval", CACHE_MISS) do
+      log_header = "EMS: [#{ems.hostname}]"
+      begin
+        summary = vim_hist.queryProviderSummary(mor)
+      rescue Handsoap::Fault, StandardError => err
+        _log.error("#{log_header} The following error occurred: [#{err}]")
+        raise
+      end
 
-    phr.store_path(:realtime_interval, ems.id, mor, interval)
+      if summary.kind_of?(Hash) && summary['currentSupported'].to_s == "true"
+        interval = summary['refreshRate'].to_s
+        _log.debug("#{log_header} Found realtime interval: [#{interval}] for mor: [#{mor}]")
+      else
+        interval = nil
+        _log.debug("#{log_header} Realtime is not supported for mor: [#{mor}], summary: [#{summary.inspect}]")
+      end
+
+      phr.store_path(:realtime_interval, ems.id, mor, interval)
+    end
   end
 
   def self.hourly_interval(ems, vim_hist)
     phr = perf_history_results
     results = phr.fetch_path(:hourly_interval, ems.id)
-    return results unless results.nil?
+    if results
+      ActiveSupport::Notifications.instrument("metrics_capture.vmware.hourly_intervals", CACHE_HIT)
+      return results
+    end
 
     log_header = "EMS: [#{ems.hostname}]"
 
-    # Using the reporting value of 'hourly', get the vim interval 'Past Month'
-    #   and look for that in the intervals data
-    vim_interval = VIM_INTERVAL_NAME_BY_MIQ_INTERVAL_NAME['hourly']
+    ActiveSupport::Notifications.instrument("metrics_capture.vmware.hourly_interval", CACHE_MISS) do
+      # Using the reporting value of 'hourly', get the vim interval 'Past Month'
+      #   and look for that in the intervals data
+      vim_interval = VIM_INTERVAL_NAME_BY_MIQ_INTERVAL_NAME['hourly']
 
-    intervals = self.intervals(ems, vim_hist)
+      intervals = self.intervals(ems, vim_hist)
 
-    interval = intervals.detect { |i| i['name'].to_s.downcase == vim_interval.downcase }
-    if interval.nil?
-      _log.debug("#{log_header} Unable to find hourly interval [#{vim_interval}] in intervals: #{intervals.collect { |i| i['name'] }.inspect}")
-    else
-      interval = interval['samplingPeriod'].to_s
-      _log.debug("#{log_header} Found hourly interval: [#{interval}] for vim interval: [#{vim_interval}]")
+      interval = intervals.detect { |i| i['name'].to_s.downcase == vim_interval.downcase }
+      if interval.nil?
+        _log.debug("#{log_header} Unable to find hourly interval [#{vim_interval}] in intervals: #{intervals.collect { |i| i['name'] }.inspect}")
+      else
+        interval = interval['samplingPeriod'].to_s
+        _log.debug("#{log_header} Found hourly interval: [#{interval}] for vim interval: [#{vim_interval}]")
+      end
+
+      phr.store_path(:hourly_interval, ems.id, interval)
     end
-
-    phr.store_path(:hourly_interval, ems.id, interval)
   end
 
   def self.counter_info_by_counter_id(ems, vim_hist)
     phr = perf_history_results
     results = phr.fetch_path(:counter_info_by_id, ems.id)
-    return results unless results.nil?
-
-    log_header = "EMS: [#{ems.hostname}]"
-    begin
-      counter_info = vim_hist.id2Counter
-    rescue Handsoap::Fault, StandardError => err
-      _log.error("#{log_header} The following error occurred: [#{err}]")
-      raise
+    if results
+      ActiveSupport::Notifications.instrument("metrics_capture.vmware.counter_info_by_counter_id", CACHE_HIT)
+      return results
     end
 
-    # TODO: Move this to some generic parsing class, such as
-    # ManageIQ::Providers::Vmware::InfraManager::RefreshParser
-    results = counter_info.each_with_object({}) do |(id, c), h|
-      group    = c.fetch_path('groupInfo', 'key').to_s.downcase
-      name     = c.fetch_path('nameInfo', 'key').to_s.downcase
-      rollup   = c['rollupType'].to_s.downcase
-      stats    = c['statsType'].to_s.downcase
-      unit_key = c.fetch_path('unitInfo', 'key').to_s.downcase
+    ActiveSupport::Notifications.instrument("metrics_capture.vmware.counter_info_by_counter_id", CACHE_MISS) do
+      log_header = "EMS: [#{ems.hostname}]"
+      begin
+        counter_info = vim_hist.id2Counter
+      rescue Handsoap::Fault, StandardError => err
+        _log.error("#{log_header} The following error occurred: [#{err}]")
+        raise
+      end
 
-      h[id] = {
-        :counter_key => "#{group}_#{name}_#{stats}_#{rollup}",
-        :group       => group,
-        :name        => name,
-        :rollup      => rollup,
-        :stats       => stats,
-        :unit_key    => unit_key,
-        :precision   => (unit_key == 'percent') ? 0.01 : 1,
-      }
+      # TODO: Move this to some generic parsing class, such as
+      # ManageIQ::Providers::Vmware::InfraManager::RefreshParser
+      results = counter_info.each_with_object({}) do |(id, c), h|
+        group    = c.fetch_path('groupInfo', 'key').to_s.downcase
+        name     = c.fetch_path('nameInfo', 'key').to_s.downcase
+        rollup   = c['rollupType'].to_s.downcase
+        stats    = c['statsType'].to_s.downcase
+        unit_key = c.fetch_path('unitInfo', 'key').to_s.downcase
+
+        h[id] = {
+          :counter_key => "#{group}_#{name}_#{stats}_#{rollup}",
+          :group       => group,
+          :name        => name,
+          :rollup      => rollup,
+          :stats       => stats,
+          :unit_key    => unit_key,
+          :precision   => (unit_key == 'percent') ? 0.01 : 1,
+        }
+      end
+
+      phr.store_path(:counter_info_by_id, ems.id, results)
     end
-
-    phr.store_path(:counter_info_by_id, ems.id, results)
   end
 
   def self.avail_metrics_for_entity(ems, vim_hist, mor, interval, interval_name)
@@ -119,42 +140,47 @@ class ManageIQ::Providers::Vmware::InfraManager::MetricsCapture < ManageIQ::Prov
 
     phr = perf_history_results
     results = phr.fetch_path(:avail_metrics_for_entity, ems.id, mor, interval)
-    return results unless results.nil?
-
-    log_header = "EMS: [#{ems.hostname}]"
-    begin
-      avail_metrics = vim_hist.availMetricsForEntity(mor, :intervalId => interval)
-    rescue Handsoap::Fault, StandardError => err
-      _log.error("#{log_header} The following error occurred: [#{err}]")
-      raise
+    if results
+      ActiveSupport::Notifications.instrument("metrics_capture.vmware.avail_metrics_for_entity", CACHE_HIT)
+      return results
     end
 
-    info = counter_info_by_counter_id(ems, vim_hist)
+    ActiveSupport::Notifications.instrument("metrics_capture.vmware.avail_metrics_for_entity", CACHE_MISS) do
+      log_header = "EMS: [#{ems.hostname}]"
+      begin
+        avail_metrics = vim_hist.availMetricsForEntity(mor, :intervalId => interval)
+      rescue Handsoap::Fault, StandardError => err
+        _log.error("#{log_header} The following error occurred: [#{err}]")
+        raise
+      end
 
-    results = avail_metrics.to_miq_a.each_with_object({}) do |metric, h|
-      counter = info[metric["counterId"]]
-      next if counter.nil?
+      info = counter_info_by_counter_id(ems, vim_hist)
 
-      # Filter the metrics for only the cols we will use
-      next unless Metric::Capture.capture_cols.include?(counter[:counter_key].to_sym)
+      results = avail_metrics.to_miq_a.each_with_object({}) do |metric, h|
+        counter = info[metric["counterId"]]
+        next if counter.nil?
 
-      vim_key      = metric["counterId"].to_s
-      instance     = metric["instance"].to_s
-      full_vim_key = "#{vim_key}_#{instance}"
+        # Filter the metrics for only the cols we will use
+        next unless Metric::Capture.capture_cols.include?(counter[:counter_key].to_sym)
 
-      h[full_vim_key] = {
-        :counter_key           => counter[:counter_key],
-        :rollup                => counter[:rollup],
-        :precision             => counter[:precision],
-        :unit_key              => counter[:unit_key],
-        :vim_key               => vim_key,
-        :instance              => instance,
-        :capture_interval      => interval.to_s,
-        :capture_interval_name => interval_name.to_s
-      }
+        vim_key      = metric["counterId"].to_s
+        instance     = metric["instance"].to_s
+        full_vim_key = "#{vim_key}_#{instance}"
+
+        h[full_vim_key] = {
+          :counter_key           => counter[:counter_key],
+          :rollup                => counter[:rollup],
+          :precision             => counter[:precision],
+          :unit_key              => counter[:unit_key],
+          :vim_key               => vim_key,
+          :instance              => instance,
+          :capture_interval      => interval.to_s,
+          :capture_interval_name => interval_name.to_s
+        }
+      end
+
+      phr.store_path(:avail_metrics_for_entity, ems.id, mor, interval, results)
     end
-
-    phr.store_path(:avail_metrics_for_entity, ems.id, mor, interval, results)
   end
 
   #


### PR DESCRIPTION
add visibility to vmware interactions

Decided to just emit cache hit and misses. This avoids allocating
extra objects per emit.

@miq-bot assign agrare label wip