### PR TITLE
Fix deprecated use of #address

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -13,7 +13,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
 
   def run
     until exit_requested
-      vim = connect(ems.address, ems.authentication_userid, ems.authentication_password)
+      vim = connect(ems.hostname, ems.authentication_userid, ems.authentication_password)
 
       begin
         wait_for_updates(vim)

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
@@ -127,7 +127,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole
       :secret     => password,
       :url_secret => SecureRandom.hex
     }
-    host_address = host.address
+    host_address = host.hostname
 
     SystemConsole.launch_proxy_if_not_local(console_args, originating_server, host_address, host_port)
   end


### PR DESCRIPTION
The #address property is deprecated and has been replaced by #hostanme.