### PR TITLE
Fix update driven vm refresh operating systems

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/inventory_collections.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/inventory_collections.rb
@@ -51,5 +51,10 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::InventoryCollections
       attributes = {:parent_inventory_collections => [:vms_and_templates]}
       super(attributes.merge(extra_attributes))
     end
+
+    def operating_systems(extra_attributes = {})
+      attributes = {:parent_inventory_collections => [:vms_and_templates]}
+      super(attributes.merge(extra_attributes))
+    end
   end
 end


### PR DESCRIPTION
The parent collection for operating systems needs to be
:vms_and_templates not [:vms, :miq_templates]