### PR TITLE
Allow user to pick administrator password upon vApp provisioning

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/orchestration_template.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/orchestration_template.rb
@@ -96,7 +96,23 @@ class ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate < Orchest
           :constraints   => [
             OrchestrationTemplate::OrchestrationParameterRange.new(:min_value => 4)
           ]
-        )
+        ),
+        OrchestrationTemplate::OrchestrationParameter.new(
+          :name        => param_name('admin_password', [vm_idx]),
+          :label       => 'Administrator Password',
+          :description => 'Leave empty to auto generate',
+          :data_type   => 'string'
+        ),
+        OrchestrationTemplate::OrchestrationParameter.new(
+          :name          => param_name('admin_reset', [vm_idx]),
+          :label         => 'Require password change',
+          :description   => 'Require administrator to change password on first login',
+          :data_type     => 'boolean',
+          :default_value => false,
+          :constraints   => [
+            OrchestrationTemplate::OrchestrationParameterBoolean.new
+          ]
+        ),
       ]
 
       # Disks.

--- a/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_service_option_converter_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_service_option_converter_spec.rb
@@ -23,6 +23,8 @@ describe ManageIQ::Providers::Vmware::CloudManager::OrchestrationServiceOptionCo
       'dialog_param_num_cores-0'        => 8,
       'dialog_param_cores_per_socket-0' => 4,
       'dialog_param_memory_mb-0'        => 8192,
+      'dialog_param_admin_password-0'   => 'admin-password',
+      'dialog_param_admin_reset-0'      => 't',
       'dialog_param_disk_mb-0-0'        => 40_960,
       'dialog_param_disk_mb-0-1'        => 20_480,
       'dialog_param_nic_network-0-0'    => 'VM Network',
@@ -34,6 +36,8 @@ describe ManageIQ::Providers::Vmware::CloudManager::OrchestrationServiceOptionCo
       'dialog_param_num_cores-1'        => 4,
       'dialog_param_cores_per_socket-1' => 1,
       'dialog_param_memory_mb-1'        => 2048,
+      'dialog_param_admin_password-1'   => '',
+      'dialog_param_admin_reset-1'      => 'f',
       'dialog_param_disk_mb-1-0'        => 4096,
       'dialog_param_nic_network-1-0'    => 'RedHat Private network 43',
       'dialog_param_nic_mode-1-0'       => 'DHCP',
@@ -91,7 +95,14 @@ describe ManageIQ::Providers::Vmware::CloudManager::OrchestrationServiceOptionCo
       expect(options[:source_vms][0]).to eq(
         :name                => 'my VM1',
         :vm_id               => 'vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3',
-        :guest_customization => { :ComputerName => 'my-vm-1' },
+        :guest_customization => {
+          :Enabled               => true,
+          :ComputerName          => 'my-vm-1',
+          :AdminPasswordEnabled  => true,
+          :AdminPassword         => 'admin-password',
+          :AdminPasswordAuto     => false,
+          :ResetPasswordRequired => true
+        },
         :hardware            => {
           :cpu    => { :num_cores => 8, :cores_per_socket => 4 },
           :memory => { :quantity_mb => 8192 },
@@ -112,7 +123,13 @@ describe ManageIQ::Providers::Vmware::CloudManager::OrchestrationServiceOptionCo
       expect(options[:source_vms][1]).to eq(
         :name                => 'my VM2',
         :vm_id               => 'vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b',
-        :guest_customization => { :ComputerName => 'my-vm-2' },
+        :guest_customization => {
+          :Enabled               => true,
+          :ComputerName          => 'my-vm-2',
+          :AdminPasswordEnabled  => true,
+          :AdminPasswordAuto     => true,
+          :ResetPasswordRequired => false
+        },
         :hardware            => {
           :cpu    => { :num_cores => 4, :cores_per_socket => 1 },
           :memory => { :quantity_mb => 2048 },

--- a/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_template_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_template_spec.rb
@@ -63,6 +63,8 @@ describe ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate do
           :num_cores        => 2,
           :cores_per_socket => 2,
           :memory_mb        => 2048,
+          :admin_password   => nil,
+          :admin_reset      => false,
           :disks            => [
             { :disk_id => '2000', :disk_address => '0', :size => 16_384 },
             { :disk_id => '2001', :disk_address => '1', :size => 40_960 }
@@ -76,6 +78,8 @@ describe ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate do
           :num_cores        => 2,
           :cores_per_socket => 2,
           :memory_mb        => 4096,
+          :admin_password   => nil,
+          :admin_reset      => false,
           :disks            => [{ :disk_id => '2000', :disk_address => '0', :size => 40_960 }],
           :nics             => [
             { :idx => '0', :network => 'RedHat Private network 43', :mode => 'MANUAL', :ip_address => '192.168.43.100' },
@@ -125,12 +129,26 @@ describe ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate do
               :data_type     => 'integer',
               :required      => true,
               :default_value => args[:memory_mb]
+            },
+            'admin_password'   => {
+              :name          => "admin_password-#{vm_idx}",
+              :label         => 'Administrator Password',
+              :data_type     => 'string',
+              :required      => nil,
+              :default_value => args[:admin_password]
+            },
+            'admin_reset'      => {
+              :name          => "admin_reset-#{vm_idx}",
+              :label         => 'Require password change',
+              :data_type     => 'boolean',
+              :required      => nil,
+              :default_value => args[:admin_reset]
             }
           )
           assert_vm_disks(vm_group, args[:disks], vm_idx)
           assert_vm_nics(vm_group, args[:nics], vm_idx)
           # Group has not extra parameters.
-          expect(vm_group.parameters.size).to eq(5 + args[:disks].count + 3 * args[:nics].count)
+          expect(vm_group.parameters.size).to eq(7 + args[:disks].count + 3 * args[:nics].count)
         end
       end
 


### PR DESCRIPTION
With this commit we add yet another two fields to the vApp provisioning Service Dialog: admin_password (text input) and admin_reset (checkbox) for each VM to allow for administrator password customization.

Passoword is displayed in plaintext, because this is also the case on vCloud dashboard, so it makes no sense to hide it here.

![capture](https://user-images.githubusercontent.com/8102426/36793079-b06d777c-1c9c-11e8-8b9f-1b290a19c70f.PNG)

![capture](https://user-images.githubusercontent.com/8102426/36793151-e3b420cc-1c9c-11e8-9c1a-fcfb0fa5d839.PNG)



@miq-bot add_label enhancement,gaprindashvili/yes
@miq-bot assign @agrare 