### PR TITLE
Fix collector spec nil connection comparison

### DIFF
--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -48,9 +48,10 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
   end
 
   context "#process_object_update (private)" do
-    let(:root_folder)     { RbVmomi::VIM::Folder(nil, "group-d1") }
-    let(:datacenter)      { RbVmomi::VIM::Datacenter(nil, "datacenter-1") }
-    let(:virtual_machine) { RbVmomi::VIM::VirtualMachine(nil, "vm-1") }
+    let(:vim)             { RbVmomi::VIM.new(:ns => "urn2", :rev => "6.5") }
+    let(:root_folder)     { RbVmomi::VIM::Folder(vim, "group-d1") }
+    let(:datacenter)      { RbVmomi::VIM::Datacenter(vim, "datacenter-1") }
+    let(:virtual_machine) { RbVmomi::VIM::VirtualMachine(vim, "vm-1") }
 
     context "enter" do
       it "Folder" do
@@ -69,9 +70,8 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         expect(props).to include(
           "name"        => "Datacenters",
           "parent"      => nil,
+          "childEntity" => [datacenter],
         )
-
-        expect(props["childEntity"].first._ref).to eq(datacenter._ref)
       end
 
       it "VirtualMachine" do


### PR DESCRIPTION
The rspec include() was comparing the two datacenter objects which
RbVmomi implements by comparing the ref and the connection.  Previously
we were passing nil for the connection because we only really need to
compare the ref but this was causing errors with the new matcher.