### PR TITLE
Shift fog-vcloud-director version to 0.1.9

### DIFF
--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency("fog-vcloud-director", ["~> 0.1.8"])
+  s.add_dependency("fog-vcloud-director", ["~> 0.1.9"])
   s.add_dependency "fog-core",                "~>1.40"
   s.add_dependency "vmware_web_service",      "~>0.2.6"
   s.add_dependency "rbvmomi",                 "~>1.11.3"


### PR DESCRIPTION
VApp Template provisioning uses some features that were only supported in 0.1.9 version of the gem. With this commit we make sure that it will actually get installed.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1552842

@miq-bot add_label enhancement,gaprindashvili/yes
@miq-bot assign @agrare 