### PR TITLE
Support update VM snapshot

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm.rb
@@ -4,6 +4,7 @@ class ManageIQ::Providers::Vmware::CloudManager::Vm < ManageIQ::Providers::Cloud
   supports :snapshots
   supports :remove_all_snapshots
   supports_not :remove_snapshot
+  supports :snapshot_create
 
   def provider_object(connection = nil)
     connection ||= ext_management_system.connect

--- a/spec/models/manageiq/providers/vmware/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager_spec.rb
@@ -120,6 +120,15 @@ describe ManageIQ::Providers::Vmware::CloudManager do
 
         @ems.vm_create_snapshot(vm, snapshot_options)
       end
+
+      it 'supports snapshot create' do
+        expect(vm.supports_snapshot_create?).to be_truthy
+      end
+
+      it 'supports snapshot create (for second snapshot)' do
+        FactoryGirl.create(:snapshot, :vm_or_template_id => vm.id)
+        expect(vm.supports_snapshot_create?).to be_truthy
+      end
     end
 
     context ".vm_revert_to_snapshot" do


### PR DESCRIPTION
Create new snapshot was disabled when VM already had an existing snapshot. VCloud only supports having one snapshot per VM, but you can still create new snapshot, which updates the existing one. So now VM supports `snapshot_create` even when it already has a snapshot.
