### PR TITLE
Use utility function vm_powered_on? instead manual comparison

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm/operations.rb
@@ -5,7 +5,7 @@ module ManageIQ::Providers::Vmware::CloudManager::Vm::Operations
 
   included do
     supports :terminate do
-      unsupported_reason_add(:terminate, "The VM is powered on") unless current_state == "off"
+      unsupported_reason_add(:terminate, "The VM is powered on") if vm_powered_on?
     end
   end
 

--- a/spec/models/manageiq/providers/vmware/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/vm_spec.rb
@@ -34,6 +34,11 @@ describe ManageIQ::Providers::Vmware::CloudManager::Vm do
       let(:state) { :standby_guest }
       include_examples "Vm operation is not available"
     end
+
+    context("with :terminate") do
+      let(:state) { :terminate }
+      include_examples "Vm operation is available when not powered on"
+    end
   end
 
   context "when destroyed" do


### PR DESCRIPTION
With this commit we replace manual comparison of status with utility function. The logic is a bit more bullet-proof now since we now only prevent VM delete when VM is "ON" while we originally only allowed delete when VM was "OFF". So effectively we now allow VM delete even if status is e.g. "unknown" which I think should succeed.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1550841

@miq-bot assign @agrare 
@miq-bot add_label enhancement,gaprindashvili/yes

Followup for https://github.com/ManageIQ/manageiq-providers-vmware/pull/184