### PR TITLE
Fix rspec warning about removing initialize

### DIFF
--- a/app/models/manageiq/providers/vmware/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/network_manager/refresh_parser.rb
@@ -5,18 +5,19 @@ module ManageIQ::Providers
 
     def initialize(ems, options = nil)
       @ems                  = ems
-      @connection           = ems.connect
       @options              = options || {}
       @data                 = {}
       @data_index           = {}
       @inv                  = Hash.new { |h, k| h[k] = [] }
-      @org                  = @connection.organizations.first
       @network_name_mapping = {}
     end
 
     def ems_inv_to_hashes
       $vcloud_log.info("#{log_header} Collecting data for EMS name: [#{@ems.name}] id: [#{@ems.id}]...")
 
+      connect
+
+      get_org
       get_vdc_networks
       get_vapp_networks
       get_network_ports
@@ -27,6 +28,14 @@ module ManageIQ::Providers
     end
 
     private
+
+    def connect
+      @connection ||= @ems.connect
+    end
+
+    def get_org
+      @org = @connection.organizations.first
+    end
 
     def get_vdc_networks
       @inv[:vdc_networks] = @org.networks || []

--- a/spec/models/manageiq/providers/vmware/network_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/vmware/network_manager/refresh_parser_spec.rb
@@ -1,15 +1,17 @@
 describe ManageIQ::Providers::Vmware::NetworkManager::RefreshParser do
   describe "Utility" do
     before do
-      allow_any_instance_of(described_class).to receive(:initialize).and_return(nil)
       allow($vcloud_log).to receive(:debug)
       allow($vcloud_log).to receive(:error)
       allow($vcloud_log).to receive(:info)
     end
-    let(:refresher) { described_class.new }
-    let(:network) do
-      double(:id => 'id1', :name => 'name1')
+    let(:ems) do
+      FactoryGirl.create(:ems_vmware_cloud).tap do |ems|
+        ems.authentications << FactoryGirl.create(:authentication, :status => "Valid")
+      end
     end
+    let(:refresher) { described_class.new(ems) }
+    let(:network)   { double(:id => 'id1', :name => 'name1') }
 
     describe 'build_vapp_network' do
       [


### PR DESCRIPTION
Ruby is warning about rspec removing initialize for the network_manager:

`rspec-mocks-3.6.0/lib/rspec/mocks/any_instance/recorder.rb:195: warning: removing 'initialize' may cause serious problems`

We can get around this by actually passing in the right args to the
RefreshParser initializer and calling connect in the ems_inv_to_hashes
method instead of the initializer.