### PR TITLE
Skip "none" vApp network when inventoring

### DIFF
--- a/app/models/manageiq/providers/vmware/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/network_manager/refresh_parser.rb
@@ -44,6 +44,9 @@ module ManageIQ::Providers
 
       @ems.orchestration_stacks.each do |stack|
         fetch_network_configurations_for_vapp(stack.ems_ref).map do |net_conf|
+          # 'none' is special network placeholder that we must ignore
+          next if net_conf[:networkName] == 'none'
+
           $vcloud_log.debug("#{log_header} processing net_conf for vapp #{stack.ems_ref}: #{net_conf}")
           network_id = network_id_from_links(net_conf)
           $vcloud_log.debug("#{log_header} calculated vApp network id: #{network_id}")

--- a/spec/vcr_cassettes/manageiq/providers/vmware/network_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/vmware/network_manager/refresher.yml
@@ -9325,6 +9325,21 @@ http_interactions:
             <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a421d543-768d-4ae5-b7b0-48caeeaccd64/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
                 <ovf:Info>The configuration parameters for logical networks</ovf:Info>
                 <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a421d543-768d-4ae5-b7b0-48caeeaccd64/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
+                <NetworkConfig networkName="none">
+                    <Description>This is a special place-holder used for disconnected network interfaces.</Description>
+                    <Configuration>
+                        <IpScopes>
+                            <IpScope>
+                                <IsInherited>false</IsInherited>
+                                <Gateway>196.254.254.254</Gateway>
+                                <Netmask>255.255.0.0</Netmask>
+                                <Dns1>196.254.254.254</Dns1>
+                            </IpScope>
+                        </IpScopes>
+                        <FenceMode>isolated</FenceMode>
+                    </Configuration>
+                    <IsDeployed>false</IsDeployed>
+                </NetworkConfig>
                 <NetworkConfig networkName="vApp network test 2">
                     <Link rel="repair" href="https://VMWARE_CLOUD_HOST/api/admin/network/e12c7b8c-ef85-4541-87e1-13218c7f1bd8/action/reset"/>
                     <Description></Description>


### PR DESCRIPTION
With this commit we prevent NetworkManager from crashing is case when there is a special network "none" listed in vApp network configuration section. This "none" network is a reserved vApp network name which is for some reason present in case when at least one NIC of the vApp VMs is not connected to any network.

Following XML is present for such "none" networks:

```
<vcloud:NetworkConfig networkName="none">
    <vcloud:Description>This is a special place-holder used for disconnected network interfaces.</vcloud:Description>
    <vcloud:Configuration>
        <vcloud:IpScopes>
            <vcloud:IpScope>
                <vcloud:IsInherited>false</vcloud:IsInherited>
                <vcloud:Gateway>196.254.254.254</vcloud:Gateway>
                <vcloud:Netmask>255.255.0.0</vcloud:Netmask>
                <vcloud:Dns1>196.254.254.254</vcloud:Dns1>
            </vcloud:IpScope>
        </vcloud:IpScopes>
        <vcloud:FenceMode>isolated</vcloud:FenceMode>
    </vcloud:Configuration>
    <vcloud:IsDeployed>false</vcloud:IsDeployed>
</vcloud:NetworkConfig>
```

and it must be ignored when inventoring.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1520372

@miq-bot add_label enhancement
@miq-bot assign @agrare 