### PR TITLE
Fix VMware spec tests using have_attributes

### DIFF
--- a/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_service_option_converter_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_service_option_converter_spec.rb
@@ -59,7 +59,7 @@ describe ManageIQ::Providers::Vmware::CloudManager::OrchestrationServiceOptionCo
       expect(options).not_to be_nil
       expect(options[:vapp_networks]).not_to be_nil
       expect(options[:vapp_networks].count).to eq(2)
-      expect(options[:vapp_networks][0]).to have_attributes(
+      expect(options[:vapp_networks][0]).to include(
         :name       => 'VM Network',
         :parent     => nil,
         :fence_mode => 'isolated',
@@ -72,7 +72,7 @@ describe ManageIQ::Providers::Vmware::CloudManager::OrchestrationServiceOptionCo
           }
         ]
       )
-      expect(options[:vapp_networks][1]).to have_attributes(
+      expect(options[:vapp_networks][1]).to include(
         :name       => 'RedHat Private network 43',
         :parent     => 'b915be99-1471-4e51-bcde-da2da791b98f',
         :fence_mode => 'bridged',

--- a/spec/models/manageiq/providers/vmware/infra_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/event_parser_spec.rb
@@ -6,14 +6,13 @@ describe ManageIQ::Providers::Vmware::InfraManager::EventParser do
       event = YAML.load_file(File.join(EPV_DATA_DIR, 'general_user_event.yml'))
       data = described_class.event_to_hash(event, 12345)
 
-      expect(data).to have_attributes(
+      expect(data).to include(
         :event_type   => "GeneralUserEvent",
         :chain_id     => "5361104",
         :is_task      => false,
         :source       => "VC",
         :message      => "User logged event: EVM SmartState Analysis completed for VM [tch-UBUNTU-904-LTS-DESKTOP]",
         :timestamp    => "2010-08-24T01:08:10.396636Z",
-        :full_data    => event,
         :ems_id       => 12345,
         :username     => "MANAGEIQ\\thennessy",
 
@@ -24,6 +23,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::EventParser do
         :host_name    => "yoda.manageiq.com",
       )
 
+      expect(data[:full_data]).to    eq(event)
       expect(data[:full_data]).to    be_instance_of VimHash
       expect(data[:vm_ems_ref]).to   be_instance_of String
       expect(data[:host_ems_ref]).to be_instance_of String
@@ -35,7 +35,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::EventParser do
         data = described_class.event_to_hash(event, 12345)
 
         assert_result_fields(data, event)
-        expect(data).to have_attributes(
+        expect(data).to include(
           :event_type => "vprob.vmfs.resource.corruptondisk",
           :message    => "event.vprob.vmfs.resource.corruptondisk.fullFormat (vprob.vmfs.resource.corruptondisk)"
         )
@@ -46,29 +46,24 @@ describe ManageIQ::Providers::Vmware::InfraManager::EventParser do
         data = described_class.event_to_hash(event, 12345)
 
         assert_result_fields(data, event)
-        expect(data).to have_attributes(
+        expect(data).to include(
           :event_type => "EventEx",
           :message    => ""
         )
       end
 
       def assert_result_fields(data, event)
-        expect(data).to have_attributes(
+        expect(data).to include(
           :chain_id     => "297179",
           :is_task      => false,
           :source       => "VC",
           :timestamp    => "2010-11-12T17:15:42.661128Z",
-          :full_data    => event,
           :ems_id       => 12345,
-          :username     => nil,
-
-          :vm_ems_ref   => nil,
-          :vm_name      => nil,
-          :vm_location  => nil,
           :host_ems_ref => "host-29",
           :host_name    => "vi4esx1.galaxy.local",
         )
 
+        expect(data[:full_data]).to    eq(event)
         expect(data[:full_data]).to    be_instance_of VimHash
         expect(data[:host_ems_ref]).to be_instance_of String
       end
@@ -78,7 +73,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::EventParser do
       let(:event) { YAML.load_file(File.join(EPV_DATA_DIR, 'task_event.yaml')) }
 
       it "sets the vm_uid_ems" do
-        expect(described_class.event_to_hash(event, 12_345)).to have_attributes(
+        expect(described_class.event_to_hash(event, 12_345)).to include(
           :vm_uid_ems => event["vm"]["uuid"]
         )
       end

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -66,18 +66,19 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
 
         _obj, props = collector.send(:process_object_update, object_update)
 
-        expect(props).to have_attributes(
+        expect(props).to include(
           "name"        => "Datacenters",
           "parent"      => nil,
-          "childEntity" => [datacenter]
         )
+
+        expect(props["childEntity"].first._ref).to eq(datacenter._ref)
       end
 
       it "VirtualMachine" do
         object_update = virtual_machine_enter_object_update
 
         _obj, props = collector.send(:process_object_update, object_update)
-        expect(props).to have_attributes(
+        expect(props).to include(
           "summary.config.uuid"       => "eaf4991e-ab31-4f86-9ec0-aeb5d5a27c33",
           "summary.config.name"       => "vm1",
           "summary.config.vmPathName" => "[datastore1] vm1/vm1.vmx",
@@ -103,7 +104,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
           )
 
           _obj, props = collector.send(:process_object_update, object_update)
-          expect(props).to have_attributes(
+          expect(props).to include(
             "summary.config.name" => "vm2"
           )
         end
@@ -118,7 +119,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
           )
 
           _obj, props = collector.send(:process_object_update, object_update)
-          expect(props).to have_attributes(
+          expect(props).to include(
             "summary.config.uuid"       => "eaf4991e-ab31-4f86-9ec0-aeb5d5a27c33",
             "summary.config.name"       => "vm2",
             "summary.config.vmPathName" => "[datastore1] vm1/vm1.vmx",


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/issues/17021 removed extensions used by this repositories spec tests.
This fixes these tests to use the standard rspec methods.