### PR TITLE
[GAPRINDASHVILI] Inventory VM hostname to name

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/refresh_parser.rb
@@ -110,7 +110,8 @@ class ManageIQ::Providers::Vmware::CloudManager::RefreshParser < ManageIQ::Provi
   def parse_vm(vm)
     status        = vm.status
     uid           = vm.id
-    name          = vm.name
+    hostname      = vm.customization.try(:computer_name)
+    name          = hostname.present? ? "#{vm.name} (#{hostname})" : vm.name
     guest_os      = vm.operating_system
     bitness       = vm.operating_system =~ /64-bit/ ? 64 : 32
     cpus          = vm.cpu

--- a/spec/models/manageiq/providers/vmware/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/refresher_spec.rb
@@ -157,7 +157,7 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
   end
 
   def assert_specific_vm_powered_on
-    v = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "spec1-vm1")
+    v = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "spec1-vm1 (WebServerVM)")
     expect(v).to have_attributes(
       :template              => false,
       :ems_ref               => "vm-f9ceb77c-b9d9-400c-8c06-72c785e884af",
@@ -241,7 +241,7 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
   end
 
   def assert_specific_vm_powered_off
-    v = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "spec2-vm1")
+    v = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "spec2-vm1 (WebServerVM3)")
     expect(v).to have_attributes(
       :template              => false,
       :ems_ref               => "vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6",
@@ -330,8 +330,8 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
                             .find_by(:name => "spec-1")
     @orchestration_stack2 = ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack
                             .find_by(:name => "spec2")
-    vm1 = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "spec1-vm1")
-    vm2 = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "spec2-vm1")
+    vm1 = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "spec1-vm1 (WebServerVM)")
+    vm2 = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "spec2-vm1 (WebServerVM3)")
 
     expect(vm1.orchestration_stack).to eq(@orchestration_stack1)
     expect(vm2.orchestration_stack).to eq(@orchestration_stack2)
@@ -351,7 +351,7 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
   end
 
   def assert_specific_vm_with_snapshot
-    vm = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "spec2-vm1")
+    vm = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "spec2-vm1 (WebServerVM3)")
 
     expect(vm.snapshots.first).not_to be_nil
     expect(vm.snapshots.first).to have_attributes(

--- a/spec/models/manageiq/providers/vmware/network_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/network_manager/refresher_spec.rb
@@ -88,7 +88,7 @@ describe ManageIQ::Providers::Vmware::NetworkManager::Refresher do
 
     def assert_specific_network_port
       expect(net_port).to have_attributes(
-        :name                  => 'RHEL7-001#NIC#0',
+        :name                  => 'RHEL7-001 (WebServerVM)#NIC#0',
         :mac_address           => '00:50:56:01:00:09',
         :device_type           => 'VmOrTemplate',
         :source                => 'refresh',
@@ -99,7 +99,7 @@ describe ManageIQ::Providers::Vmware::NetworkManager::Refresher do
 
     def assert_specific_vm_networking
       expect(vm).to have_attributes(
-        :name           => 'RHEL7-001',
+        :name           => 'RHEL7-001 (WebServerVM)',
         :ipaddresses    => ['10.12.6.17'],
         :mac_addresses  => [net_port.mac_address],
         :cloud_networks => [vdc_net],
@@ -167,7 +167,7 @@ describe ManageIQ::Providers::Vmware::NetworkManager::Refresher do
 
     def assert_specific_network_port
       expect(net_port).to have_attributes(
-        :name                  => 'vAppRHEL7-w-002#NIC#0',
+        :name                  => 'vAppRHEL7-w-002 (WebServerVM)#NIC#0',
         :mac_address           => '00:50:56:01:00:0c',
         :device_type           => 'VmOrTemplate',
         :source                => 'refresh',
@@ -200,7 +200,7 @@ describe ManageIQ::Providers::Vmware::NetworkManager::Refresher do
 
     def assert_specific_vm_networking
       expect(vm).to have_attributes(
-        :name           => 'vAppRHEL7-w-002',
+        :name           => 'vAppRHEL7-w-002 (WebServerVM)',
         :ipaddresses    => ['192.168.2.100', floating_ip.address],
         :mac_addresses  => [net_port.mac_address],
         :cloud_networks => [vapp_net],
@@ -220,7 +220,7 @@ describe ManageIQ::Providers::Vmware::NetworkManager::Refresher do
     it "full refresh" do
       refresh_network_manager(described_class.name.underscore) do
         expect(vm).to have_attributes(
-          :name         => 'RHEL01-rspec',
+          :name         => 'RHEL01-rspec (WebServerVM)',
           :floating_ips => [floating_ip]
         )
 

--- a/spec/vcr_cassettes/manageiq/providers/vmware/cloud_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/vmware/cloud_manager/refresher.yml
@@ -5640,4 +5640,163 @@ http_interactions:
         </SnapshotSection>
     http_version:
   recorded_at: Fri, 23 Feb 2018 12:50:20 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/guestCustomizationSection
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 27 Feb 2018 13:47:04 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 847868c4-6cce-4d35-9b90-bfdeea747cfd
+      X-Vcloud-Authorization:
+      - eb22e4808d8a463ab6d72dd293d4cc0a
+      Set-Cookie:
+      - vcloud-token=eb22e4808d8a463ab6d72dd293d4cc0a; Secure; Path=/
+      Content-Type:
+      - application/vnd.vmware.vcloud.guestcustomizationsection+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '26'
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1743'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <GuestCustomizationSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-352c29cb-43a9-42e3-8726-c2d38b99f78f/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+            <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+            <Enabled>false</Enabled>
+            <ChangeSid>true</ChangeSid>
+            <VirtualMachineId>352c29cb-43a9-42e3-8726-c2d38b99f78f</VirtualMachineId>
+            <JoinDomainEnabled>false</JoinDomainEnabled>
+            <UseOrgSettings>false</UseOrgSettings>
+            <AdminPasswordEnabled>true</AdminPasswordEnabled>
+            <AdminPasswordAuto>true</AdminPasswordAuto>
+            <ResetPasswordRequired>false</ResetPasswordRequired>
+            <ComputerName>WebServerVM</ComputerName>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-352c29cb-43a9-42e3-8726-c2d38b99f78f/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+        </GuestCustomizationSection>
+    http_version:
+  recorded_at: Tue, 27 Feb 2018 13:47:04 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/guestCustomizationSection
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 27 Feb 2018 13:47:04 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 847868c4-6cce-4d35-9b90-bfdeea747cfd
+      X-Vcloud-Authorization:
+      - eb22e4808d8a463ab6d72dd293d4cc0a
+      Set-Cookie:
+      - vcloud-token=eb22e4808d8a463ab6d72dd293d4cc0a; Secure; Path=/
+      Content-Type:
+      - application/vnd.vmware.vcloud.guestcustomizationsection+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '26'
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1743'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <GuestCustomizationSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-352c29cb-43a9-42e3-8726-c2d38b99f78f/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+            <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+            <Enabled>false</Enabled>
+            <ChangeSid>true</ChangeSid>
+            <VirtualMachineId>352c29cb-43a9-42e3-8726-c2d38b99f78f</VirtualMachineId>
+            <JoinDomainEnabled>false</JoinDomainEnabled>
+            <UseOrgSettings>false</UseOrgSettings>
+            <AdminPasswordEnabled>true</AdminPasswordEnabled>
+            <AdminPasswordAuto>true</AdminPasswordAuto>
+            <ResetPasswordRequired>false</ResetPasswordRequired>
+            <ComputerName>WebServerVM2</ComputerName>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-352c29cb-43a9-42e3-8726-c2d38b99f78f/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+        </GuestCustomizationSection>
+    http_version:
+  recorded_at: Tue, 27 Feb 2018 13:47:04 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/guestCustomizationSection
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 27 Feb 2018 13:47:04 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 847868c4-6cce-4d35-9b90-bfdeea747cfd
+      X-Vcloud-Authorization:
+      - eb22e4808d8a463ab6d72dd293d4cc0a
+      Set-Cookie:
+      - vcloud-token=eb22e4808d8a463ab6d72dd293d4cc0a; Secure; Path=/
+      Content-Type:
+      - application/vnd.vmware.vcloud.guestcustomizationsection+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '26'
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1743'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <GuestCustomizationSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-352c29cb-43a9-42e3-8726-c2d38b99f78f/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+            <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+            <Enabled>false</Enabled>
+            <ChangeSid>true</ChangeSid>
+            <VirtualMachineId>352c29cb-43a9-42e3-8726-c2d38b99f78f</VirtualMachineId>
+            <JoinDomainEnabled>false</JoinDomainEnabled>
+            <UseOrgSettings>false</UseOrgSettings>
+            <AdminPasswordEnabled>true</AdminPasswordEnabled>
+            <AdminPasswordAuto>true</AdminPasswordAuto>
+            <ResetPasswordRequired>false</ResetPasswordRequired>
+            <ComputerName>WebServerVM3</ComputerName>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-352c29cb-43a9-42e3-8726-c2d38b99f78f/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+        </GuestCustomizationSection>
+    http_version:
+  recorded_at: Tue, 27 Feb 2018 13:47:04 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/vmware/network_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/vmware/network_manager/refresher.yml
@@ -12610,4 +12610,322 @@ http_interactions:
         </SnapshotSection>
     http_version:
   recorded_at: Fri, 23 Feb 2018 12:50:19 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-1a5ebd7d-c507-4ddd-b554-489ee5964dab/guestCustomizationSection
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 27 Feb 2018 13:47:04 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 847868c4-6cce-4d35-9b90-bfdeea747cfd
+      X-Vcloud-Authorization:
+      - eb22e4808d8a463ab6d72dd293d4cc0a
+      Set-Cookie:
+      - vcloud-token=eb22e4808d8a463ab6d72dd293d4cc0a; Secure; Path=/
+      Content-Type:
+      - application/vnd.vmware.vcloud.guestcustomizationsection+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '26'
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1743'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <GuestCustomizationSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-1a5ebd7d-c507-4ddd-b554-489ee5964dab/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+            <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+            <Enabled>false</Enabled>
+            <ChangeSid>true</ChangeSid>
+            <VirtualMachineId>1a5ebd7d-c507-4ddd-b554-489ee5964dab</VirtualMachineId>
+            <JoinDomainEnabled>false</JoinDomainEnabled>
+            <UseOrgSettings>false</UseOrgSettings>
+            <AdminPasswordEnabled>true</AdminPasswordEnabled>
+            <AdminPasswordAuto>true</AdminPasswordAuto>
+            <ResetPasswordRequired>false</ResetPasswordRequired>
+            <ComputerName>WebServerVM</ComputerName>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-1a5ebd7d-c507-4ddd-b554-489ee5964dab/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+        </GuestCustomizationSection>
+    http_version:
+  recorded_at: Tue, 27 Feb 2018 13:47:04 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-6850d9ee-ce30-42e0-aaad-3909e1861c48/guestCustomizationSection
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 27 Feb 2018 13:47:04 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 847868c4-6cce-4d35-9b90-bfdeea747cfd
+      X-Vcloud-Authorization:
+      - eb22e4808d8a463ab6d72dd293d4cc0a
+      Set-Cookie:
+      - vcloud-token=eb22e4808d8a463ab6d72dd293d4cc0a; Secure; Path=/
+      Content-Type:
+      - application/vnd.vmware.vcloud.guestcustomizationsection+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '26'
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1743'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <GuestCustomizationSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-6850d9ee-ce30-42e0-aaad-3909e1861c48/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+            <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+            <Enabled>false</Enabled>
+            <ChangeSid>true</ChangeSid>
+            <VirtualMachineId>6850d9ee-ce30-42e0-aaad-3909e1861c48</VirtualMachineId>
+            <JoinDomainEnabled>false</JoinDomainEnabled>
+            <UseOrgSettings>false</UseOrgSettings>
+            <AdminPasswordEnabled>true</AdminPasswordEnabled>
+            <AdminPasswordAuto>true</AdminPasswordAuto>
+            <ResetPasswordRequired>false</ResetPasswordRequired>
+            <ComputerName>WebServerVM</ComputerName>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-6850d9ee-ce30-42e0-aaad-3909e1861c48/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+        </GuestCustomizationSection>
+    http_version:
+  recorded_at: Tue, 27 Feb 2018 13:47:04 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-796ea504-ea50-4952-b7f7-a67ae40ba3a0/guestCustomizationSection
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 27 Feb 2018 13:47:04 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 847868c4-6cce-4d35-9b90-bfdeea747cfd
+      X-Vcloud-Authorization:
+      - eb22e4808d8a463ab6d72dd293d4cc0a
+      Set-Cookie:
+      - vcloud-token=eb22e4808d8a463ab6d72dd293d4cc0a; Secure; Path=/
+      Content-Type:
+      - application/vnd.vmware.vcloud.guestcustomizationsection+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '26'
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1743'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <GuestCustomizationSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-796ea504-ea50-4952-b7f7-a67ae40ba3a0/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+            <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+            <Enabled>false</Enabled>
+            <ChangeSid>true</ChangeSid>
+            <VirtualMachineId>796ea504-ea50-4952-b7f7-a67ae40ba3a0</VirtualMachineId>
+            <JoinDomainEnabled>false</JoinDomainEnabled>
+            <UseOrgSettings>false</UseOrgSettings>
+            <AdminPasswordEnabled>true</AdminPasswordEnabled>
+            <AdminPasswordAuto>true</AdminPasswordAuto>
+            <ResetPasswordRequired>false</ResetPasswordRequired>
+            <ComputerName>WebServerVM</ComputerName>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-796ea504-ea50-4952-b7f7-a67ae40ba3a0/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+        </GuestCustomizationSection>
+    http_version:
+  recorded_at: Tue, 27 Feb 2018 13:47:04 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-6294e7eb-2f02-42fe-8cde-6e727115bb63/guestCustomizationSection
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 27 Feb 2018 13:47:04 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 847868c4-6cce-4d35-9b90-bfdeea747cfd
+      X-Vcloud-Authorization:
+      - eb22e4808d8a463ab6d72dd293d4cc0a
+      Set-Cookie:
+      - vcloud-token=eb22e4808d8a463ab6d72dd293d4cc0a; Secure; Path=/
+      Content-Type:
+      - application/vnd.vmware.vcloud.guestcustomizationsection+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '26'
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1743'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <GuestCustomizationSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-6294e7eb-2f02-42fe-8cde-6e727115bb63/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+            <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+            <Enabled>false</Enabled>
+            <ChangeSid>true</ChangeSid>
+            <VirtualMachineId>6294e7eb-2f02-42fe-8cde-6e727115bb63</VirtualMachineId>
+            <JoinDomainEnabled>false</JoinDomainEnabled>
+            <UseOrgSettings>false</UseOrgSettings>
+            <AdminPasswordEnabled>true</AdminPasswordEnabled>
+            <AdminPasswordAuto>true</AdminPasswordAuto>
+            <ResetPasswordRequired>false</ResetPasswordRequired>
+            <ComputerName>WebServerVM</ComputerName>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-6294e7eb-2f02-42fe-8cde-6e727115bb63/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+        </GuestCustomizationSection>
+    http_version:
+  recorded_at: Tue, 27 Feb 2018 13:47:04 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-e9404ecd-a2b8-4781-8e10-8fe6ca450305/guestCustomizationSection
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 27 Feb 2018 13:47:04 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 847868c4-6cce-4d35-9b90-bfdeea747cfd
+      X-Vcloud-Authorization:
+      - eb22e4808d8a463ab6d72dd293d4cc0a
+      Set-Cookie:
+      - vcloud-token=eb22e4808d8a463ab6d72dd293d4cc0a; Secure; Path=/
+      Content-Type:
+      - application/vnd.vmware.vcloud.guestcustomizationsection+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '26'
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1743'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <GuestCustomizationSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-e9404ecd-a2b8-4781-8e10-8fe6ca450305/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+            <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+            <Enabled>false</Enabled>
+            <ChangeSid>true</ChangeSid>
+            <VirtualMachineId>e9404ecd-a2b8-4781-8e10-8fe6ca450305</VirtualMachineId>
+            <JoinDomainEnabled>false</JoinDomainEnabled>
+            <UseOrgSettings>false</UseOrgSettings>
+            <AdminPasswordEnabled>true</AdminPasswordEnabled>
+            <AdminPasswordAuto>true</AdminPasswordAuto>
+            <ResetPasswordRequired>false</ResetPasswordRequired>
+            <ComputerName>WebServerVM</ComputerName>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-e9404ecd-a2b8-4781-8e10-8fe6ca450305/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+        </GuestCustomizationSection>
+    http_version:
+  recorded_at: Tue, 27 Feb 2018 13:47:04 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-37ff4eb7-a711-4baa-82cf-3075f099ebb0/guestCustomizationSection
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 27 Feb 2018 13:47:04 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 847868c4-6cce-4d35-9b90-bfdeea747cfd
+      X-Vcloud-Authorization:
+      - eb22e4808d8a463ab6d72dd293d4cc0a
+      Set-Cookie:
+      - vcloud-token=eb22e4808d8a463ab6d72dd293d4cc0a; Secure; Path=/
+      Content-Type:
+      - application/vnd.vmware.vcloud.guestcustomizationsection+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '26'
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1743'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <GuestCustomizationSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-37ff4eb7-a711-4baa-82cf-3075f099ebb0/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+            <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+            <Enabled>false</Enabled>
+            <ChangeSid>true</ChangeSid>
+            <VirtualMachineId>37ff4eb7-a711-4baa-82cf-3075f099ebb0</VirtualMachineId>
+            <JoinDomainEnabled>false</JoinDomainEnabled>
+            <UseOrgSettings>false</UseOrgSettings>
+            <AdminPasswordEnabled>true</AdminPasswordEnabled>
+            <AdminPasswordAuto>true</AdminPasswordAuto>
+            <ResetPasswordRequired>false</ResetPasswordRequired>
+            <ComputerName>WebServerVM</ComputerName>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-37ff4eb7-a711-4baa-82cf-3075f099ebb0/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+        </GuestCustomizationSection>
+    http_version:
+  recorded_at: Tue, 27 Feb 2018 13:47:04 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
VM doesn't have attribute hostname yet. For now we inventory VM hostname and and save it to name, so it looks like `name (hostname)`.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1553824

Signed-off-by: sasoc <saso.cvitkovic@gmail.com>