### PR TITLE
Don't run EventCatcher when "none" was selected on GUI

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/event_catcher.rb
@@ -8,4 +8,14 @@ class ManageIQ::Providers::Vmware::CloudManager::EventCatcher < ::MiqEventCatche
   def self.settings_name
     :event_catcher_vmware_cloud
   end
+
+  def self.all_valid_ems_in_zone
+    # Only run event catcher for those vClouds that have credentials for it.
+    # NOTE: ATM it's safest to check if hostname is non-empty string because
+    # frontend seems to be inserting empty Authentication and Endpoint even
+    # if user opts-in for "None" in AMQP tab.
+    super.select do |ems|
+      ems.endpoints.any? { |e| e.role == 'amqp' && e.hostname.present? }
+    end
+  end
 end

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -21,4 +21,11 @@ FactoryGirl.define do
       ems.authentications << FactoryGirl.create(:authentication, cred)
     end
   end
+
+  factory :ems_vmware_cloud_with_amqp_authentication, :parent => :ems_vmware_cloud do
+    after(:create) do |x|
+      x.authentications << FactoryGirl.create(:authentication, :authtype => 'amqp')
+      x.endpoints       << FactoryGirl.create(:endpoint, :role => 'amqp')
+    end
+  end
 end

--- a/spec/models/manageiq/providers/vmware/cloud_manager/event_catcher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/event_catcher_spec.rb
@@ -1,0 +1,44 @@
+describe ManageIQ::Providers::Vmware::CloudManager::EventCatcher do
+  it '#ems_class' do
+    expect(described_class.ems_class).to eq(ManageIQ::Providers::Vmware::CloudManager)
+  end
+
+  it '#settings_name' do
+    expect(described_class.settings_name).to eq(:event_catcher_vmware_cloud)
+  end
+
+  describe '#all_valid_ems_in_zone' do
+    let(:ems_without_amqp) { FactoryGirl.create(:ems_vmware_cloud) }
+    let(:ems_with_amqp)    { FactoryGirl.create(:ems_vmware_cloud_with_amqp_authentication) }
+    let(:ems_with_empty_amqp) do
+      ems = FactoryGirl.create(:ems_vmware_cloud_with_amqp_authentication)
+      ems.endpoints.detect { |h| h.role == 'amqp' }.update(:hostname => '')
+      ems
+    end
+
+    it 'no ems at all' do
+      allow(described_class.superclass).to receive(:all_valid_ems_in_zone).and_return([])
+      expect(described_class.all_valid_ems_in_zone).to eq([])
+    end
+
+    it 'ems without AMQP credentials' do
+      allow(described_class.superclass).to receive(:all_valid_ems_in_zone).and_return([ems_without_amqp])
+      expect(described_class.all_valid_ems_in_zone).to eq([])
+    end
+
+    it 'ems with empty AMQP credentials' do
+      allow(described_class.superclass).to receive(:all_valid_ems_in_zone).and_return([ems_with_empty_amqp])
+      expect(described_class.all_valid_ems_in_zone).to eq([])
+    end
+
+    it 'ems with AMQP credentials' do
+      allow(described_class.superclass).to receive(:all_valid_ems_in_zone).and_return([ems_with_amqp])
+      expect(described_class.all_valid_ems_in_zone).to eq([ems_with_amqp])
+    end
+
+    it 'mixture of all' do
+      allow(described_class.superclass).to receive(:all_valid_ems_in_zone).and_return([ems_with_amqp, ems_without_amqp, ems_with_empty_amqp])
+      expect(described_class.all_valid_ems_in_zone).to eq([ems_with_amqp])
+    end
+  end
+end


### PR DESCRIPTION
With this commit we prevent EventCatcher thread from being spawned for vCD providers that have no AMQP credentials.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1527209

@miq-bot add_label enhancement, gaprindashvili/yes
@miq-bot assign @agrare 

(based on https://github.com/ManageIQ/manageiq/pull/16937)
