### PR TITLE
Support create snapshot for VM

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -84,4 +84,16 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
   def self.display_name(number = 1)
     n_('Cloud Provider (VMware vCloud)', 'Cloud Providers (VMware vCloud)', number)
   end
+
+  def vm_create_snapshot(vm, options = {})
+    defaults = {
+      :memory  => false,
+      :quiesce => false
+    }
+    options = defaults.merge(options)
+    with_provider_connection do |service|
+      response = service.post_create_snapshot(vm.ems_ref, options)
+      service.process_task(response.body)
+    end
+  end
 end

--- a/app/models/manageiq/providers/vmware/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm.rb
@@ -1,6 +1,8 @@
 class ManageIQ::Providers::Vmware::CloudManager::Vm < ManageIQ::Providers::CloudManager::Vm
   include_concern 'Operations'
 
+  supports :snapshots
+
   def provider_object(connection = nil)
     connection ||= ext_management_system.connect
     connection.vms.get_single_vm(uid_ems)

--- a/spec/models/manageiq/providers/vmware/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager_spec.rb
@@ -101,4 +101,25 @@ describe ManageIQ::Providers::Vmware::CloudManager do
   it "#supported_catalog_types" do
     expect(@ems.supported_catalog_types).to eq(%w(vmware))
   end
+
+  describe 'snapshot operations' do
+    before(:each) do
+      expect(@ems).to receive(:with_provider_connection).and_yield(connection)
+    end
+
+    let(:vm) { FactoryGirl.create(:vm_vmware, :ext_management_system => @ems) }
+    let(:response) { double("response", :body => nil) }
+
+    context ".vm_create_snapshot" do
+      let(:snapshot_options) { { :name => 'name', :memory => false } }
+      let(:connection) { double("connection", :post_create_snapshot => "post_create_snapshot") }
+
+      it 'creates a snapshot' do
+        expect(connection).to receive(:post_create_snapshot).and_return(response)
+        expect(connection).to receive(:process_task).and_return(true)
+
+        @ems.vm_create_snapshot(vm, snapshot_options)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add `vm_create_snapshot` method that calls vCloud API
to create snapshot for VM.