### PR TITLE
Completely stop/suspend VM, not just partially

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm/operations/power.rb
@@ -9,12 +9,18 @@ module ManageIQ::Providers::Vmware::CloudManager::Vm::Operations::Power
   end
 
   def raw_stop
-    with_provider_object(&:power_off)
+    with_provider_connection do |service|
+      response = service.post_undeploy_vapp(ems_ref, :UndeployPowerAction => 'powerOff')
+      service.process_task(response.body)
+    end
     update_attributes!(:raw_power_state => "off")
   end
 
   def raw_suspend
-    with_provider_object(&:suspend)
+    with_provider_connection do |service|
+      response = service.post_undeploy_vapp(ems_ref, :UndeployPowerAction => 'suspend')
+      service.process_task(response.body)
+    end
     update_attributes!(:raw_power_state => "suspended")
   end
 

--- a/spec/models/manageiq/providers/vmware/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/vm_spec.rb
@@ -50,4 +50,33 @@ describe ManageIQ::Providers::Vmware::CloudManager::Vm do
       vm.raw_destroy
     end
   end
+
+  describe 'power operations' do
+    before(:each) do
+      allow(ems).to receive(:with_provider_connection).and_yield(connection)
+    end
+
+    let(:ems)        { FactoryGirl.create(:ems_vmware_cloud) }
+    let(:vm)         { FactoryGirl.create(:vm_vcloud, :ext_management_system => ems, :ems_ref => 'id') }
+    let(:connection) { double('connection') }
+    let(:response)   { double('response', :body => nil) }
+
+    context '.raw_stop' do
+      it 'stops the virtual machine' do
+        expect(connection).to receive(:post_undeploy_vapp).with('id', :UndeployPowerAction => 'powerOff').and_return(response)
+        expect(connection).to receive(:process_task)
+
+        vm.raw_stop
+      end
+    end
+
+    context '.raw_suspend' do
+      it 'suspends the virtual machine' do
+        expect(connection).to receive(:post_undeploy_vapp).with('id', :UndeployPowerAction => 'suspend').and_return(response)
+        expect(connection).to receive(:process_task)
+
+        vm.raw_suspend
+      end
+    end
+  end
 end


### PR DESCRIPTION
If you stop/suspend VM in vCloud Director UI, it stops/suspends completely. But when calling same action using vCloud API it only stops/suspends VM partially, that is because it stays in `deployed` state. To reach the same effect as in vCloud Director UI we now use `post_undeploy_vapp` with `'UndeployPowerAction'` set to `'powerOff'`/`'suspend'`

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1551534