### PR TITLE
Update vmware_web_service for smartstate fix

### DIFF
--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*"]
 
   s.add_dependency("fog-vcloud-director", ["~> 0.1.8"])
-  s.add_dependency "vmware_web_service",      "~>0.2.3"
+  s.add_dependency "vmware_web_service",      "~>0.2.4"
   s.add_dependency "rbvmomi",                 "~>1.11.3"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
Update vmware_web_service gem to pull in an ffi-vix_disk_lib patch to
fix a segfault when using the 6.5 version of vix disk lib.

~~Depends https://github.com/ManageIQ/vmware_web_service/pull/28~~

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1527658