### PR TITLE
Migrate model display names from locale/en.yml to plugin

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -80,4 +80,8 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
   rescue => err
     $vcloud_log.error("vm=[#{vm.name}], error: #{err}")
   end
+
+  def self.display_name(number = 1)
+    n_('Cloud Provider (VMware vCloud)', 'Cloud Providers (VMware vCloud)', number)
+  end
 end

--- a/app/models/manageiq/providers/vmware/cloud_manager/orchestration_template.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/orchestration_template.rb
@@ -100,4 +100,8 @@ class ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate < Orchest
   rescue REXML::ParseException => err
     err.message
   end
+
+  def self.display_name(number = 1)
+    n_('vApp Template', 'vApp Templates', number)
+  end
 end

--- a/app/models/manageiq/providers/vmware/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm.rb
@@ -18,4 +18,8 @@ class ManageIQ::Providers::Vmware::CloudManager::Vm < ManageIQ::Providers::Cloud
     # https://github.com/xlab-si/fog-vcloud-director/blob/master/lib/fog/vcloud_director/parsers/compute/vm.rb#L70
     POWER_STATES[raw_power_state.to_s] || "terminated"
   end
+
+  def self.display_name(number = 1)
+    n_('Instance (VMware vCloud)', 'Instances (VMware vCloud)', number)
+  end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -540,4 +540,8 @@ module ManageIQ::Providers
       EmsRefresh.save_storage_files_inventory(datastore, hashes)
     end
   end
+
+  def self.display_name(number = 1)
+    n_('Infrastructure Provider (VMware)', 'Infrastructure Providers (VMware)', number)
+  end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/host.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/host.rb
@@ -70,4 +70,8 @@ class ManageIQ::Providers::Vmware::InfraManager::Host < ::Host
   end
 
   supports :quick_stats
+
+  def self.display_name(number = 1)
+    n_('Host (Vmware)', 'Hosts (Vmware)', number)
+  end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/host_esx.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/host_esx.rb
@@ -173,4 +173,8 @@ class ManageIQ::Providers::Vmware::InfraManager::HostEsx < ManageIQ::Providers::
     ash = vim_advanced_settings
     AdvancedSetting.add_elements(self, ash) unless ash.nil?
   end
+
+  def self.display_name(number = 1)
+    n_('Host (Vmware)', 'Hosts (Vmware)', number)
+  end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm.rb
@@ -28,4 +28,8 @@ class ManageIQ::Providers::Vmware::InfraManager::Vm < ManageIQ::Providers::Infra
 
   supports :snapshots
   supports :quick_stats
+
+  def self.display_name(number = 1)
+    n_('Virtual Machine (VMware)', 'Virtual Machines (VMware)', number)
+  end
 end


### PR DESCRIPTION
This is a continuation of the work started in https://github.com/ManageIQ/manageiq/pull/16596 where we want to migrate display model names from locale/en.yml into particular models, where we'll use standard gettext. Main goal here is to make this one aspect of our application pluggable.

Core PR: https://github.com/ManageIQ/manageiq/pull/16836