### PR TITLE
[WIP] Add EMS Operations Worker

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -10,6 +10,8 @@ module ManageIQ::Providers
     require_nested :Host
     require_nested :HostEsx
     require_nested :Inventory
+    require_nested :Operations
+    require_nested :OperationsWorker
     require_nested :Provision
     require_nested :ProvisionViaPxe
     require_nested :ProvisionWorkflow

--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -11,6 +11,7 @@ module ManageIQ::Providers
     require_nested :HostEsx
     require_nested :Inventory
     require_nested :Operations
+    require_nested :OperationsClient
     require_nested :OperationsWorker
     require_nested :Provision
     require_nested :ProvisionViaPxe
@@ -167,11 +168,13 @@ module ManageIQ::Providers
     end
 
     def vm_start(vm, options = {})
-      invoke_vim_ws(:start, vm, options[:user_event])
+      task_ref = operations_client.post("/vm/#{vm.ems_ref}/start")
+      wait_for_task(task_ref)
     end
 
     def vm_stop(vm, options = {})
-      invoke_vim_ws(:stop, vm, options[:user_event])
+      task_ref = operations_client.post("/vm/#{vm.ems_ref}/stop")
+      wait_for_task(task_ref)
     end
 
     def vm_poweroff(vm, options = {})
@@ -179,31 +182,33 @@ module ManageIQ::Providers
     end
 
     def vm_suspend(vm, options = {})
-      invoke_vim_ws(:suspend, vm, options[:user_event])
+      task_ref = operations_client.post("/vm/#{vm.ems_ref}/suspend")
+      wait_for_task(task_ref)
     end
 
     def vm_shutdown_guest(vm, options = {})
-      invoke_vim_ws(:shutdownGuest, vm, options[:user_event])
+      operations_client.post("/vm/#{vm.ems_ref}/shutdown")
     end
 
     def vm_reboot_guest(vm, options = {})
-      invoke_vim_ws(:rebootGuest, vm, options[:user_event])
+      operations_client.post("/vm/#{vm.ems_ref}/reboot")
     end
 
     def vm_reset(vm, options = {})
-      invoke_vim_ws(:reset, vm, options[:user_event])
+      task_ref = operations_client.post("/vm/#{vm.ems_ref}/reset")
+      wait_for_task(task_ref)
     end
 
     def vm_standby_guest(vm, options = {})
-      invoke_vim_ws(:standbyGuest, vm, options[:user_event])
+      operations_client.post("/vm/#{vm.ems_ref}/standby")
     end
 
     def vm_unregister(vm, options = {})
-      invoke_vim_ws(:unregister, vm, options[:user_event])
+      operations_client.post("/vm/#{vm.ems_ref}/unregister")
     end
 
     def vm_mark_as_template(vm, options = {})
-      invoke_vim_ws(:markAsTemplate, vm, options[:user_event])
+      operations_client.post("/vm/#{vm.ems_ref}/mark-as-template")
     end
 
     def vm_mark_as_vm(vm, options = {})
@@ -211,7 +216,7 @@ module ManageIQ::Providers
         :host     => nil,
       }
       options = defaults.merge(options)
-      invoke_vim_ws(:markAsVm, vm, options[:user_event], options[:pool], options[:host])
+      operations_client.post("/vm/#{vm.ems_ref}/mark-as-vm", options)
     end
 
     def vm_migrate(vm, options = {})
@@ -461,6 +466,25 @@ module ManageIQ::Providers
       end
 
       result
+    end
+
+    def operations_client(auth_type = :default)
+      @operations_client ||= {}
+      @operations_client[auth_type] ||= ManageIQ::Providers::Vmware::InfraManager::OperationsClient.new(self, address, *auth_user_pwd(auth_type))
+    end
+
+    def wait_for_task(task_ref)
+      loop do
+        task_props = YAML.safe_load(operations_client.get("/task/#{task_ref}"))
+        case task_props["info.state"]
+        when "success"
+          return task_props["info.result"]
+        when "error"
+          return task_props["info.error"]
+        else
+          sleep 1
+        end
+      end
     end
 
     def vm_log_user_event(vm, event_message)

--- a/app/models/manageiq/providers/vmware/infra_manager/operations.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/operations.rb
@@ -1,4 +1,40 @@
 require "sinatra/base"
 
 class ManageIQ::Providers::Vmware::InfraManager::Operations < Sinatra::Base
+  require_nested :Connection
+
+  def initialize
+    super
+
+    @connections      = Concurrent::Map.new
+    @connection_class = self.class::Connection
+  end
+
+  private
+
+  attr_reader :connections, :connection_class
+
+  def with_provider_connection
+    raise "Invalid connection parameters" unless validate_connection_params
+
+    connections.compute_if_absent(connection_key) { connection_class.new(*connection_params) }.with { |conn| yield conn }
+  end
+
+  def connection_param_keys
+    %i(server username password)
+  end
+
+  def connection_params
+    params.values_at(*connection_param_keys)
+  end
+
+  def connection_key
+    server, username, _ = connection_params
+    "#{server}__#{username}"
+  end
+
+  def validate_connection_params
+    server, user, password = connection_params
+    server && user && password
+  end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/operations.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/operations.rb
@@ -1,0 +1,4 @@
+require "sinatra/base"
+
+class ManageIQ::Providers::Vmware::InfraManager::Operations < Sinatra::Base
+end

--- a/app/models/manageiq/providers/vmware/infra_manager/operations.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/operations.rb
@@ -3,11 +3,17 @@ require "sinatra/base"
 class ManageIQ::Providers::Vmware::InfraManager::Operations < Sinatra::Base
   require_nested :Connection
 
+  disable :traps
+
   def initialize
     super
 
     @connections      = Concurrent::Map.new
     @connection_class = self.class::Connection
+  end
+
+  def shutdown
+    connections.each_value(&:close)
   end
 
   private

--- a/app/models/manageiq/providers/vmware/infra_manager/operations.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/operations.rb
@@ -1,5 +1,10 @@
 require "sinatra/base"
 
+# Beat rails autoload to ResourcePool
+RbVmomi
+RbVmomi::VIM
+RbVmomi::VIM::ResourcePool
+
 class ManageIQ::Providers::Vmware::InfraManager::Operations < Sinatra::Base
   require_nested :Connection
 
@@ -14,6 +19,123 @@ class ManageIQ::Providers::Vmware::InfraManager::Operations < Sinatra::Base
 
   def shutdown
     connections.each_value(&:close)
+  end
+
+  get "/vm/:ref" do
+    with_provider_connection do |vim|
+      vm       = RbVmomi::VIM.VirtualMachine(vim, ref)
+      path_set = params[:prop_set] || %w(name)
+
+      YAML.dump(vm.collect!(*path_set))
+    end
+  end
+
+  post "/vm/:ref/start" do
+    host_ref = params["host"]
+
+    with_provider_connection do |vim|
+      vm   = RbVmomi::VIM.VirtualMachine(vim, ref)
+      host = RbVmomi::VIM.HostSystem(vim, host_ref) if host_ref
+
+      task = vm.PowerOnVM_Task(:host => host)
+      task._ref
+    end
+  end
+
+  post "/vm/:ref/stop" do
+    with_provider_connection do |vim|
+      vm = RbVmomi::VIM.VirtualMachine(vim, ref)
+
+      task = vm.PowerOffVM_Task
+      task._ref
+    end
+  end
+
+  post "/vm/:ref/suspend" do
+    with_provider_connection do |vim|
+      vm = RbVmomi::VIM.VirtualMachine(vim, ref)
+
+      task = vm.SuspendVM_Task
+      task._ref
+    end
+  end
+
+  post "/vm/:ref/shutdown" do
+    with_provider_connection do |vim|
+      vm = RbVmomi::VIM.VirtualMachine(vim, ref)
+      vm.ShutdownGuest
+    end
+  end
+
+  post "/vm/:ref/reboot" do
+    with_provider_connection do |vim|
+      vm = RbVmomi::VIM.VirtualMachine(vim, ref)
+      vm.RebootGuest
+    end
+  end
+
+  post "/vm/:ref/reset" do
+    with_provider_connection do |vim|
+      vm = RbVmomi::VIM.VirtualMachine(vim, ref)
+
+      task = vm.ResetVM_Task
+      task._ref
+    end
+  end
+
+  post "/vm/:ref/standby" do
+    with_provider_connection do |vim|
+      vm = RbVmomi::VIM.VirtualMachine(vim, ref)
+      vm.StandbyGuest
+    end
+  end
+
+  post "/vm/:ref/unregister" do
+    with_provider_connection do |vim|
+      vm = RbVmomi::VIM.VirtualMachine(vim, ref)
+      vm.UnregisterVM
+    end
+  end
+
+  post "/vm/:ref/mark-as-template" do
+    with_provider_connection do |vim|
+      vm = RbVmomi::VIM.VirtualMachine(vim, ref)
+      vm.MarkAsTemplate
+    end
+  end
+
+  post "/vm/:ref/mark-as-vm" do
+    pool_ref, host_ref = params.values_at("pool", "host")
+
+    with_provider_connection do |vim|
+      vm   = RbVmomi::VIM.VirtualMachine(vim, ref)
+      pool = RbVmomi::VIM.ResourcePool(vim, pool_ref) if pool_ref
+      host = RbVmomi::VIM.HostSystem(vim, host_ref)   if host_ref
+
+      vm.MarkAsVirtualMachine(:pool => pool, :host => host)
+    end
+  end
+
+  post "/vm/:ref/clone" do
+    folder_ref, name, spec = params.values_at("folder", "name", "spec")
+
+    with_provider_connection do |vim|
+      vm     = RbVmomi::VIM.VirtualMachine(vim, ref)
+      folder = RbVmomi::VIM.Folder(vim, folder_ref) if folder_ref
+      spec   = YAML.safe_load(spec)
+
+      task = vm.CloneVM_Task(:folder => folder, :name => name, :spec => spec)
+      task._ref
+    end
+  end
+
+  get "/task/:ref" do
+    path_set = params[:prop_set] || %w(info.state info.error info.result)
+
+    with_provider_connection do |vim|
+      task = RbVmomi::VIM.Task(vim, ref)
+      YAML.dump(task.collect!(*path_set))
+    end
   end
 
   private
@@ -32,6 +154,10 @@ class ManageIQ::Providers::Vmware::InfraManager::Operations < Sinatra::Base
 
   def connection_params
     params.values_at(*connection_param_keys)
+  end
+
+  def ref
+    params[:ref]
   end
 
   def connection_key

--- a/app/models/manageiq/providers/vmware/infra_manager/operations/connection.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/operations/connection.rb
@@ -1,0 +1,53 @@
+require "rbvmomi/vim"
+
+class ManageIQ::Providers::Vmware::InfraManager::Operations::Connection
+  def initialize(server, username, password)
+    @server     = server
+    @username   = username
+    @password   = password
+    @lock       = Mutex.new
+    @connection = nil
+  end
+
+  def with
+    lock.synchronize { yield connection }
+  end
+
+  def close
+    lock.synchronize { disconnect }
+  end
+
+  private
+
+  attr_reader :server, :username, :password, :lock
+
+  def connection
+    @connection ||= connect
+  end
+
+  def disconnect
+    unless @connection.nil?
+      @connection.close
+      @connection = nil
+    end
+  end
+
+  def connect
+    RbVmomi::VIM.new(connect_opts).tap do |vim|
+      vim.rev = vim.serviceContent.about.apiVersion
+      vim.serviceContent.sessionManager.Login(:userName => username, :password => password)
+    end
+  end
+
+  def connect_opts
+    {
+      :ns       => "urn:vim25",
+      :host     => server,
+      :ssl      => true,
+      :insecure => true,
+      :path     => "/sdk",
+      :port     => 443,
+      :rev      => "6.5",
+    }
+  end
+end

--- a/app/models/manageiq/providers/vmware/infra_manager/operations_client.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/operations_client.rb
@@ -1,0 +1,37 @@
+class ManageIQ::Providers::Vmware::InfraManager::OperationsClient
+  def initialize(ems, server, username, password)
+    @ems            = ems
+    @connect_params = {:server => server, :username => username, :password => password}
+  end
+
+  def get(path, args = {})
+    url = "#{operations_worker_uri}#{path}"
+    headers = {
+      :params => connect_params,
+      :args   => args,
+    }
+
+    response = RestClient.get(url, headers)
+    response.body
+  end
+
+  def post(path, args = {})
+    url = "#{operations_worker_uri}#{path}"
+    payload = connect_params.merge(args)
+
+    response = RestClient.post(url, payload)
+    response.body
+  end
+
+  private
+
+  attr_reader :ems, :connect_params
+
+  def operations_worker_uri
+    @operations_worker_uri ||= operations_worker_klass.uri(ems)
+  end
+
+  def operations_worker_klass
+    @operations_worker_klass ||= ems.class::OperationsWorker
+  end
+end

--- a/app/models/manageiq/providers/vmware/infra_manager/operations_worker.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/operations_worker.rb
@@ -3,7 +3,7 @@ class ManageIQ::Providers::Vmware::InfraManager::OperationsWorker < MiqWorker
 
   include PerEmsWorkerMixin
 
-  self.required_roles = ["ems_metrics_collector", "ems_operations"]
+  self.required_roles = %w(ems_metrics_collector ems_operations)
 
   def friendly_name
     @friendly_name ||= begin
@@ -18,5 +18,10 @@ class ManageIQ::Providers::Vmware::InfraManager::OperationsWorker < MiqWorker
 
   def self.ems_class
     parent
+  end
+
+  def self.uri(ems)
+    worker = find_by_ems(ems).find_by(MiqWorker::CONDITION_CURRENT)
+    worker.try(:uri)
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/operations_worker.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/operations_worker.rb
@@ -1,0 +1,22 @@
+class ManageIQ::Providers::Vmware::InfraManager::OperationsWorker < MiqWorker
+  require_nested :Runner
+
+  include PerEmsWorkerMixin
+
+  self.required_roles = ["ems_metrics_collector", "ems_operations"]
+
+  def friendly_name
+    @friendly_name ||= begin
+      ems = ext_management_system
+      if ems.nil?
+        queue_name.titleize
+      else
+        _("EMS Operations Worker for Provider: %{name}") % {:name => ems.name}
+      end
+    end
+  end
+
+  def self.ems_class
+    parent
+  end
+end

--- a/app/models/manageiq/providers/vmware/infra_manager/operations_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/operations_worker/runner.rb
@@ -1,0 +1,8 @@
+class ManageIQ::Providers::Vmware::InfraManager::OperationsWorker::Runner < ::MiqWorker::Runner
+  OPTIONS_PARSER_SETTINGS = ::MiqWorker::Runner::OPTIONS_PARSER_SETTINGS + [
+    [:ems_id, 'EMS Instance ID', String],
+  ]
+
+  def do_work
+  end
+end

--- a/app/models/manageiq/providers/vmware/infra_manager/operations_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/operations_worker/runner.rb
@@ -60,7 +60,7 @@ class ManageIQ::Providers::Vmware::InfraManager::OperationsWorker::Runner < ::Mi
   end
 
   def rest_server(started_event)
-    operations_klass.run! { started_event.set }
+    operations_class.run!(:port => rest_server_port) { started_event.set }
     rest_server_instance.shutdown
   rescue => err
     _log.warn("Exception in Operations REST server: #{err}")
@@ -71,6 +71,16 @@ class ManageIQ::Providers::Vmware::InfraManager::OperationsWorker::Runner < ::Mi
 
   def update_worker_uri(uri)
     @worker.update_attributes(:uri => uri)
+  end
+
+  def rest_server_port
+    return ENV['PORT'] if ENV['PORT'].present?
+
+    # Get the ems_id without the region factor
+    short_ems_id = ApplicationRecord.split_id(ems.id).last
+
+    base_port_number = ENV['BASE_PORT'] || 6_000
+    base_port_number + short_ems_id
   end
 
   def rest_server_uri

--- a/app/models/manageiq/providers/vmware/infra_manager/operations_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/operations_worker/runner.rb
@@ -3,6 +3,83 @@ class ManageIQ::Providers::Vmware::InfraManager::OperationsWorker::Runner < ::Mi
     [:ems_id, 'EMS Instance ID', String],
   ]
 
+  def after_initialize
+    @ems = ExtManagementSystem.find(@cfg[:ems_id])
+    do_exit("Unable to find instance for EMS ID [#{@cfg[:ems_id]}].", 1) if @ems.nil?
+    do_exit("EMS ID [#{@cfg[:ems_id]}] failed authentication check.", 1) unless @ems.authentication_check.first
+
+    @operations_class = @ems.class::Operations
+  end
+
+  def do_before_work_loop
+    start_rest_server
+  end
+
   def do_work
+    return if rest_server_thread_alive?
+
+    _log.warn("REST server not running, restarting...")
+    start_rest_server
+    _log.info("Restarted REST server thread")
+  end
+
+  def before_exit(_message, _exit_code)
+    stop_rest_server_thread
+
+    unless rest_server_thread.nil?
+      rest_server_thread.join(10) rescue nil
+    end
+  end
+
+  private
+
+  attr_reader :ems, :operations_class, :rest_server_thread
+
+  def start_rest_server
+    thread_started = Concurrent::Event.new
+
+    _log.info("Starting Operations REST server...")
+
+    @rest_server_thread = Thread.new { rest_server(thread_started) }
+    thread_started.wait
+
+    if rest_server_thread.alive?
+      update_worker_uri(rest_server_uri)
+      _log.info("Starting Operations REST server...Complete")
+    else
+      _log.warn("Starting Operations REST server...Failed")
+    end
+  end
+
+  def stop_rest_server_thread
+    operations_class.quit!
+  end
+
+  def rest_server_thread_alive?
+    rest_server_thread.try(:alive?)
+  end
+
+  def rest_server(started_event)
+    operations_klass.run! { started_event.set }
+    rest_server_instance.shutdown
+  rescue => err
+    _log.warn("Exception in Operations REST server: #{err}")
+    _log.log_backtrace(err)
+  ensure
+    started_event.set
+  end
+
+  def update_worker_uri(uri)
+    @worker.update_attributes(:uri => uri)
+  end
+
+  def rest_server_uri
+    "#{operations_class.bind}:#{operations_class.port}"
+  end
+
+  def rest_server_instance
+    # HACK: can't find another way to get at the sinatra instance to
+    # gracefully shutdown connections
+    operations_class.prototype.instance_variable_get(:@instance)
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -43,6 +43,7 @@
         :amqp_port: 5672
         :amqp_heartbeat: 30
         :amqp_recovery_attempts: 4
+    :operations_worker_vmware: {}
     :queue_worker_base:
       :ems_metrics_collector_worker:
         :ems_metrics_collector_worker_vmware: {}

--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency "fog-core",                "~>1.40"
   s.add_dependency "vmware_web_service",      "~>0.2.6"
   s.add_dependency "rbvmomi",                 "~>1.11.3"
+  s.add_dependency "sinatra",                 "~>2.0.1"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
This adds a REST Operations Worker using Sinatra to perform API operations (e.g. vm.start, vm.stop) and a simple Operations Client.

EMS Operations are currently handled by the MiqVimBrokerWorker which does the connection brokering and actually invokes the API using handsoap.

This uses Concurrent::Map + Mutex to achieve the connection brokering and uses `RbVmomi` for the API calls.

TODO:

- [ ] Not all API calls are converted, want to get some feedback on the direction before converting all of them

- [x] Set the sinatra port to something other than 4567, this can be done with an ENV var which should work for containers not sure if we can also use this on an appliance

- [ ] The OperationsClient is really basic and could be enhanced to be more like the manageiq-api-client