### PR TITLE
Support delete snapshot for VM

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -109,4 +109,11 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
       service.process_task(response.body)
     end
   end
+
+  def vm_remove_all_snapshots(vm, _options = {})
+    with_provider_connection do |service|
+      response = service.post_remove_all_snapshots(vm.ems_ref)
+      service.process_task(response.body)
+    end
+  end
 end

--- a/app/models/manageiq/providers/vmware/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm.rb
@@ -2,6 +2,8 @@ class ManageIQ::Providers::Vmware::CloudManager::Vm < ManageIQ::Providers::Cloud
   include_concern 'Operations'
 
   supports :snapshots
+  supports :remove_all_snapshots
+  supports_not :remove_snapshot
 
   def provider_object(connection = nil)
     connection ||= ext_management_system.connect

--- a/spec/factories/vm.rb
+++ b/spec/factories/vm.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :vm_vcloud, :class => "ManageIQ::Providers::Vmware::CloudManager::Vm", :parent => :vm_cloud do
+    location        { |x| "[storage] #{x.name}/#{x.name}.vmx" }
+    vendor          "vmware"
+    raw_power_state "poweredOn"
+  end
+end

--- a/spec/models/manageiq/providers/vmware/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager_spec.rb
@@ -104,15 +104,15 @@ describe ManageIQ::Providers::Vmware::CloudManager do
 
   describe 'snapshot operations' do
     before(:each) do
-      expect(@ems).to receive(:with_provider_connection).and_yield(connection)
+      allow(@ems).to receive(:with_provider_connection).and_yield(connection)
     end
 
-    let(:vm) { FactoryGirl.create(:vm_vmware, :ext_management_system => @ems) }
+    let(:vm) { FactoryGirl.create(:vm_vcloud, :ext_management_system => @ems) }
     let(:response) { double("response", :body => nil) }
+    let(:connection) { double('connection') }
 
     context ".vm_create_snapshot" do
       let(:snapshot_options) { { :name => 'name', :memory => false } }
-      let(:connection) { double("connection", :post_create_snapshot => "post_create_snapshot") }
 
       it 'creates a snapshot' do
         expect(connection).to receive(:post_create_snapshot).and_return(response)
@@ -123,13 +123,28 @@ describe ManageIQ::Providers::Vmware::CloudManager do
     end
 
     context ".vm_revert_to_snapshot" do
-      let(:connection) { double('connection') }
-
       it 'reverts a vm to snapshot' do
         expect(connection).to receive(:post_revert_snapshot).and_return(response)
         expect(connection).to receive(:process_task).and_return(true)
 
         @ems.vm_revert_to_snapshot(vm)
+      end
+    end
+
+    context ".vm_remove_snapshot" do
+      it 'removes all snapshots' do
+        expect(connection).to receive(:post_remove_all_snapshots).and_return(response)
+        expect(connection).to receive(:process_task).and_return(true)
+
+        @ems.vm_remove_all_snapshots(vm)
+      end
+
+      it 'supports remove all snapshots' do
+        expect(vm.supports_remove_all_snapshots?).to be_truthy
+      end
+
+      it 'supports remove snapshot' do
+        expect(vm.supports_remove_snapshot?).to be_falsey
       end
     end
   end


### PR DESCRIPTION
Add `vm_remove_snapshot` and `vm_remove_all_snapshots`
methods that call vCloud API to delete snapshot. Since
fog-vcloud-director only has remove_all_snapshots,
`vm_remove_snapshot` calls `vm_remove_all_snapshots`.