### PR TITLE
Update disk's controller type parsing

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/refresh_parser.rb
@@ -120,15 +120,11 @@ class ManageIQ::Providers::Vmware::CloudManager::RefreshParser < ManageIQ::Provi
     stack         = @data_index.fetch_path(:orchestration_stacks, vapp_uid)
     disk_capacity = vm.hard_disks.inject(0) { |sum, x| sum + x.values[0] } * 1.megabyte
 
-    vm_disks = vm.disks.all
-
-    disks = vm_disks.select { |d| d.description == "Hard disk" }.map do |disk|
-      parent = vm_disks.find { |d| d.id == disk.parent }
-
+    disks = vm.disks.all.select { |d| hdd? d.bus_type }.map do |disk|
       {
         :device_name     => disk.name,
         :device_type     => "disk",
-        :controller_type => parent.description,
+        :controller_type => controller_description(disk.bus_sub_type),
         :size            => disk.capacity * 1.megabyte,
         :location        => "#{vm.id}-#{disk.id}",
         :filename        => "#{vm.id}-#{disk.id}",
@@ -236,5 +232,28 @@ class ManageIQ::Providers::Vmware::CloudManager::RefreshParser < ManageIQ::Provi
     else
       return nil
     end
+  end
+
+  # See https://pubs.vmware.com/vcd-80/index.jsp#com.vmware.vcloud.api.sp.doc_90/GUID-E1BA999D-87FA-4E2C-B638-24A211AB8160.html
+  def controller_description(bus_subtype)
+    case bus_subtype
+    when 'buslogic'
+      'BusLogic Parallel SCSI controller'
+    when 'lsilogic'
+      'LSI Logic Parallel SCSI controller'
+    when 'lsilogicsas'
+      'LSI Logic SAS SCSI controller'
+    when 'VirtualSCSI'
+      'Paravirtual SCSI controller'
+    when 'vmware.sata.ahci'
+      'SATA controller'
+    else
+      'IDE controller'
+    end
+  end
+
+  # See https://pubs.vmware.com/vcd-80/index.jsp#com.vmware.vcloud.api.sp.doc_90/GUID-E1BA999D-87FA-4E2C-B638-24A211AB8160.html
+  def hdd?(bus_type)
+    [5, 6, 20].include?(bus_type)
   end
 end

--- a/spec/models/manageiq/providers/vmware/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/refresher_spec.rb
@@ -234,7 +234,7 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(v.hardware.disks.first).to have_attributes(
       :device_name     => "Hard disk 1",
       :device_type     => "disk",
-      :controller_type => "SCSI Controller",
+      :controller_type => "LSI Logic Parallel SCSI controller",
       :size            => 17_179_869_184,
     )
     expect(v.hardware.guest_devices.size).to eq(0)
@@ -320,7 +320,7 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(v.hardware.disks.first).to have_attributes(
       :device_name     => "Hard disk 1",
       :device_type     => "disk",
-      :controller_type => "SCSI Controller",
+      :controller_type => "LSI Logic Parallel SCSI controller",
       :size            => 17_179_869_184,
     )
     expect(v.hardware.guest_devices.size).to eq(0)


### PR DESCRIPTION
Disk controller type parsing was completely wrong, since it relied on

a) parent disk
b) description

But there is no such thing as "parent disk", `disk.parent` actually points to "parent controller". Inventoring crashed hard when such "parent disk" was not found!

With this commit we update refresh parser to now properly inventory controller type based on disk's bus subtype. Also, we prevent distinguising real disks from simple ones (like CD) based on "disk.description", which is rather unreliable, and now distinguish based on disk's bus type.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1553124

@miq-bot add_label enhancement,gaprindashvili/yes
@miq-bot assign @agrare 