### PR TITLE
Add VM uuid as the vm_uid_ems to the event payload

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/event_parser.rb
@@ -84,6 +84,8 @@ module ManageIQ::Providers::Vmware::InfraManager::EventParser
       result[:vm_name] = URI.decode(vm_name) unless vm_name.nil?
       vm_location = vm_data['path']
       result[:vm_location] = vm_location unless vm_location.nil?
+      vm_uid_ems = vm_data['uuid']
+      result[:vm_uid_ems] = vm_uid_ems unless vm_uid_ems.nil?
     end
 
     # Get the dest vm information

--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("fog-vcloud-director", ["~> 0.1.8"])
   s.add_dependency "fog-core",                "~>1.40"
-  s.add_dependency "vmware_web_service",      "~>0.2.4"
+  s.add_dependency "vmware_web_service",      "~>0.2.6"
   s.add_dependency "rbvmomi",                 "~>1.11.3"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"

--- a/spec/models/manageiq/providers/vmware/infra_manager/event_data/task_event.yaml
+++ b/spec/models/manageiq/providers/vmware/infra_manager/event_data/task_event.yaml
@@ -1,0 +1,148 @@
+--- !ruby/hash-with-ivars:VimHash
+elements:
+  key: !ruby/string:VimString
+    str: '2109001'
+    xsiType: :SOAP::SOAPInt
+    vimType: 
+  chainId: !ruby/string:VimString
+    str: '2109001'
+    xsiType: :SOAP::SOAPInt
+    vimType: 
+  createdTime: !ruby/string:VimString
+    str: '2018-01-29T20:22:55.002915Z'
+    xsiType: :SOAP::SOAPDateTime
+    vimType: 
+  userName: !ruby/string:VimString
+    str: RH CORP\agrare
+    xsiType: :SOAP::SOAPString
+    vimType: 
+  datacenter: !ruby/hash-with-ivars:VimHash
+    elements:
+      name: !ruby/string:VimString
+        str: dev-vc65-DC
+        xsiType: :SOAP::SOAPString
+        vimType: 
+      datacenter: !ruby/string:VimString
+        str: datacenter-2
+        xsiType: :ManagedObjectReference
+        vimType: :Datacenter
+    ivars:
+      :@xsiType: :DatacenterEventArgument
+      :@vimType: 
+  computeResource: !ruby/hash-with-ivars:VimHash
+    elements:
+      name: !ruby/string:VimString
+        str: dev-vc65-cluster
+        xsiType: :SOAP::SOAPString
+        vimType: 
+      computeResource: !ruby/string:VimString
+        str: domain-c7
+        xsiType: :ManagedObjectReference
+        vimType: :ClusterComputeResource
+    ivars:
+      :@xsiType: :ComputeResourceEventArgument
+      :@vimType: 
+  host: !ruby/hash-with-ivars:VimHash
+    elements:
+      name: !ruby/string:VimString
+        str: dell-r430-16.example.com
+        xsiType: :SOAP::SOAPString
+        vimType: 
+      host: !ruby/string:VimString
+        str: host-261
+        xsiType: :ManagedObjectReference
+        vimType: :HostSystem
+    ivars:
+      :@xsiType: :HostEventArgument
+      :@vimType: 
+  vm: !ruby/hash-with-ivars:VimHash
+    elements:
+      name: !ruby/string:VimString
+        str: ag_test_2
+        xsiType: :SOAP::SOAPString
+        vimType: 
+      vm: !ruby/string:VimString
+        str: vm-854
+        xsiType: :ManagedObjectReference
+        vimType: :VirtualMachine
+      path: !ruby/string:VimString
+        str: "[NFS Share] ag_test_2/ag_test_2.vmx"
+        xsiType: :xsd:string
+        vimType: 
+      uuid: !ruby/string:VimString
+        str: 423cb279-6a04-5b89-4a4a-a77e56e71173
+        xsiType: :xsd:string
+        vimType: 
+    ivars:
+      :@xsiType: :VmEventArgument
+      :@vimType: 
+  fullFormattedMessage: !ruby/string:VimString
+    str: 'Task: Delete virtual machine'
+    xsiType: :SOAP::SOAPString
+    vimType: 
+  changeTag: !ruby/string:VimString
+    str: ''
+    xsiType: :SOAP::SOAPString
+    vimType: 
+  info: !ruby/hash-with-ivars:VimHash
+    elements:
+      key: !ruby/string:VimString
+        str: task-14604
+        xsiType: :SOAP::SOAPString
+        vimType: 
+      task: !ruby/string:VimString
+        str: task-14604
+        xsiType: :ManagedObjectReference
+        vimType: :Task
+      name: !ruby/string:VimString
+        str: Destroy_Task
+        xsiType: :SOAP::SOAPString
+        vimType: 
+      descriptionId: !ruby/string:VimString
+        str: VirtualMachine.destroy
+        xsiType: :SOAP::SOAPString
+        vimType: 
+      entity: !ruby/string:VimString
+        str: vm-854
+        xsiType: :ManagedObjectReference
+        vimType: :VirtualMachine
+      entityName: !ruby/string:VimString
+        str: ag_test_2
+        xsiType: :SOAP::SOAPString
+        vimType: 
+      state: !ruby/string:VimString
+        str: queued
+        xsiType: :SOAP::SOAPString
+        vimType: 
+      cancelled: !ruby/string:VimString
+        str: 'false'
+        xsiType: :SOAP::SOAPBoolean
+        vimType: 
+      cancelable: !ruby/string:VimString
+        str: 'true'
+        xsiType: :SOAP::SOAPBoolean
+        vimType: 
+      reason: !ruby/hash-with-ivars:VimHash
+        elements:
+          userName: !ruby/string:VimString
+            str: RH CORP\agrare
+            xsiType: :SOAP::SOAPString
+            vimType: 
+        ivars:
+          :@xsiType: :TaskReasonUser
+          :@vimType: 
+      queueTime: !ruby/string:VimString
+        str: '2018-01-29T20:22:55.002675Z'
+        xsiType: :SOAP::SOAPDateTime
+        vimType: 
+      eventChainId: !ruby/string:VimString
+        str: '0'
+        xsiType: :SOAP::SOAPInt
+        vimType: 
+    ivars:
+      :@xsiType: :TaskInfo
+      :@vimType: 
+  eventType: TaskEvent
+ivars:
+  :@xsiType: :TaskEvent
+  :@vimType: 

--- a/spec/models/manageiq/providers/vmware/infra_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/event_parser_spec.rb
@@ -73,5 +73,15 @@ describe ManageIQ::Providers::Vmware::InfraManager::EventParser do
         expect(data[:host_ems_ref]).to be_instance_of String
       end
     end
+
+    context "with a TaskEvent" do
+      let(:event) { YAML.load_file(File.join(EPV_DATA_DIR, 'task_event.yaml')) }
+
+      it "sets the vm_uid_ems" do
+        expect(described_class.event_to_hash(event, 12_345)).to have_attributes(
+          :vm_uid_ems => event["vm"]["uuid"]
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Add the UUID for the VM to the event payload so that it can be used to
find disconnected VMs when linking events.

Depends:
- [x] https://github.com/ManageIQ/vmware_web_service/pull/32

https://bugzilla.redhat.com/show_bug.cgi?id=1538996