### PR TITLE
Fix broken specs from EMS hostname validation

### DIFF
--- a/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
@@ -50,11 +50,6 @@ describe ManageIQ::Providers::Vmware::InfraManager do
       expect(@ems.remote_console_vmrc_support_known?).to be_truthy
     end
 
-    it "false for missing hostname" do
-      @ems.update_attributes(:hostname => nil, :api_version => "5.0", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
-      expect(@ems.remote_console_vmrc_support_known?).not_to be_truthy
-    end
-
     it "false for blank hostname" do
       @ems.update_attributes(:hostname => "", :api_version => "5.0", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
       expect(@ems.remote_console_vmrc_support_known?).not_to be_truthy
@@ -135,7 +130,7 @@ describe ManageIQ::Providers::Vmware::InfraManager do
     end
 
     it "will restart EventCatcher when hostname changes" do
-      @ems.update_attributes(:hostname => "something else")
+      @ems.update_attributes(:hostname => "something-else")
       assert_event_catcher_restart_queued
     end
 


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/16714 Caused the specs which
use invalid hostnames to fail in different ways then expected.  The test
checking for nil ems hostname is now invalid because that isn't possible
and the other changed the hostname to something with a space which can
be replaced with a '-'