### PR TITLE
Move MiqEmsRefreshCoreWorker to VMware repo

### DIFF
--- a/app/models/miq_ems_refresh_core_worker.rb
+++ b/app/models/miq_ems_refresh_core_worker.rb
@@ -1,0 +1,23 @@
+class MiqEmsRefreshCoreWorker < MiqWorker
+  require_nested :Runner
+
+  include PerEmsWorkerMixin
+
+  self.required_roles = ["ems_inventory"]
+
+  def self.has_required_role?
+    return false if Settings.prototype.ems_vmware.update_driven_refresh
+    super
+  end
+
+  def self.ems_class
+    ManageIQ::Providers::Vmware::InfraManager
+  end
+
+  def friendly_name
+    @friendly_name ||= begin
+      ems = ext_management_system
+      ems.nil? ? queue_name.titleize : "Core Refresh Worker for Provider: #{ems.name}"
+    end
+  end
+end

--- a/app/models/miq_ems_refresh_core_worker/runner.rb
+++ b/app/models/miq_ems_refresh_core_worker/runner.rb
@@ -1,0 +1,175 @@
+require 'thread'
+
+class MiqEmsRefreshCoreWorker::Runner < MiqWorker::Runner
+  OPTIONS_PARSER_SETTINGS = MiqWorker::Runner::OPTIONS_PARSER_SETTINGS + [
+    [:ems_id, 'EMS Instance ID', String],
+  ]
+
+  def after_initialize
+    @ems = ExtManagementSystem.find(@cfg[:ems_id])
+    do_exit("Unable to find instance for EMS id [#{@cfg[:ems_id]}].", 1) if @ems.nil?
+    do_exit("EMS id [#{@cfg[:ems_id]}] failed authentication check.", 1) unless @ems.authentication_check.first
+
+    # Global Work Queue
+    @queue = Queue.new
+  end
+
+  def do_before_work_loop
+    @tid = start_updater
+  end
+
+  def log_prefix
+    @log_prefix ||= "EMS [#{@ems.hostname}] as [#{@ems.authentication_userid}]"
+  end
+
+  def before_exit(message, _exit_code)
+    @exit_requested = true
+
+    unless @vim.nil?
+      safe_log("#{message} Stopping thread.")
+      @vim.stop rescue nil
+    end
+
+    unless @tid.nil?
+      safe_log("#{message} Waiting for thread to stop.")
+      @tid.join(worker_settings[:thread_shutdown_timeout] || 10.seconds) rescue nil
+    end
+
+    if @queue
+      safe_log("#{message} Draining queue.")
+      drain_queue rescue nil
+    end
+  end
+
+  def start_updater
+    @log_prefix = nil
+    @exit_requested = false
+
+    begin
+      _log.info("#{log_prefix} Validating Connection/Credentials")
+      @ems.verify_credentials
+    rescue => err
+      _log.warn("#{log_prefix} #{err.message}")
+      return nil
+    end
+
+    _log.info("#{log_prefix} Starting thread")
+    require 'VMwareWebService/MiqVimCoreUpdater'
+
+    tid = Thread.new do
+      begin
+        @vim = MiqVimCoreUpdater.new(@ems.hostname, @ems.authentication_userid, @ems.authentication_password)
+        @vim.monitorUpdates { |*u| @queue.enq(u) }
+      rescue Handsoap::Fault => err
+        if  @exit_requested && (err.code == "ServerFaultCode") && (err.reason == "The task was canceled by a user.")
+          _log.info("#{log_prefix} Thread terminated normally")
+        else
+          _log.error("#{log_prefix} Thread aborted because [#{err.message}]")
+          _log.error("#{log_prefix} Error details: [#{err.details}]")
+          _log.log_backtrace(err)
+        end
+        Thread.exit
+      rescue => err
+        _log.error("#{log_prefix} Thread aborted because [#{err.message}]")
+        _log.log_backtrace(err) unless err.kind_of?(Errno::ECONNREFUSED)
+        Thread.exit
+      end
+    end
+
+    _log.info("#{log_prefix} Started thread")
+
+    tid
+  end
+
+  def do_work
+    if @tid.nil? || !@tid.alive?
+      _log.info("#{log_prefix} Thread gone. Restarting...")
+      @tid = start_updater
+    end
+
+    process_updates
+  end
+
+  def drain_queue
+    process_update(@queue.deq) while @queue.length > 0
+  end
+
+  def process_updates
+    while @queue.length > 0
+      heartbeat
+      process_update(@queue.deq)
+      Thread.pass
+    end
+  end
+
+  def process_update(update)
+    mor, props = update
+    return if mor.vimType != "VirtualMachine" # Ignore non-VMs for now
+    return if props.nil?                      # Ignore deleted/created VMs for now
+
+    # HACK: MiqVimCoreUpdater needs to have this property added in order to
+    #       deal with issues where VC4 will give periodic full updates unless
+    #       there is a property that returns frequently.  We deal with this by
+    #       ignoring it.  See FB15506.
+    props.delete("runtime.memoryOverhead")
+    return if props.empty?
+
+    vm = VmOrTemplate.find_by(:ems_ref => mor, :ems_id => @ems.id)
+    return if vm.nil?
+
+    new_attrs = {}
+    props.each do |k, v|
+      case k
+      when "runtime.powerState"
+        new_attrs[:raw_power_state] = v
+      when "config.template"
+        new_attrs[:template] = (v.to_s.downcase == "true")
+      when "guest.net"
+        process_vm_guest_net(vm, v)
+      end
+    end
+
+    # Don't set the raw_power_state directly for templates or templates-to-be
+    new_attrs.delete(:raw_power_state) if new_attrs[:template] || (new_attrs[:template].nil? && vm.template?)
+
+    unless new_attrs.blank?
+      _log.info("#{log_prefix} Updating Vm id: [#{vm.id}], name: [#{vm.name}] with the following attributes: #{new_attrs.inspect}")
+      vm.update_attributes(new_attrs)
+    end
+  end
+
+  # NOTE: At this time, this method only handles updates to existing nics and
+  #   will not create or delete nics.
+  def process_vm_guest_net(vm, inv)
+    inv = inv.to_miq_a
+    return if inv.none? { |i| i['connected'] }
+
+    MiqPreloader.preload(vm, :hardware => {:nics => :network})
+
+    nics = vm.try(:hardware).try(:nics).to_miq_a.select(&:network)
+    return if nics.blank?
+    nics_by_uid = nics.index_by(&:address)
+
+    new_attrs_by_nic_uid = {}
+
+    inv.each do |i|
+      uid = i['macAddress']
+      next unless nics_by_uid.key?(uid)
+
+      ipv4, ipv6 = i['ipAddress'].to_miq_a.compact.collect(&:to_s).partition(&:ipv4?)
+      ipv4 = ipv4.first
+      ipv6 = ipv6.first
+      next if ipv4.nil? && ipv6.nil?
+
+      new_attrs_by_nic_uid[uid] = {
+        :ipaddress   => ipv4,
+        :ipv6address => ipv6
+      }
+    end
+
+    unless new_attrs_by_nic_uid.empty?
+      _log.info("#{log_prefix} Updating Vm id: [#{vm.id}], name: [#{vm.name}] with the following network attributes: #{new_attrs_by_nic_uid.inspect}")
+      new_attrs_by_nic_uid.each { |uid, new_attrs| nics_by_uid[uid].network.update_attributes(new_attrs) }
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -31,6 +31,10 @@
     :update_driven_refresh: false
 :workers:
   :worker_base:
+    :ems_refresh_core_worker:
+      :poll: 1.seconds
+      :nice_delta: 1
+      :thread_shutdown_timeout: 10.seconds
     :event_catcher:
       :event_catcher_vmware:
         :flooding_monitor_enabled: true

--- a/spec/factories/miq_ems_refresh_core_worker.rb
+++ b/spec/factories/miq_ems_refresh_core_worker.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :miq_ems_refresh_core_worker do
+    pid { Process.pid }
+  end
+end

--- a/spec/models/miq_ems_refresh_core_worker/runner_spec.rb
+++ b/spec/models/miq_ems_refresh_core_worker/runner_spec.rb
@@ -1,0 +1,210 @@
+describe MiqEmsRefreshCoreWorker::Runner do
+  before(:each) do
+    _guid, server, zone = EvmSpecHelper.create_guid_miq_server_zone
+    @ems = FactoryGirl.create(:ems_vmware_with_authentication, :zone => zone)
+
+    # General stubbing for testing any worker (methods called during initialize)
+    @worker_record = FactoryGirl.create(:miq_ems_refresh_core_worker, :queue_name => "ems_#{@ems.id}", :miq_server => server)
+    allow_any_instance_of(described_class).to receive(:sync_config)
+    allow_any_instance_of(described_class).to receive(:set_connection_pool_size)
+    allow_any_instance_of(described_class).to receive(:heartbeat_using_drb?).and_return(false)
+    allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive(:authentication_check).and_return([true, ""])
+
+    @worker = MiqEmsRefreshCoreWorker::Runner.new(:guid => @worker_record.guid, :ems_id => @ems.id)
+  end
+
+  context "#process_update" do
+    context "against a ManageIQ::Providers::Vmware::InfraManager::Vm" do
+      before(:each) do
+        Timecop.travel(1.day.ago) do
+          @vm = FactoryGirl.create(:vm_with_ref, :ext_management_system => @ems, :raw_power_state => "unknown")
+        end
+      end
+
+      it "with unknown properties" do
+        should_not_have_changed @vm, "unknown.property" => "unknown_value"
+      end
+
+      context "with runtime.memoryOverhead HACK" do
+        it "alone" do
+          should_not_have_changed @vm, "runtime.memoryOverhead" => 123456
+        end
+
+        it "and other valid properties" do
+          should_have_changed @vm, {"runtime.memoryOverhead" => 123456, "runtime.powerState" => "poweredOn"}, "on", false
+        end
+      end
+
+      it "with a deleted Vm" do
+        should_not_have_changed @vm, nil
+      end
+
+      it "with non-VM updates" do
+        expect do
+          @worker.process_update([VimString.new("host-123", "HostSystem", "ManagedObjectReference"), {"unknown.property" => "unknown_value"}])
+        end.not_to raise_error
+      end
+
+      context "with runtime.powerState and/or config.template set to" do
+        it "poweredOff, true" do
+          should_have_changed @vm, {"runtime.powerState" => "poweredOff", "config.template" => "true"}, "never", true
+        end
+
+        it "poweredOff, false" do
+          should_have_changed @vm, {"runtime.powerState" => "poweredOff", "config.template" => "false"}, "off", false
+        end
+
+        it "poweredOn, false" do
+          should_have_changed @vm, {"runtime.powerState" => "poweredOn", "config.template" => "false"}, "on", false
+        end
+
+        it "poweredOn, unset" do
+          should_have_changed @vm, {"runtime.powerState" => "poweredOn"}, "on", false
+        end
+
+        it "poweredOff, unset" do
+          should_have_changed @vm, {"runtime.powerState" => "poweredOff"}, "off", false
+        end
+
+        it "suspended, unset" do
+          should_have_changed @vm, {"runtime.powerState" => "suspended"}, "suspended", false
+        end
+
+        it "unset, true" do
+          should_have_changed @vm, {"config.template" => "true"}, "never", true
+        end
+
+        it "unset, false" do
+          should_not_have_changed @vm, "config.template" => "false"
+        end
+      end
+
+      context "with guest.net" do
+        it "and no networks persisted" do
+          props = {"guest.net" => [{"ipAddress" => ["1.2.3.4", "::1:2:3:4"], 'macAddress' => "00:00:00:00:00:00"}]}
+          @worker.process_update([@vm.ems_ref_obj, props])
+          expect(@vm.ipaddresses).to be_empty
+        end
+
+        context "and networks already persisted" do
+          before(:each) do
+            @hw = FactoryGirl.create(:hardware, :vm_or_template => @vm)
+            @nics = (1..2).collect { FactoryGirl.create(:guest_device_nic_with_network, :hardware => @hw) }.sort_by(&:address)
+            @expected_addresses = @nics.collect { |n| [n.network.ipaddress, n.network.ipv6address] }
+          end
+
+          it "and no ip changes" do
+            props = {"guest.net" => [{'macAddress' => @nics[0].address, 'connected' => true}]}
+            @worker.process_update([@vm.ems_ref_obj, props])
+            should_not_have_network_changes
+
+            props = {}
+            @worker.process_update([@vm.ems_ref_obj, props])
+            should_not_have_network_changes
+          end
+
+          it "and ip changes but nic not connected" do
+            props = {"guest.net" => [{"ipAddress" => ["1.2.3.4", "::1:2:3:4"], 'macAddress' => @nics[0].address, 'connected' => false}]}
+            @worker.process_update([@vm.ems_ref_obj, props])
+            should_not_have_network_changes
+          end
+
+          it "and ip changes for unknown nic" do
+            props = {"guest.net" => [{"ipAddress" => ["1.2.3.4", "::1:2:3:4"], 'macAddress' => '00:00:00:00:00:00', 'connected' => false}]}
+            @worker.process_update([@vm.ems_ref_obj, props])
+            should_not_have_network_changes
+          end
+
+          it "and ip changes but nic doesn't have a network" do
+            @nics[0].update_attribute(:network, nil)
+            @expected_addresses[0] = [nil, nil]
+
+            props = {"guest.net" => [{"ipAddress" => ["1.2.3.4", "::1:2:3:4"], 'macAddress' => @nics[0].address, 'connected' => true}]}
+            @worker.process_update([@vm.ems_ref_obj, props])
+            should_not_have_network_changes
+          end
+
+          it "and ip changes" do
+            props = {"guest.net" => [{"ipAddress" => ["1.2.3.4", "::1:2:3:4"], 'macAddress' => @nics[0].address, 'connected' => true}]}
+            @worker.process_update([@vm.ems_ref_obj, props])
+
+            expected = [["1.2.3.4", "::1:2:3:4"], @expected_addresses[1]]
+            should_have_network_changes(expected)
+          end
+        end
+
+        def should_not_have_network_changes
+          expect(@hw.nics.reload.sort_by(&:address).collect { |n| [n.network.try(:ipaddress), n.network.try(:ipv6address)] }).to eq(@expected_addresses)
+        end
+
+        def should_have_network_changes(expected)
+          expect(@hw.nics.reload.sort_by(&:address).collect { |n| [n.network.try(:ipaddress), n.network.try(:ipv6address)] }).to eq(expected)
+        end
+      end
+    end
+
+    context "against a ManageIQ::Providers::Vmware::InfraManager::Template" do
+      before(:each) do
+        Timecop.travel(1.day.ago) do
+          @template = FactoryGirl.create(:template_vmware_with_ref, :ext_management_system => @ems)
+        end
+      end
+
+      context "with runtime.powerState and/or config.template set to" do
+        it "poweredOff, false" do
+          should_have_changed @template, {"runtime.powerState" => "poweredOff", "config.template" => "false"}, "off", false
+        end
+
+        it "poweredOn, false" do
+          should_have_changed @template, {"runtime.powerState" => "poweredOn", "config.template" => "false"}, "on", false
+        end
+
+        it "poweredOff, true" do
+          should_not_have_changed @template, "runtime.powerState" => "poweredOff"
+        end
+
+        it "poweredOff, set" do
+          should_not_have_changed @template, "runtime.powerState" => "poweredOff"
+        end
+
+        it "unset, true" do
+          should_not_have_changed @template, "config.template" => "true"
+        end
+
+        it "unset, false" do
+          should_have_changed @template, {"config.template" => "false"}, "unknown", false
+        end
+      end
+    end
+
+    def should_have_changed(obj, props, expected_state, expected_template)
+      expected_time = nil
+      template_changes = (obj.template != expected_template)
+      Timecop.freeze(Time.now) do
+        @worker.process_update([obj.ems_ref_obj, props])
+        expected_time = Time.now.utc
+      end
+      expect do
+        if template_changes
+          obj = obj.corresponding_model.find(obj.id)
+        else
+          obj.reload
+        end
+      end.not_to raise_error
+      expect(obj.template).to eq(expected_template)
+      expect(obj.state).to eq(expected_state)
+      expect(obj.state_changed_on).to be_within(0.00001).of expected_time
+    end
+
+    def should_not_have_changed(obj, props)
+      expected_template = obj.template
+      expected_state    = obj.state
+      expected_time     = obj.state_changed_on
+      @worker.process_update([obj.ems_ref_obj, props])
+      expect { obj.reload }.not_to raise_error
+      expect(obj.template).to eq(expected_template)
+      expect(obj.state).to eq(expected_state)
+      expect(obj.state_changed_on).to be_within(0.00001).of expected_time
+    end
+  end
+end

--- a/spec/models/miq_ems_refresh_core_worker_spec.rb
+++ b/spec/models/miq_ems_refresh_core_worker_spec.rb
@@ -1,0 +1,17 @@
+describe MiqEmsRefreshCoreWorker do
+  context "update_driven_refresh" do
+    before do
+      stub_settings_merge(
+        :prototype => {
+          :ems_vmware => {
+            :update_driven_refresh => true
+          }
+        }
+      )
+    end
+
+    it ".has_required_role?" do
+      expect(described_class.has_required_role?).to be_falsy
+    end
+  end
+end


### PR DESCRIPTION
This moves the MiqEmsRefreshCoreWorker to the Vmware repository

https://github.com/ManageIQ/manageiq/pull/16687 removes the worker from the main repo