### PR TITLE
Reconfigure VM: Add / Remove Network Adapters

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm.rb
@@ -10,6 +10,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Vm < ManageIQ::Providers::Infra
   end
 
   supports :reconfigure_disks
+  supports :reconfigure_network_adapters
 
   supports :reconfigure_disksize
 

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
@@ -332,8 +332,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure
 
   def remove_network_adapter_config_spec(vim_obj, vmcs, options)
     raise "remove_network_adapter_config_spec: network_adapter name is required." unless options[:network][:name]
-    networkName = options[:network][:name]
-    controller_key, key, unitNumber = vim_obj.send(:getDeviceKeysByNetwork, networkName)
+    networkAdapterLabel = options[:network][:name]
+    controller_key, key, unitNumber = vim_obj.send(:getDeviceKeysByLabel, networkAdapterLabel)
     add_device_config_spec(vmcs, VirtualDeviceConfigSpecOperation::Remove) do |vdcs|
       vdcs.device = VimHash.new("VirtualEthernetCard") do |dev|
         dev.key = key


### PR DESCRIPTION
This PR adds support for reconfiguring network adapters for VMware VMs.

This PR is part of a set of PRs:
https://github.com/ManageIQ/vmware_web_service/pull/25 (merged by @agrare)
https://github.com/ManageIQ/manageiq-providers-vmware/pull/163
https://github.com/ManageIQ/manageiq/pull/16700
https://github.com/ManageIQ/manageiq-ui-classic/pull/3121

More info: https://github.com/ManageIQ/manageiq-ui-classic/issues/3119
  