### PR TITLE
Implement graph inventory refresh for cloud manager

### DIFF
--- a/app/models/manageiq/providers/vmware/builder.rb
+++ b/app/models/manageiq/providers/vmware/builder.rb
@@ -1,0 +1,30 @@
+class ManageIQ::Providers::Vmware::Builder
+  class << self
+    def build_inventory(ems, target)
+      cloud_manager_inventory(ems, target)
+    end
+
+    private
+
+    def cloud_manager_inventory(ems, target)
+      inventory(
+        ems,
+        target,
+        ManageIQ::Providers::Vmware::Inventory::Collector::CloudManager,
+        ManageIQ::Providers::Vmware::Inventory::Persister::CloudManager,
+        [ManageIQ::Providers::Vmware::Inventory::Parser::CloudManager]
+      )
+    end
+
+    def inventory(manager, raw_target, collector_class, persister_class, parsers_classes)
+      collector = collector_class.new(manager, raw_target)
+      persister = persister_class.new(manager, raw_target)
+
+      ::ManageIQ::Providers::Vmware::Inventory.new(
+        persister,
+        collector,
+        parsers_classes.map(&:new)
+      )
+    end
+  end
+end

--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -15,6 +15,8 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
   include ManageIQ::Providers::Vmware::CloudManager::ManagerEventsMixin
   include HasNetworkManagerMixin
 
+  has_many :snapshots, :through => :vms_and_templates
+
   before_create :ensure_managers
 
   def ensure_network_manager

--- a/app/models/manageiq/providers/vmware/cloud_manager/refresher.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/refresher.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Vmware::CloudManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
+class ManageIQ::Providers::Vmware::CloudManager::Refresher < ManageIQ::Providers::BaseManager::ManagerRefresher
   include ::EmsRefresh::Refreshers::EmsRefresherMixin
 
   def parse_legacy_inventory(ems)

--- a/app/models/manageiq/providers/vmware/cloud_manager/snapshot.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/snapshot.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Vmware::CloudManager::Snapshot < ::Snapshot
+end

--- a/app/models/manageiq/providers/vmware/inventory.rb
+++ b/app/models/manageiq/providers/vmware/inventory.rb
@@ -1,0 +1,5 @@
+class ManageIQ::Providers::Vmware::Inventory < ManagerRefresh::Inventory
+  require_nested :Collector
+  require_nested :Parser
+  require_nested :Persister
+end

--- a/app/models/manageiq/providers/vmware/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/inventory/collector.rb
@@ -1,0 +1,26 @@
+class ManageIQ::Providers::Vmware::Inventory::Collector < ManagerRefresh::Inventory::Collector
+  require_nested :CloudManager
+
+  def initialize(_manager, _target)
+    super
+
+    initialize_inventory_sources
+  end
+
+  def initialize_inventory_sources
+    @orgs           = []
+    @vdcs           = []
+    @vapps          = []
+    @vms            = []
+    @vapp_templates = []
+    @images         = []
+  end
+
+  def connection
+    @connection ||= manager.connect
+  end
+
+  def public_images?
+    options.try(:get_public_images)
+  end
+end

--- a/app/models/manageiq/providers/vmware/inventory/collector/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/inventory/collector/cloud_manager.rb
@@ -1,0 +1,64 @@
+class ManageIQ::Providers::Vmware::Inventory::Collector::CloudManager < ManageIQ::Providers::Vmware::Inventory::Collector
+  VAPP_TEMPLATE_STATUS_READY = "8".freeze
+
+  def orgs
+    return @orgs if @orgs.any?
+    @orgs = connection.organizations
+  end
+
+  def vdcs
+    return @vdcs if @vdcs.any?
+    @vdcs = orgs.each_with_object([]) do |org, res|
+      res.concat(org.vdcs.all)
+    end
+  end
+
+  def vapps
+    return @vapps if @vapps.any?
+    @vapps = vdcs.each_with_object([]) do |vdc, res|
+      res.concat(vdc.vapps.all)
+    end
+  end
+
+  def vms
+    return @vms if @vms.any?
+    @vms = vapps.each_with_object([]) do |vapp, res|
+      # Remove this each loop, once fog api will be updated to send hostname and snapshot together with vms
+      vapp.vms.each do |vm|
+        res << {
+          :vm       => vm,
+          :hostname => vm.customization.try(:computer_name),
+          :snapshot => connection.get_snapshot_section(vm.id).try(:data)
+        }
+      end
+    end
+  end
+
+  def vapp_templates
+    return @vapp_templates if @vapp_templates.any?
+    @vapp_templates = orgs.each_with_object([]) do |org, res|
+      org.catalogs.each do |catalog|
+        next if !public_images? && catalog.is_published
+
+        catalog.catalog_items.each do |item|
+          # Skip all Catalog Items which are not vApp Templates (e.g. Media & Other)
+          next unless item.vapp_template_id.starts_with?('vappTemplate-')
+          next unless (t = item.vapp_template) && t.status == VAPP_TEMPLATE_STATUS_READY
+
+          res << {
+            :vapp_template => t,
+            :is_published  => catalog.is_published,
+            :content       => connection.get_vapp_template_ovf_descriptor(t.id).try(:body)
+          }
+        end
+      end
+    end
+  end
+
+  def images
+    return @images if @images.any?
+    @images = vapp_templates.each_with_object([]) do |template_obj, res|
+      res.concat(template_obj[:vapp_template].vms.map { |image| { :image => image, :is_published => template_obj[:is_published] } })
+    end
+  end
+end

--- a/app/models/manageiq/providers/vmware/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/inventory/parser.rb
@@ -1,0 +1,26 @@
+class ManageIQ::Providers::Vmware::Inventory::Parser < ManagerRefresh::Inventory::Parser
+  require_nested :CloudManager
+
+  # See https://pubs.vmware.com/vcd-80/index.jsp#com.vmware.vcloud.api.sp.doc_90/GUID-E1BA999D-87FA-4E2C-B638-24A211AB8160.html
+  def controller_description(bus_subtype)
+    case bus_subtype
+    when 'buslogic'
+      'BusLogic Parallel SCSI controller'
+    when 'lsilogic'
+      'LSI Logic Parallel SCSI controller'
+    when 'lsilogicsas'
+      'LSI Logic SAS SCSI controller'
+    when 'VirtualSCSI'
+      'Paravirtual SCSI controller'
+    when 'vmware.sata.ahci'
+      'SATA controller'
+    else
+      'IDE controller'
+    end
+  end
+
+  # See https://pubs.vmware.com/vcd-80/index.jsp#com.vmware.vcloud.api.sp.doc_90/GUID-E1BA999D-87FA-4E2C-B638-24A211AB8160.html
+  def hdd?(bus_type)
+    [5, 6, 20].include?(bus_type)
+  end
+end

--- a/app/models/manageiq/providers/vmware/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/inventory/parser/cloud_manager.rb
@@ -1,0 +1,102 @@
+class ManageIQ::Providers::Vmware::Inventory::Parser::CloudManager < ManageIQ::Providers::Vmware::Inventory::Parser
+  def parse
+    vdcs
+    vapps
+    vms
+    vapp_templates
+    images
+  end
+
+  private
+
+  def vdcs
+    collector.vdcs.each do |vdc|
+      persister.availability_zones.find_or_build(vdc.id).assign_attributes(
+        :name => vdc.name
+      )
+    end
+  end
+
+  def vapps
+    collector.vapps.each do |vapp|
+      persister.orchestration_stacks.find_or_build(vapp.id).assign_attributes(
+        :name        => vapp.name,
+        :description => vapp.name,
+        :status      => vapp.human_status,
+      )
+    end
+  end
+
+  def vms
+    collector.vms.each do |vm|
+      parsed_vm = persister.vms.find_or_build(vm[:vm].id).assign_attributes(
+        :uid_ems             => vm[:vm].id,
+        :name                => vm[:vm].name,
+        :hostname            => vm[:hostname],
+        :vendor              => 'vmware',
+        :raw_power_state     => vm[:vm].status,
+        :orchestration_stack => persister.orchestration_stacks.lazy_find(vm[:vm].vapp_id),
+        :snapshots           => []
+      )
+
+      if (resp = vm[:snapshot]) && (snapshot = resp.fetch_path(:body, :Snapshot))
+        uid = "#{vm[:vm].id}_#{snapshot[:created]}"
+        persister.snapshots.find_or_build_by(:vm_or_template => parsed_vm, :ems_ref => uid).assign_attributes(
+          :name        => "#{vm[:vm].name} (snapshot)",
+          :uid         => uid,
+          :parent_uid  => vm[:vm].id,
+          :create_time => Time.zone.parse(snapshot[:created]),
+          :total_size  => snapshot[:size]
+        )
+      end
+
+      hardware = persister.hardwares.find_or_build(parsed_vm).assign_attributes(
+        :guest_os             => vm[:vm].operating_system,
+        :guest_os_full_name   => vm[:vm].operating_system,
+        :bitness              => vm[:vm].operating_system =~ /64-bit/ ? 64 : 32,
+        :cpu_sockets          => vm[:vm].cpu,
+        :cpu_cores_per_socket => 1,
+        :cpu_total_cores      => vm[:vm].cpu,
+        :memory_mb            => vm[:vm].memory,
+        :disk_capacity        => vm[:vm].hard_disks.inject(0) { |sum, x| sum + x.values[0] } * 1.megabyte,
+      )
+
+      vm[:vm].disks.all.select { |d| hdd? d.bus_type }.map do |disk|
+        persister.disks.find_or_build_by(:hardware => hardware, :device_name => disk.name).assign_attributes(
+          :device_type     => 'disk',
+          :controller_type => controller_description(disk.bus_sub_type),
+          :size            => disk.capacity * 1.megabyte,
+          :location        => "#{vm[:vm].id}-#{disk.id}",
+          :filename        => "#{vm[:vm].id}-#{disk.id}",
+        )
+      end
+
+      persister.operating_systems.find_or_build(parsed_vm).assign_attributes(
+        :product_name => vm[:vm].operating_system,
+      )
+    end
+  end
+
+  def vapp_templates
+    collector.vapp_templates.each do |vapp_template|
+      persister.orchestration_templates.find_or_build(vapp_template[:vapp_template].id).assign_attributes(
+        :name        => vapp_template[:vapp_template].name,
+        :description => vapp_template[:vapp_template].description,
+        :orderable   => true,
+        :content     => "<!-- #{vapp_template[:vapp_template].id} -->\n#{vapp_template[:content]}",
+      )
+    end
+  end
+
+  def images
+    collector.images.each do |image|
+      persister.miq_templates.find_or_build(image[:image].id).assign_attributes(
+        :uid_ems            => image[:image].id,
+        :name               => image[:image].name,
+        :vendor             => 'vmware',
+        :raw_power_state    => 'never',
+        :publicly_available => image[:is_published]
+      )
+    end
+  end
+end

--- a/app/models/manageiq/providers/vmware/inventory/persister.rb
+++ b/app/models/manageiq/providers/vmware/inventory/persister.rb
@@ -1,0 +1,26 @@
+class ManageIQ::Providers::Vmware::Inventory::Persister < ManagerRefresh::Inventory::Persister
+  require_nested :CloudManager
+
+  protected
+
+  def cloud
+    ManageIQ::Providers::Vmware::InventoryCollectionDefault::CloudManager
+  end
+
+  def targeted
+    false
+  end
+
+  def strategy
+    nil
+  end
+
+  def shared_options
+    settings_options = options[:inventory_collections].try(:to_hash) || {}
+
+    settings_options.merge(
+      :strategy => strategy,
+      :targeted => targeted,
+    )
+  end
+end

--- a/app/models/manageiq/providers/vmware/inventory/persister/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/inventory/persister/cloud_manager.rb
@@ -1,0 +1,18 @@
+class ManageIQ::Providers::Vmware::Inventory::Persister::CloudManager < ManageIQ::Providers::Vmware::Inventory::Persister
+  def initialize_inventory_collections
+    add_inventory_collections(
+      cloud,
+      %i(
+        availability_zones
+        orchestration_stacks
+        vms
+        snapshots
+        hardwares
+        disks
+        operating_systems
+        orchestration_templates
+        miq_templates
+      )
+    )
+  end
+end

--- a/app/models/manageiq/providers/vmware/inventory_collection_default/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/inventory_collection_default/cloud_manager.rb
@@ -1,0 +1,150 @@
+class ManageIQ::Providers::Vmware::InventoryCollectionDefault::CloudManager < ManagerRefresh::InventoryCollectionDefault::CloudManager
+  class << self
+    def availability_zones(extra_attributes = {})
+      attributes = {
+        :model_class                 => ::ManageIQ::Providers::Vmware::CloudManager::AvailabilityZone,
+        :inventory_object_attributes => %i(
+          type
+          ems_id
+          ems_ref
+          name
+        )
+      }
+
+      super(attributes.merge!(extra_attributes))
+    end
+
+    def orchestration_stacks(extra_attributes = {})
+      attributes = {
+        :model_class                 => ::ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack,
+        :inventory_object_attributes => %i(
+          type
+          ems_id
+          ems_ref
+          name
+          description
+          status
+        )
+      }
+
+      super(attributes.merge!(extra_attributes))
+    end
+
+    def vms(extra_attributes = {})
+      attributes = {
+        :model_class                 => ::ManageIQ::Providers::Vmware::CloudManager::Vm,
+        :inventory_object_attributes => %i(
+          type
+          uid_ems
+          ems_ref
+          name
+          hostname
+          vendor
+          raw_power_state
+          snapshots
+          hardware
+          operating_system
+          orchestration_stack
+        )
+      }
+
+      super(attributes.merge!(extra_attributes))
+    end
+
+    def snapshots(extra_attributes = {})
+      attributes = {
+        :model_class                 => ::ManageIQ::Providers::Vmware::CloudManager::Snapshot,
+        :inventory_object_attributes => %i(
+          type
+          name
+          uid
+          ems_ref
+          parent_uid
+          create_time
+          total_size
+        ),
+      }
+
+      super(attributes.merge!(extra_attributes))
+    end
+
+    def hardwares(extra_attributes = {})
+      attributes = {
+        :inventory_object_attributes => %i(
+          guest_os
+          guest_os_full_name
+          bitness
+          cpu_sockets
+          cpu_cores_per_socket
+          cpu_total_cores
+          memory_mb
+          disk_capacity
+          disks
+        )
+      }
+
+      super(attributes.merge!(extra_attributes))
+    end
+
+    def disks(extra_attributes = {})
+      attributes = {
+        :inventory_object_attributes => %i(
+          device_name
+          device_type
+          controller_type
+          size
+          location
+          filename
+        )
+      }
+
+      super(attributes.merge!(extra_attributes))
+    end
+
+    def operating_systems(extra_attributes = {})
+      attributes = {
+        :inventory_object_attributes => %i(
+          product_name
+        )
+      }
+
+      super(attributes.merge!(extra_attributes))
+    end
+
+    def orchestration_templates(extra_attributes = {})
+      attributes = {
+        :model_class                 => ::ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate,
+        :inventory_object_attributes => %i(
+          type
+          ems_ref
+          name
+          description
+          orderable
+          content
+          ems_id
+        ),
+        :builder_params              => {
+          :ems_id => ->(persister) { persister.manager.id },
+        }
+      }
+
+      super(attributes.merge!(extra_attributes))
+    end
+
+    def miq_templates(extra_attributes = {})
+      attributes = {
+        :model_class                 => ::ManageIQ::Providers::Vmware::CloudManager::Template,
+        :inventory_object_attributes => %i(
+          uid_ems
+          ems_ref
+          name
+          vendor
+          raw_power_state
+          publicly_available
+        )
+      }
+
+      super(attributes.merge!(extra_attributes))
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,6 +12,7 @@
           :critical:
 :ems_refresh:
   :vmware_cloud:
+    :inventory_object_refresh: false
     :get_public_images: false
 :http_proxy:
   :vmware_cloud:

--- a/spec/models/manageiq/providers/vmware/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/refresher_spec.rb
@@ -1,4 +1,31 @@
 describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
+  ALL_REFRESH_SETTINGS = [
+    {
+      :inventory_object_refresh => false
+    },
+    {
+      :inventory_object_refresh => true,
+      :inventory_collections    => {
+        :saver_strategy => :default,
+      },
+    }, {
+      :inventory_object_refresh => true,
+      :inventory_collections    => {
+        :saver_strategy => :batch,
+        :use_ar_object  => true,
+      },
+    }, {
+      :inventory_object_refresh => true,
+      :inventory_collections    => {
+        :saver_strategy => :batch,
+        :use_ar_object  => false,
+      },
+    }, {
+      :inventory_object_saving_strategy => :recursive,
+      :inventory_object_refresh         => true
+    }
+  ].freeze
+
   before do
     @host = Rails.application.secrets.vmware_cloud.try(:[], 'host') || 'vmwarecloudhost'
     host_uri = URI.parse("https://#{@host}")
@@ -36,27 +63,39 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     @ems.authentications << FactoryGirl.create(:authentication, cred)
   end
 
-  it ".ems_type" do
+  it '.ems_type' do
     expect(described_class.ems_type).to eq(:vmware_cloud)
   end
 
-  it "will perform a full refresh" do
-    2.times do # Run twice to verify that a second run with existing data does not change anything
-      @ems.reload
-      VCR.use_cassette(described_class.name.underscore, :allow_unused_http_interactions => true) do
-        EmsRefresh.refresh(@ems)
+  ALL_REFRESH_SETTINGS.each do |settings|
+    context "with settings #{settings}" do
+      before(:each) do
+        stub_settings_merge(
+          :ems_refresh => {
+            :vmware_cloud => settings
+          }
+        )
       end
-      @ems.reload
 
-      assert_specific_orchestration_stack
-      assert_table_counts
-      assert_ems
-      assert_specific_vdc
-      assert_specific_template
-      assert_specific_vm_powered_on
-      assert_specific_vm_powered_off
-      assert_specific_orchestration_template
-      assert_specific_vm_with_snapshot
+      it 'will perform a full refresh' do
+        2.times do
+          @ems.reload
+          VCR.use_cassette(described_class.name.underscore, :allow_unused_http_interactions => true) do
+            EmsRefresh.refresh(@ems)
+          end
+          @ems.reload
+
+          assert_specific_orchestration_stack
+          assert_table_counts
+          assert_ems
+          assert_specific_vdc
+          assert_specific_template
+          assert_specific_vm_powered_on
+          assert_specific_vm_powered_off
+          assert_specific_orchestration_template
+          assert_specific_vm_with_snapshot
+        end
+      end
     end
   end
 
@@ -68,32 +107,32 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(AuthPrivateKey.count).to eq(0)
     expect(CloudNetwork.count).to eq(0)
     expect(CloudSubnet.count).to eq(0)
-    expect(OrchestrationTemplate.count).to eq(4)
+    expect(OrchestrationTemplate.count).to eq(1)
     expect(OrchestrationStack.count).to eq(3)
     expect(OrchestrationStackParameter.count).to eq(0)
     expect(OrchestrationStackOutput.count).to eq(0)
     expect(OrchestrationStackResource.count).to eq(0)
     expect(SecurityGroup.count).to eq(0)
     expect(FirewallRule.count).to eq(0)
-    expect(VmOrTemplate.count).to eq(8)
+    expect(VmOrTemplate.count).to eq(4)
     expect(Vm.count).to eq(3)
-    expect(MiqTemplate.count).to eq(5)
+    expect(MiqTemplate.count).to eq(1)
 
     expect(CustomAttribute.count).to eq(0)
     expect(Disk.count).to eq(3)
     expect(GuestDevice.count).to eq(0)
     expect(Hardware.count).to eq(3)
     expect(OperatingSystem.count).to eq(3)
-    expect(Snapshot.count).to eq(2)
+    expect(Snapshot.count).to eq(1)
     expect(SystemService.count).to eq(0)
 
     expect(Relationship.count).to eq(0)
-    expect(MiqQueue.count).to eq(9)
+    expect(MiqQueue.count).to eq(5)
   end
 
   def assert_ems
     expect(@ems).to have_attributes(
-      :api_version => "5.5",
+      :api_version => '5.5',
       :uid_ems     => nil
     )
 
@@ -103,37 +142,37 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(@ems.key_pairs.size).to eq(0)
     expect(@ems.cloud_networks.count).to eq(0)
     expect(@ems.security_groups.count).to eq(0)
-    expect(@ems.vms_and_templates.size).to eq(8)
+    expect(@ems.vms_and_templates.size).to eq(4)
     expect(@ems.vms.size).to eq(3)
-    expect(@ems.miq_templates.size).to eq(5)
+    expect(@ems.miq_templates.size).to eq(1)
     expect(@ems.orchestration_stacks.size).to eq(3)
-    expect(@ems.orchestration_templates.size).to eq(4)
+    expect(@ems.orchestration_templates.size).to eq(1)
 
     expect(@ems.direct_orchestration_stacks.size).to eq(3)
   end
 
   def assert_specific_vdc
-    @vdc = ManageIQ::Providers::Vmware::CloudManager::AvailabilityZone.where(:name => "MIQDev-Default-vCD-DualSiteStorage-PAYG").first
+    @vdc = ManageIQ::Providers::Vmware::CloudManager::AvailabilityZone.where(:name => 'MIQ Devel VDC').first
     expect(@vdc).to have_attributes(
       :ems_id  => @ems.id,
-      :name    => "MIQDev-Default-vCD-DualSiteStorage-PAYG",
-      :ems_ref => "89ade969-1dc4-4156-abad-e29f79511676",
-      :type    => "ManageIQ::Providers::Vmware::CloudManager::AvailabilityZone"
+      :name    => 'MIQ Devel VDC',
+      :ems_ref => '0946827a-1a9e-4b9f-8ea3-732b3afe47c6',
+      :type    => 'ManageIQ::Providers::Vmware::CloudManager::AvailabilityZone'
     )
   end
 
   def assert_specific_template
-    @template = ManageIQ::Providers::Vmware::CloudManager::Template.where(:name => "CentOS7").first
+    @template = ManageIQ::Providers::Vmware::CloudManager::Template.where(:name => 'spec2-vm1').first
     expect(@template).not_to be_nil
     expect(@template).to have_attributes(
       :template              => true,
-      :ems_ref               => "vm-857551b6-380c-44d0-ab34-9d144866f0b4",
+      :ems_ref               => 'vm-ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6',
       :ems_ref_obj           => nil,
-      :uid_ems               => "vm-857551b6-380c-44d0-ab34-9d144866f0b4",
-      :vendor                => "vmware",
-      :power_state           => "never",
+      :uid_ems               => 'vm-ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6',
+      :vendor                => 'vmware',
+      :power_state           => 'never',
       :publicly_available    => false,
-      :location              => "unknown",
+      :location              => 'unknown',
       :tools_status          => nil,
       :boot_time             => nil,
       :standby_action        => nil,
@@ -158,15 +197,15 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
   end
 
   def assert_specific_vm_powered_on
-    v = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "spec1-vm1")
+    v = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => 'spec1-vm1')
     expect(v).to have_attributes(
       :template              => false,
-      :ems_ref               => "vm-f9ceb77c-b9d9-400c-8c06-72c785e884af",
+      :ems_ref               => 'vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2',
       :ems_ref_obj           => nil,
-      :uid_ems               => "vm-f9ceb77c-b9d9-400c-8c06-72c785e884af",
-      :vendor                => "vmware",
-      :power_state           => "on",
-      :location              => "unknown",
+      :uid_ems               => 'vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2',
+      :vendor                => 'vmware',
+      :power_state           => 'on',
+      :location              => 'unknown',
       :tools_status          => nil,
       :boot_time             => nil,
       :standby_action        => nil,
@@ -182,7 +221,7 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
       :cpu_limit             => nil,
       :cpu_shares            => nil,
       :cpu_shares_level      => nil,
-      :hostname              => 'WebServerVM'
+      :hostname              => 'spec1-vm1'
     )
 
     expect(v.ext_management_system).to eq(@ems)
@@ -195,7 +234,7 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(v.security_groups.size).to eq(0)
 
     expect(v.operating_system).to have_attributes(
-      :product_name => "CentOS 4/5/6/7 (64-bit)",
+      :product_name => 'Microsoft Windows Server 2016 (64-bit)',
     )
     expect(v.custom_attributes.size).to eq(0)
     expect(v.snapshots.size).to eq(0)
@@ -203,28 +242,28 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(v.hardware).to have_attributes(
       :config_version       => nil,
       :virtual_hw_version   => nil,
-      :guest_os             => "CentOS 4/5/6/7 (64-bit)",
-      :guest_os_full_name   => "CentOS 4/5/6/7 (64-bit)",
-      :cpu_sockets          => 2,
+      :guest_os             => 'Microsoft Windows Server 2016 (64-bit)',
+      :guest_os_full_name   => 'Microsoft Windows Server 2016 (64-bit)',
+      :cpu_sockets          => 1,
       :bios                 => nil,
       :bios_location        => nil,
       :time_sync            => nil,
       :annotation           => nil,
-      :memory_mb            => 2048,
+      :memory_mb            => 512,
       :host_id              => nil,
       :cpu_speed            => nil,
       :cpu_type             => nil,
       :size_on_disk         => nil,
-      :manufacturer         => "",
-      :model                => "",
+      :manufacturer         => '',
+      :model                => '',
       :number_of_nics       => nil,
       :cpu_usage            => nil,
       :memory_usage         => nil,
       :cpu_cores_per_socket => 1,
-      :cpu_total_cores      => 2,
+      :cpu_total_cores      => 1,
       :vmotion_enabled      => nil,
       :disk_free_space      => nil,
-      :disk_capacity        => 17_179_869_184,
+      :disk_capacity        => 10_737_418_240,
       :memory_console       => nil,
       :bitness              => 64,
       :virtualization_type  => nil,
@@ -233,25 +272,25 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
 
     expect(v.hardware.disks.size).to eq(1)
     expect(v.hardware.disks.first).to have_attributes(
-      :device_name     => "Hard disk 1",
-      :device_type     => "disk",
-      :controller_type => "LSI Logic Parallel SCSI controller",
-      :size            => 17_179_869_184,
+      :device_name     => 'Hard disk 1',
+      :device_type     => 'disk',
+      :controller_type => 'LSI Logic SAS SCSI controller',
+      :size            => 10_737_418_240,
     )
     expect(v.hardware.guest_devices.size).to eq(0)
     expect(v.hardware.nics.size).to eq(0)
   end
 
   def assert_specific_vm_powered_off
-    v = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "spec2-vm1")
+    v = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => 'spec2-vm1')
     expect(v).to have_attributes(
       :template              => false,
-      :ems_ref               => "vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6",
+      :ems_ref               => 'vm-aaf94123-cbf9-4de9-841c-41dd41ac310e',
       :ems_ref_obj           => nil,
-      :uid_ems               => "vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6",
-      :vendor                => "vmware",
-      :power_state           => "off",
-      :location              => "unknown",
+      :uid_ems               => 'vm-aaf94123-cbf9-4de9-841c-41dd41ac310e',
+      :vendor                => 'vmware',
+      :power_state           => 'off',
+      :location              => 'unknown',
       :tools_status          => nil,
       :boot_time             => nil,
       :standby_action        => nil,
@@ -267,7 +306,7 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
       :cpu_limit             => nil,
       :cpu_shares            => nil,
       :cpu_shares_level      => nil,
-      :hostname              => 'WebServerVM3'
+      :hostname              => 'spec2-vm1'
     )
 
     expect(v.ext_management_system).to eq(@ems)
@@ -280,7 +319,7 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(v.security_groups.size).to eq(0)
 
     expect(v.operating_system).to have_attributes(
-      :product_name => "CentOS 4/5/6/7 (64-bit)",
+      :product_name => 'VMware Photon OS (64-bit)',
     )
 
     expect(v.custom_attributes.size).to eq(0)
@@ -289,25 +328,25 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(v.hardware).to have_attributes(
       :config_version       => nil,
       :virtual_hw_version   => nil,
-      :guest_os             => "CentOS 4/5/6/7 (64-bit)",
-      :guest_os_full_name   => "CentOS 4/5/6/7 (64-bit)",
-      :cpu_sockets          => 2,
+      :guest_os             => 'VMware Photon OS (64-bit)',
+      :guest_os_full_name   => 'VMware Photon OS (64-bit)',
+      :cpu_sockets          => 1,
       :bios                 => nil,
       :bios_location        => nil,
       :time_sync            => nil,
       :annotation           => nil,
-      :memory_mb            => 2048,
+      :memory_mb            => 256,
       :host_id              => nil,
       :cpu_speed            => nil,
       :cpu_type             => nil,
       :size_on_disk         => nil,
-      :manufacturer         => "",
-      :model                => "",
+      :manufacturer         => '',
+      :model                => '',
       :number_of_nics       => nil,
       :cpu_usage            => nil,
       :memory_usage         => nil,
       :cpu_cores_per_socket => 1,
-      :cpu_total_cores      => 2,
+      :cpu_total_cores      => 1,
       :vmotion_enabled      => nil,
       :disk_free_space      => nil,
       :disk_capacity        => 17_179_869_184,
@@ -319,9 +358,9 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
 
     expect(v.hardware.disks.size).to eq(1)
     expect(v.hardware.disks.first).to have_attributes(
-      :device_name     => "Hard disk 1",
-      :device_type     => "disk",
-      :controller_type => "LSI Logic Parallel SCSI controller",
+      :device_name     => 'Hard disk 1',
+      :device_type     => 'disk',
+      :controller_type => 'Paravirtual SCSI controller',
       :size            => 17_179_869_184,
     )
     expect(v.hardware.guest_devices.size).to eq(0)
@@ -330,40 +369,40 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
 
   def assert_specific_orchestration_stack
     @orchestration_stack1 = ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack
-                            .find_by(:name => "spec-1")
+                            .find_by(:name => 'spec1-vapp')
     @orchestration_stack2 = ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack
-                            .find_by(:name => "spec2")
-    vm1 = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "spec1-vm1")
-    vm2 = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "spec2-vm1")
+                            .find_by(:name => 'spec2-vapp')
+    vm1 = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => 'spec1-vm1')
+    vm2 = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => 'spec2-vm1')
 
     expect(vm1.orchestration_stack).to eq(@orchestration_stack1)
     expect(vm2.orchestration_stack).to eq(@orchestration_stack2)
   end
 
   def assert_specific_orchestration_template
-    @template = ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate.where(:name => "vApp_CentOS_and_msWin").first
+    @template = ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate.where(:name => 'spec2-vapp-win').first
     expect(@template).not_to be_nil
     expect(@template).to have_attributes(
-      :ems_ref   => "vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5",
+      :ems_ref   => 'vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910',
       :orderable => true,
     )
 
     expect(@template.ems_id).to eq(@ems.id)
     expect(@template.content.include?('ovf:Envelope')).to be_truthy
-    expect(@template.md5).to eq('vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5')
+    expect(@template.md5).to eq('vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910')
   end
 
   def assert_specific_vm_with_snapshot
-    vm = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "spec2-vm1")
+    vm = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => 'spec2-vm1')
 
     expect(vm.snapshots.first).not_to be_nil
     expect(vm.snapshots.first).to have_attributes(
-      :ems_ref    => 'vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6_2018-02-22T12:22:20.784+01:00',
-      :uid        => 'vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6_2018-02-22T12:22:20.784+01:00',
-      :parent_uid => 'vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6',
+      :ems_ref    => 'vm-aaf94123-cbf9-4de9-841c-41dd41ac310e_2018-03-12T15:43:30.986+01:00',
+      :uid        => 'vm-aaf94123-cbf9-4de9-841c-41dd41ac310e_2018-03-12T15:43:30.986+01:00',
+      :parent_uid => 'vm-aaf94123-cbf9-4de9-841c-41dd41ac310e',
       :name       => 'spec2-vm1 (snapshot)',
-      :total_size => 4_294_967_296
+      :total_size => 17_179_869_184
     )
-    expect(vm.snapshots.first.create_time.to_s).to eq('2018-02-22 11:22:20 UTC')
+    expect(vm.snapshots.first.create_time.to_s).to eq('2018-03-12 14:43:30 UTC')
   end
 end

--- a/spec/vcr_cassettes/manageiq/providers/vmware/cloud_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/vmware/cloud_manager/refresher.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.42.0
+      - fog-core/1.45.0
       Accept:
       - application/*+xml;version=5.1
       Authorization:
@@ -16,37 +16,37 @@ http_interactions:
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Date:
-      - Fri, 16 Sep 2016 08:51:45 GMT
+      - Wed, 14 Mar 2018 10:54:29 GMT
       X-Vmware-Vcloud-Request-Id:
-      - f2446fad-ab18-4c10-87e4-52cb884be531
+      - 78dce2f8-e931-4961-b950-3e127e64abc4
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
       Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '78'
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
       Content-Type:
       - application/vnd.vmware.vcloud.session+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '174'
       Content-Length:
-      - '1300'
+      - '1750'
     body:
       encoding: ASCII-8BIT
       string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <Session xmlns="http://www.vmware.com/vcloud/v1.5" org="MIQDev" user="bergigre_remote" href="https://VMWARE_CLOUD_HOST/api/session" type="application/vnd.vmware.vcloud.session+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <Session xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" org="miq-dev" user="administrator" href="https://VMWARE_CLOUD_HOST/api/session" type="application/vnd.vmware.vcloud.session+xml">
             <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/org/" type="application/vnd.vmware.vcloud.orgList+xml"/>
             <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/session"/>
             <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/admin/" type="application/vnd.vmware.admin.vcloud+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/org/e338a4ac-551b-4b6c-b5c0-aff31b71417f" name="MIQDev" type="application/vnd.vmware.vcloud.org+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/org/6d6733f6-536a-454f-bbc3-efee7f6de081" name="miq-dev" type="application/vnd.vmware.vcloud.org+xml"/>
             <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/query" type="application/vnd.vmware.vcloud.query.queryList+xml"/>
             <Link rel="entityResolver" href="https://VMWARE_CLOUD_HOST/api/entity/" type="application/vnd.vmware.vcloud.entity+xml"/>
             <Link rel="down:extensibility" href="https://VMWARE_CLOUD_HOST/api/extensibility" type="application/vnd.vmware.vcloud.apiextensibility+xml"/>
         </Session>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:51:46 GMT
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:29 GMT
 - request:
     method: get
     uri: https://VMWARE_CLOUD_HOST/api/org
@@ -55,221 +55,181 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.42.0
+      - fog-core/1.45.0
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Date:
-      - Fri, 16 Sep 2016 08:51:51 GMT
+      - Wed, 14 Mar 2018 10:54:29 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 2402f385-6a7a-4418-acfa-c516eb59d40b
+      - 736ffdd9-a391-4fb4-a452-8cb8f4adfdc0
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
       Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '80'
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
       Content-Type:
       - application/vnd.vmware.vcloud.orglist+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '4'
       Vary:
       - Accept-Encoding, User-Agent
       Content-Length:
-      - '520'
+      - '1049'
     body:
       encoding: ASCII-8BIT
       string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <OrgList xmlns="http://www.vmware.com/vcloud/v1.5" href="https://VMWARE_CLOUD_HOST/api/org/" type="application/vnd.vmware.vcloud.orgList+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Org href="https://VMWARE_CLOUD_HOST/api/org/e338a4ac-551b-4b6c-b5c0-aff31b71417f" name="MIQDev" type="application/vnd.vmware.vcloud.org+xml"/>
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <OrgList xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/org/" type="application/vnd.vmware.vcloud.orgList+xml">
+            <Org href="https://VMWARE_CLOUD_HOST/api/org/6d6733f6-536a-454f-bbc3-efee7f6de081" name="miq-dev" type="application/vnd.vmware.vcloud.org+xml"/>
         </OrgList>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:51:51 GMT
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:29 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/org/e338a4ac-551b-4b6c-b5c0-aff31b71417f
+    uri: https://VMWARE_CLOUD_HOST/api/org/6d6733f6-536a-454f-bbc3-efee7f6de081
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.42.0
+      - fog-core/1.45.0
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Date:
-      - Fri, 16 Sep 2016 08:51:56 GMT
+      - Wed, 14 Mar 2018 10:54:29 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 3522e3c9-1d5e-4728-9348-0fc2622e3c1b
+      - 7f0f4f42-f231-4c51-97f7-82d3fb63d74a
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
       Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '87'
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
       Content-Type:
       - application/vnd.vmware.vcloud.org+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '117'
       Vary:
       - Accept-Encoding, User-Agent
       Content-Length:
-      - '2589'
+      - '3075'
     body:
       encoding: ASCII-8BIT
-      string: !binary |-
-        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPE9yZyB4
-        bWxucz0iaHR0cDovL3d3dy52bXdhcmUuY29tL3ZjbG91ZC92MS41IiBuYW1l
-        PSJNSVFEZXYiIGlkPSJ1cm46dmNsb3VkOm9yZzplMzM4YTRhYy01NTFiLTRi
-        NmMtYjVjMC1hZmYzMWI3MTQxN2YiIGhyZWY9Imh0dHBzOi8vVk1XQVJFX0NM
-        T1VEX0hPU1QvYXBpL29yZy9lMzM4YTRhYy01NTFiLTRiNmMtYjVjMC1hZmYz
-        MWI3MTQxN2YiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3Vk
-        Lm9yZyt4bWwiIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9Y
-        TUxTY2hlbWEtaW5zdGFuY2UiIHhzaTpzY2hlbWFMb2NhdGlvbj0iaHR0cDov
-        L3d3dy52bXdhcmUuY29tL3ZjbG91ZC92MS41IGh0dHA6Ly9WTVdBUkVfQ0xP
-        VURfSE9TVC9hcGkvdjEuNS9zY2hlbWEvbWFzdGVyLnhzZCI+CiAgICA8TGlu
-        ayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vVk1XQVJFX0NMT1VEX0hPU1Qv
-        YXBpL3ZkYy84OWFkZTk2OS0xZGM0LTQxNTYtYWJhZC1lMjlmNzk1MTE2NzYi
-        IG5hbWU9Ik1JUURldi1EZWZhdWx0LXZDRC1EdWFsU2l0ZVN0b3JhZ2UtUEFZ
-        RyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudmRjK3ht
-        bCIvPgogICAgPExpbmsgcmVsPSJkb3duIiBocmVmPSJodHRwczovL1ZNV0FS
-        RV9DTE9VRF9IT1NUL2FwaS90YXNrc0xpc3QvZTMzOGE0YWMtNTUxYi00YjZj
-        LWI1YzAtYWZmMzFiNzE0MTdmIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13
-        YXJlLnZjbG91ZC50YXNrc0xpc3QreG1sIi8+CiAgICA8TGluayByZWw9ImRv
-        d24iIGhyZWY9Imh0dHBzOi8vVk1XQVJFX0NMT1VEX0hPU1QvYXBpL2NhdGFs
-        b2cvMDQ5MGFkM2ItZjM0My00YjgwLThkNWItZWNiMDM5N2ZkNDEyIiBuYW1l
-        PSJTaGFyZWQgVGlldG8gQ2F0YWxvZyIgdHlwZT0iYXBwbGljYXRpb24vdm5k
-        LnZtd2FyZS52Y2xvdWQuY2F0YWxvZyt4bWwiLz4KICAgIDxMaW5rIHJlbD0i
-        ZG93biIgaHJlZj0iaHR0cHM6Ly9WTVdBUkVfQ0xPVURfSE9TVC9hcGkvY2F0
-        YWxvZy8wNDkwYWQzYi1mMzQzLTRiODAtOGQ1Yi1lY2IwMzk3ZmQ0MTIvY29u
-        dHJvbEFjY2Vzcy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNs
-        b3VkLmNvbnRyb2xBY2Nlc3MreG1sIi8+CiAgICA8TGluayByZWw9ImRvd24i
-        IGhyZWY9Imh0dHBzOi8vVk1XQVJFX0NMT1VEX0hPU1QvYXBpL2NhdGFsb2cv
-        MjYxMDM3YmMtODI5OS00MmMxLTlhYzEtYjhjNGM5NjRkOTlkIiBuYW1lPSJY
-        VGVzdENhdGFsb2ciIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNs
-        b3VkLmNhdGFsb2creG1sIi8+CiAgICA8TGluayByZWw9ImRvd24iIGhyZWY9
-        Imh0dHBzOi8vVk1XQVJFX0NMT1VEX0hPU1QvYXBpL2NhdGFsb2cvMjYxMDM3
-        YmMtODI5OS00MmMxLTlhYzEtYjhjNGM5NjRkOTlkL2NvbnRyb2xBY2Nlc3Mv
-        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5jb250cm9s
-        QWNjZXNzK3htbCIvPgogICAgPExpbmsgcmVsPSJjb250cm9sQWNjZXNzIiBo
-        cmVmPSJodHRwczovL1ZNV0FSRV9DTE9VRF9IT1NUL2FwaS9jYXRhbG9nLzI2
-        MTAzN2JjLTgyOTktNDJjMS05YWMxLWI4YzRjOTY0ZDk5ZC9hY3Rpb24vY29u
-        dHJvbEFjY2VzcyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xv
-        dWQuY29udHJvbEFjY2Vzcyt4bWwiLz4KICAgIDxMaW5rIHJlbD0iYWRkIiBo
-        cmVmPSJodHRwczovL1ZNV0FSRV9DTE9VRF9IT1NUL2FwaS9hZG1pbi9vcmcv
-        ZTMzOGE0YWMtNTUxYi00YjZjLWI1YzAtYWZmMzFiNzE0MTdmL2NhdGFsb2dz
-        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLmFkbWluLmNhdGFsb2cr
-        eG1sIi8+CiAgICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vVk1X
-        QVJFX0NMT1VEX0hPU1QvYXBpL25ldHdvcmsvNWFlODQwZGUtMTk4ZS00YTM0
-        LWEzMGEtNmMzNjM3NzQ2MGM2IiBuYW1lPSJJTlRfMTkyLjE2OC4xMC4wbTI0
-        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5vcmdOZXR3
-        b3JrK3htbCIvPgogICAgPExpbmsgcmVsPSJkb3duIiBocmVmPSJodHRwczov
-        L1ZNV0FSRV9DTE9VRF9IT1NUL2FwaS9zdXBwb3J0ZWRTeXN0ZW1zSW5mby8i
-        IHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnN1cHBvcnRl
-        ZFN5c3RlbXNJbmZvK3htbCIvPgogICAgPExpbmsgcmVsPSJkb3duIiBocmVm
-        PSJodHRwczovL1ZNV0FSRV9DTE9VRF9IT1NUL2FwaS9vcmcvZTMzOGE0YWMt
-        NTUxYi00YjZjLWI1YzAtYWZmMzFiNzE0MTdmL21ldGFkYXRhIiB0eXBlPSJh
-        cHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5tZXRhZGF0YSt4bWwiLz4K
-        ICAgIDxEZXNjcmlwdGlvbj5Pcmdhbml6YXRpb24gZm9yIFJlZEhhdCBkZXZl
-        bG9wbWVudCBvZiBNYW5hZ2VJUSB2Q2xvdWQgY29ubmVjdG9yDUNvbnRhY3Qg
-        RGF2aWQgQmFydG/FoTwvRGVzY3JpcHRpb24+CiAgICA8RnVsbE5hbWU+TWFu
-        YWdlSVEgRGV2ZWxvcG1lbnQ8L0Z1bGxOYW1lPgo8L09yZz4K
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:51:57 GMT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <Org xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" name="miq-dev" id="urn:vcloud:org:6d6733f6-536a-454f-bbc3-efee7f6de081" href="https://VMWARE_CLOUD_HOST/api/org/6d6733f6-536a-454f-bbc3-efee7f6de081" type="application/vnd.vmware.vcloud.org+xml">
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6" name="MIQ Devel VDC" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/tasksList/6d6733f6-536a-454f-bbc3-efee7f6de081" type="application/vnd.vmware.vcloud.tasksList+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/d3e213db-d4fa-49e4-a940-5810ab811648" name="RedHat Catalog2" type="application/vnd.vmware.vcloud.catalog+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/d3e213db-d4fa-49e4-a940-5810ab811648/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/8fac6233-474c-44b4-a45b-87e488102170" name="My First Catalog" type="application/vnd.vmware.vcloud.catalog+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/8fac6233-474c-44b4-a45b-87e488102170/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="controlAccess" href="https://VMWARE_CLOUD_HOST/api/catalog/8fac6233-474c-44b4-a45b-87e488102170/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/admin/org/6d6733f6-536a-454f-bbc3-efee7f6de081/catalogs" type="application/vnd.vmware.admin.catalog+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/network/9e381434-a787-49b5-949e-5d67eff76a18" name="ManageIQ Development network" type="application/vnd.vmware.vcloud.orgNetwork+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/network/5038b60d-fbb8-42e8-8bf3-e711f703507c" name="ManageIQ Dev external network" type="application/vnd.vmware.vcloud.orgNetwork+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/supportedSystemsInfo/" type="application/vnd.vmware.vcloud.supportedSystemsInfo+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/org/6d6733f6-536a-454f-bbc3-efee7f6de081/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Description></Description>
+            <FullName>ManageIQ Development Org</FullName>
+        </Org>
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:29 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676
+    uri: https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.42.0
+      - fog-core/1.45.0
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Date:
-      - Fri, 16 Sep 2016 08:52:01 GMT
+      - Wed, 14 Mar 2018 10:54:30 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 8ccc9468-db65-4bc5-b4ba-18ee713a0a47
+      - c1cd45f3-94b4-4dd9-bb62-984b3494789f
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
       Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '54'
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
       Content-Type:
       - application/vnd.vmware.vcloud.vdc+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '168'
       Vary:
       - Accept-Encoding, User-Agent
       Content-Length:
-      - '6272'
+      - '6561'
     body:
       encoding: ASCII-8BIT
       string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <Vdc xmlns="http://www.vmware.com/vcloud/v1.5" status="1" name="MIQDev-Default-vCD-DualSiteStorage-PAYG" id="urn:vcloud:vdc:89ade969-1dc4-4156-abad-e29f79511676" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/org/e338a4ac-551b-4b6c-b5c0-aff31b71417f" type="application/vnd.vmware.vcloud.org+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676/action/uploadVAppTemplate" type="application/vnd.vmware.vcloud.uploadVAppTemplateParams+xml"/>
-            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676/media" type="application/vnd.vmware.vcloud.media+xml"/>
-            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676/action/instantiateOvf" type="application/vnd.vmware.vcloud.instantiateOvfParams+xml"/>
-            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676/action/instantiateVAppTemplate" type="application/vnd.vmware.vcloud.instantiateVAppTemplateParams+xml"/>
-            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676/action/cloneVApp" type="application/vnd.vmware.vcloud.cloneVAppParams+xml"/>
-            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676/action/cloneVAppTemplate" type="application/vnd.vmware.vcloud.cloneVAppTemplateParams+xml"/>
-            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676/action/cloneMedia" type="application/vnd.vmware.vcloud.cloneMediaParams+xml"/>
-            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676/action/captureVApp" type="application/vnd.vmware.vcloud.captureVAppParams+xml"/>
-            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676/action/composeVApp" type="application/vnd.vmware.vcloud.composeVAppParams+xml"/>
-            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676/disk" type="application/vnd.vmware.vcloud.diskCreateParams+xml"/>
-            <Link rel="edgeGateways" href="https://VMWARE_CLOUD_HOST/api/admin/vdc/89ade969-1dc4-4156-abad-e29f79511676/edgeGateways" type="application/vnd.vmware.vcloud.query.records+xml"/>
-            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/admin/vdc/89ade969-1dc4-4156-abad-e29f79511676/networks" type="application/vnd.vmware.vcloud.orgVdcNetwork+xml"/>
-            <Link rel="orgVdcNetworks" href="https://VMWARE_CLOUD_HOST/api/admin/vdc/89ade969-1dc4-4156-abad-e29f79511676/networks" type="application/vnd.vmware.vcloud.query.records+xml"/>
-            <Description/>
-            <AllocationModel>AllocationVApp</AllocationModel>
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <Vdc xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" status="1" name="MIQ Devel VDC" id="urn:vcloud:vdc:0946827a-1a9e-4b9f-8ea3-732b3afe47c6" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6" type="application/vnd.vmware.vcloud.vdc+xml">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/org/6d6733f6-536a-454f-bbc3-efee7f6de081" type="application/vnd.vmware.vcloud.org+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6/action/uploadVAppTemplate" type="application/vnd.vmware.vcloud.uploadVAppTemplateParams+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6/media" type="application/vnd.vmware.vcloud.media+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6/action/instantiateOvf" type="application/vnd.vmware.vcloud.instantiateOvfParams+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6/action/instantiateVAppTemplate" type="application/vnd.vmware.vcloud.instantiateVAppTemplateParams+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6/action/cloneVApp" type="application/vnd.vmware.vcloud.cloneVAppParams+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6/action/cloneVAppTemplate" type="application/vnd.vmware.vcloud.cloneVAppTemplateParams+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6/action/cloneMedia" type="application/vnd.vmware.vcloud.cloneMediaParams+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6/action/captureVApp" type="application/vnd.vmware.vcloud.captureVAppParams+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6/action/composeVApp" type="application/vnd.vmware.vcloud.composeVAppParams+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6/disk" type="application/vnd.vmware.vcloud.diskCreateParams+xml"/>
+            <Link rel="edgeGateways" href="https://VMWARE_CLOUD_HOST/api/admin/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6/edgeGateways" type="application/vnd.vmware.vcloud.query.records+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/admin/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6/networks" type="application/vnd.vmware.vcloud.orgVdcNetwork+xml"/>
+            <Link rel="orgVdcNetworks" href="https://VMWARE_CLOUD_HOST/api/admin/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6/networks" type="application/vnd.vmware.vcloud.query.records+xml"/>
+            <Description>Used for ManageIQ development.</Description>
+            <AllocationModel>AllocationPool</AllocationModel>
             <ComputeCapacity>
                 <Cpu>
                     <Units>MHz</Units>
-                    <Allocated>0</Allocated>
-                    <Limit>0</Limit>
-                    <Reserved>0</Reserved>
-                    <Used>2000</Used>
+                    <Allocated>5690</Allocated>
+                    <Limit>5690</Limit>
+                    <Reserved>2845</Reserved>
+                    <Used>0</Used>
                     <Overhead>0</Overhead>
                 </Cpu>
                 <Memory>
                     <Units>MB</Units>
-                    <Allocated>0</Allocated>
-                    <Limit>0</Limit>
-                    <Reserved>0</Reserved>
-                    <Used>2048</Used>
-                    <Overhead>48</Overhead>
+                    <Allocated>23439</Allocated>
+                    <Limit>23439</Limit>
+                    <Reserved>11719</Reserved>
+                    <Used>6656</Used>
+                    <Overhead>131</Overhead>
                 </Memory>
             </ComputeCapacity>
             <ResourceEntities>
-                <ResourceEntity href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" name="vApp_cankamat_remote_1" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                <ResourceEntity href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" name="vApp_CentOS_and_msWin" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                <ResourceEntity href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4" name="spec-1" type="application/vnd.vmware.vcloud.vApp+xml"/>
-                <ResourceEntity href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d" name="vApp_system_4" type="application/vnd.vmware.vcloud.vApp+xml"/>
-                <ResourceEntity href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd" name="spec2" type="application/vnd.vmware.vcloud.vApp+xml"/>
-                <ResourceEntity href="https://VMWARE_CLOUD_HOST/api/media/48ce1b6a-2c31-485d-a6ce-8f914c044459" name="CentOS 7" type="application/vnd.vmware.vcloud.media+xml"/>
+                <ResourceEntity href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910" name="spec2-vapp-win" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                <ResourceEntity href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172" name="spec1-vapp" type="application/vnd.vmware.vcloud.vApp+xml"/>
+                <ResourceEntity href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1" name="miq-devel-vm" type="application/vnd.vmware.vcloud.vApp+xml"/>
+                <ResourceEntity href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9" name="spec2-vapp" type="application/vnd.vmware.vcloud.vApp+xml"/>
             </ResourceEntities>
             <AvailableNetworks>
-                <Network href="https://VMWARE_CLOUD_HOST/api/network/5ae840de-198e-4a34-a30a-6c36377460c6" name="INT_192.168.10.0m24" type="application/vnd.vmware.vcloud.network+xml"/>
+                <Network href="https://VMWARE_CLOUD_HOST/api/network/5038b60d-fbb8-42e8-8bf3-e711f703507c" name="ManageIQ Dev external network" type="application/vnd.vmware.vcloud.network+xml"/>
+                <Network href="https://VMWARE_CLOUD_HOST/api/network/9e381434-a787-49b5-949e-5d67eff76a18" name="ManageIQ Development network" type="application/vnd.vmware.vcloud.network+xml"/>
             </AvailableNetworks>
             <Capabilities>
                 <SupportedHardwareVersions>
@@ -278,6 +238,9 @@ http_interactions:
                     <SupportedHardwareVersion>vmx-08</SupportedHardwareVersion>
                     <SupportedHardwareVersion>vmx-09</SupportedHardwareVersion>
                     <SupportedHardwareVersion>vmx-10</SupportedHardwareVersion>
+                    <SupportedHardwareVersion>vmx-11</SupportedHardwareVersion>
+                    <SupportedHardwareVersion>vmx-12</SupportedHardwareVersion>
+                    <SupportedHardwareVersion>vmx-13</SupportedHardwareVersion>
                 </SupportedHardwareVersions>
             </Capabilities>
             <NicQuota>0</NicQuota>
@@ -286,380 +249,91 @@ http_interactions:
             <VmQuota>100</VmQuota>
             <IsEnabled>true</IsEnabled>
             <VdcStorageProfiles>
-                <VdcStorageProfile href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                <VdcStorageProfile href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/b652f213-33aa-4c1f-8f30-ea2919a30843" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
             </VdcStorageProfiles>
         </Vdc>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:52:02 GMT
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:30 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.42.0
+      - fog-core/1.45.0
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Date:
-      - Fri, 16 Sep 2016 08:52:07 GMT
+      - Wed, 14 Mar 2018 10:54:30 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 85fecf9b-221a-4dd4-86ec-01908a6cc97c
+      - edca07c9-328e-4a8a-9648-426fde43ca03
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
       Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '231'
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
       Content-Type:
       - application/vnd.vmware.vcloud.vapp+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-    body:
-      encoding: ASCII-8BIT
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VApp xmlns=\"http://www.vmware.com/vcloud/v1.5\"
-        xmlns:ovf=\"http://schemas.dmtf.org/ovf/envelope/1\" xmlns:vssd=\"http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData\"
-        xmlns:rasd=\"http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData\"
-        xmlns:vmw=\"http://www.vmware.com/schema/ovf\" xmlns:ovfenv=\"http://schemas.dmtf.org/ovf/environment/1\"
-        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" ovfDescriptorUploaded=\"true\"
-        deployed=\"true\" status=\"4\" name=\"spec-1\" id=\"urn:vcloud:vapp:0d7614c3-a61d-4d11-a733-aa2a8f6038b4\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4\"
-        type=\"application/vnd.vmware.vcloud.vApp+xml\" xsi:schemaLocation=\"http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData
-        http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd
-        http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1
-        http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://schemas.dmtf.org/ovf/environment/1
-        http://schemas.dmtf.org/ovf/envelope/1/dsp8027_1.1.0.xsd http://www.vmware.com/vcloud/v1.5
-        http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData
-        http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd\">\n
-        \   <Link rel=\"power:powerOff\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/power/action/powerOff\"/>\n
-        \   <Link rel=\"power:reboot\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/power/action/reboot\"/>\n
-        \   <Link rel=\"power:reset\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/power/action/reset\"/>\n
-        \   <Link rel=\"power:shutdown\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/power/action/shutdown\"/>\n
-        \   <Link rel=\"power:suspend\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/power/action/suspend\"/>\n
-        \   <Link rel=\"deploy\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/action/deploy\"
-        type=\"application/vnd.vmware.vcloud.deployVAppParams+xml\"/>\n    <Link rel=\"undeploy\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/action/undeploy\"
-        type=\"application/vnd.vmware.vcloud.undeployVAppParams+xml\"/>\n    <Link
-        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/network/a0912234-e83d-4162-aef1-b48556cef93f\"
-        name=\"INT_192.168.10.0m24\" type=\"application/vnd.vmware.vcloud.vAppNetwork+xml\"/>\n
-        \   <Link rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/controlAccess/\"
-        type=\"application/vnd.vmware.vcloud.controlAccess+xml\"/>\n    <Link rel=\"controlAccess\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/action/controlAccess\"
-        type=\"application/vnd.vmware.vcloud.controlAccess+xml\"/>\n    <Link rel=\"up\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676\"
-        type=\"application/vnd.vmware.vcloud.vdc+xml\"/>\n    <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4\"
-        type=\"application/vnd.vmware.vcloud.vApp+xml\"/>\n    <Link rel=\"down\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/owner\"
-        type=\"application/vnd.vmware.vcloud.owner+xml\"/>\n    <Link rel=\"down\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/metadata\"
-        type=\"application/vnd.vmware.vcloud.metadata+xml\"/>\n    <Link rel=\"ovf\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/ovf\"
-        type=\"text/xml\"/>\n    <Link rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/productSections/\"
-        type=\"application/vnd.vmware.vcloud.productSections+xml\"/>\n    <Link rel=\"snapshot:create\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/action/createSnapshot\"
-        type=\"application/vnd.vmware.vcloud.createSnapshotParams+xml\"/>\n    <Description/>\n
-        \   <LeaseSettingsSection href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/leaseSettingsSection/\"
-        type=\"application/vnd.vmware.vcloud.leaseSettingsSection+xml\" ovf:required=\"false\">\n
-        \       <ovf:Info>Lease settings section</ovf:Info>\n        <Link rel=\"edit\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/leaseSettingsSection/\"
-        type=\"application/vnd.vmware.vcloud.leaseSettingsSection+xml\"/>\n        <DeploymentLeaseInSeconds>604800</DeploymentLeaseInSeconds>\n
-        \       <StorageLeaseInSeconds>2592000</StorageLeaseInSeconds>\n        <DeploymentLeaseExpiration>2016-09-23T11:46:52.987+03:00</DeploymentLeaseExpiration>\n
-        \   </LeaseSettingsSection>\n    <ovf:StartupSection xmlns:vcloud=\"http://www.vmware.com/vcloud/v1.5\"
-        vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/startupSection/\"
-        vcloud:type=\"application/vnd.vmware.vcloud.startupSection+xml\">\n        <ovf:Info>VApp
-        startup section</ovf:Info>\n        <ovf:Item ovf:id=\"spec1-vm1\" ovf:order=\"0\"
-        ovf:startAction=\"powerOn\" ovf:startDelay=\"0\" ovf:stopAction=\"powerOff\"
-        ovf:stopDelay=\"0\"/>\n        <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/startupSection/\"
-        type=\"application/vnd.vmware.vcloud.startupSection+xml\"/>\n    </ovf:StartupSection>\n
-        \   <ovf:NetworkSection xmlns:vcloud=\"http://www.vmware.com/vcloud/v1.5\"
-        vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/networkSection/\"
-        vcloud:type=\"application/vnd.vmware.vcloud.networkSection+xml\">\n        <ovf:Info>The
-        list of logical networks</ovf:Info>\n        <ovf:Network ovf:name=\"INT_192.168.10.0m24\">\n
-        \           <ovf:Description/>\n        </ovf:Network>\n    </ovf:NetworkSection>\n
-        \   <NetworkConfigSection href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/networkConfigSection/\"
-        type=\"application/vnd.vmware.vcloud.networkConfigSection+xml\" ovf:required=\"false\">\n
-        \       <ovf:Info>The configuration parameters for logical networks</ovf:Info>\n
-        \       <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/networkConfigSection/\"
-        type=\"application/vnd.vmware.vcloud.networkConfigSection+xml\"/>\n        <NetworkConfig
-        networkName=\"INT_192.168.10.0m24\">\n            <Link rel=\"repair\" href=\"https://VMWARE_CLOUD_HOST/api/admin/network/a0912234-e83d-4162-aef1-b48556cef93f/action/reset\"/>\n
-        \           <Description/>\n            <Configuration>\n                <IpScopes>\n
-        \                   <IpScope>\n                        <IsInherited>true</IsInherited>\n
-        \                       <Gateway>192.168.10.1</Gateway>\n                        <Netmask>255.255.255.0</Netmask>\n
-        \                       <Dns1>192.168.10.1</Dns1>\n                        <DnsSuffix>test.local</DnsSuffix>\n
-        \                       <IsEnabled>true</IsEnabled>\n                        <IpRanges>\n
-        \                           <IpRange>\n                                <StartAddress>192.168.10.100</StartAddress>\n
-        \                               <EndAddress>192.168.10.199</EndAddress>\n
-        \                           </IpRange>\n                        </IpRanges>\n
-        \                   </IpScope>\n                </IpScopes>\n                <ParentNetwork
-        href=\"https://VMWARE_CLOUD_HOST/api/admin/network/5ae840de-198e-4a34-a30a-6c36377460c6\"
-        id=\"5ae840de-198e-4a34-a30a-6c36377460c6\" name=\"INT_192.168.10.0m24\"/>\n
-        \               <FenceMode>bridged</FenceMode>\n                <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>\n
-        \           </Configuration>\n            <IsDeployed>true</IsDeployed>\n
-        \       </NetworkConfig>\n    </NetworkConfigSection>\n    <SnapshotSection
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/snapshotSection\"
-        type=\"application/vnd.vmware.vcloud.snapshotSection+xml\" ovf:required=\"false\">\n
-        \       <ovf:Info>Snapshot information section</ovf:Info>\n    </SnapshotSection>\n
-        \   <DateCreated>2016-09-16T11:45:24.897+03:00</DateCreated>\n    <Owner type=\"application/vnd.vmware.vcloud.owner+xml\">\n
-        \       <User href=\"https://VMWARE_CLOUD_HOST/api/admin/user/81585659-9eaa-46e7-8100-3b0ea0aa4fd6\"
-        name=\"bergigre_remote\" type=\"application/vnd.vmware.admin.user+xml\"/>\n
-        \   </Owner>\n    <InMaintenanceMode>false</InMaintenanceMode>\n    <Children>\n
-        \       <Vm needsCustomization=\"false\" nestedHypervisorEnabled=\"false\"
-        deployed=\"true\" status=\"4\" name=\"spec1-vm1\" id=\"urn:vcloud:vm:f9ceb77c-b9d9-400c-8c06-72c785e884af\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af\"
-        type=\"application/vnd.vmware.vcloud.vm+xml\">\n            <Link rel=\"power:powerOff\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/power/action/powerOff\"/>\n
-        \           <Link rel=\"power:reboot\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/power/action/reboot\"/>\n
-        \           <Link rel=\"power:reset\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/power/action/reset\"/>\n
-        \           <Link rel=\"power:shutdown\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/power/action/shutdown\"/>\n
-        \           <Link rel=\"power:suspend\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/power/action/suspend\"/>\n
-        \           <Link rel=\"undeploy\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/action/undeploy\"
-        type=\"application/vnd.vmware.vcloud.undeployVAppParams+xml\"/>\n            <Link
-        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af\"
-        type=\"application/vnd.vmware.vcloud.vm+xml\"/>\n            <Link rel=\"down\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/metadata\"
-        type=\"application/vnd.vmware.vcloud.metadata+xml\"/>\n            <Link rel=\"down\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/productSections/\"
-        type=\"application/vnd.vmware.vcloud.productSections+xml\"/>\n            <Link
-        rel=\"screen:thumbnail\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/screen\"/>\n
-        \           <Link rel=\"screen:acquireTicket\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/screen/action/acquireTicket\"/>\n
-        \           <Link rel=\"media:insertMedia\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/media/action/insertMedia\"
-        type=\"application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml\"/>\n            <Link
-        rel=\"media:ejectMedia\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/media/action/ejectMedia\"
-        type=\"application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml\"/>\n            <Link
-        rel=\"disk:attach\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/disk/action/attach\"
-        type=\"application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml\"/>\n            <Link
-        rel=\"disk:detach\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/disk/action/detach\"
-        type=\"application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml\"/>\n            <Link
-        rel=\"installVmwareTools\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/action/installVMwareTools\"/>\n
-        \           <Link rel=\"snapshot:create\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/action/createSnapshot\"
-        type=\"application/vnd.vmware.vcloud.createSnapshotParams+xml\"/>\n            <Link
-        rel=\"reconfigureVm\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/action/reconfigureVm\"
-        name=\"spec1-vm1\" type=\"application/vnd.vmware.vcloud.vm+xml\"/>\n            <Link
-        rel=\"up\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4\"
-        type=\"application/vnd.vmware.vcloud.vApp+xml\"/>\n            <Description/>\n
-        \           <ovf:VirtualHardwareSection xmlns:vcloud=\"http://www.vmware.com/vcloud/v1.5\"
-        ovf:transport=\"\" vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/\"
-        vcloud:type=\"application/vnd.vmware.vcloud.virtualHardwareSection+xml\">\n
-        \               <ovf:Info>Virtual hardware requirements</ovf:Info>\n                <ovf:System>\n
-        \                   <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>\n
-        \                   <vssd:InstanceID>0</vssd:InstanceID>\n                    <vssd:VirtualSystemIdentifier>spec1-vm1</vssd:VirtualSystemIdentifier>\n
-        \                   <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>\n
-        \               </ovf:System>\n                <ovf:Item>\n                    <rasd:Address>00:50:56:01:00:64</rasd:Address>\n
-        \                   <rasd:AddressOnParent>0</rasd:AddressOnParent>\n                    <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>\n
-        \                   <rasd:Connection vcloud:ipAddress=\"192.168.10.100\" vcloud:primaryNetworkConnection=\"true\"
-        vcloud:ipAddressingMode=\"POOL\">INT_192.168.10.0m24</rasd:Connection>\n                    <rasd:Description>Vmxnet3
-        ethernet adapter on \"INT_192.168.10.0m24\"</rasd:Description>\n                    <rasd:ElementName>Network
-        adapter 0</rasd:ElementName>\n                    <rasd:InstanceID>1</rasd:InstanceID>\n
-        \                   <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>\n
-        \                   <rasd:ResourceType>10</rasd:ResourceType>\n                </ovf:Item>\n
-        \               <ovf:Item>\n                    <rasd:Address>0</rasd:Address>\n
-        \                   <rasd:Description>SCSI Controller</rasd:Description>\n
-        \                   <rasd:ElementName>SCSI Controller 0</rasd:ElementName>\n
-        \                   <rasd:InstanceID>2</rasd:InstanceID>\n                    <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>\n
-        \                   <rasd:ResourceType>6</rasd:ResourceType>\n                </ovf:Item>\n
-        \               <ovf:Item>\n                    <rasd:AddressOnParent>0</rasd:AddressOnParent>\n
-        \                   <rasd:Description>Hard disk</rasd:Description>\n                    <rasd:ElementName>Hard
-        disk 1</rasd:ElementName>\n                    <rasd:HostResource vcloud:capacity=\"16384\"
-        vcloud:busSubType=\"lsilogic\" vcloud:busType=\"6\"/>\n                    <rasd:InstanceID>2000</rasd:InstanceID>\n
-        \                   <rasd:Parent>2</rasd:Parent>\n                    <rasd:ResourceType>17</rasd:ResourceType>\n
-        \                   <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>\n
-        \                   <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>\n
-        \               </ovf:Item>\n                <ovf:Item>\n                    <rasd:Address>0</rasd:Address>\n
-        \                   <rasd:Description>IDE Controller</rasd:Description>\n
-        \                   <rasd:ElementName>IDE Controller 0</rasd:ElementName>\n
-        \                   <rasd:InstanceID>3</rasd:InstanceID>\n                    <rasd:ResourceType>5</rasd:ResourceType>\n
-        \               </ovf:Item>\n                <ovf:Item>\n                    <rasd:AddressOnParent>0</rasd:AddressOnParent>\n
-        \                   <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>\n
-        \                   <rasd:Description>CD/DVD Drive</rasd:Description>\n                    <rasd:ElementName>CD/DVD
-        Drive 1</rasd:ElementName>\n                    <rasd:HostResource/>\n                    <rasd:InstanceID>3000</rasd:InstanceID>\n
-        \                   <rasd:Parent>3</rasd:Parent>\n                    <rasd:ResourceType>15</rasd:ResourceType>\n
-        \               </ovf:Item>\n                <ovf:Item>\n                    <rasd:AddressOnParent>0</rasd:AddressOnParent>\n
-        \                   <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>\n
-        \                   <rasd:Description>Floppy Drive</rasd:Description>\n                    <rasd:ElementName>Floppy
-        Drive 1</rasd:ElementName>\n                    <rasd:HostResource/>\n                    <rasd:InstanceID>8000</rasd:InstanceID>\n
-        \                   <rasd:ResourceType>14</rasd:ResourceType>\n                </ovf:Item>\n
-        \               <ovf:Item vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/cpu\"
-        vcloud:type=\"application/vnd.vmware.vcloud.rasdItem+xml\">\n                    <rasd:AllocationUnits>hertz
-        * 10^6</rasd:AllocationUnits>\n                    <rasd:Description>Number
-        of Virtual CPUs</rasd:Description>\n                    <rasd:ElementName>2
-        virtual CPU(s)</rasd:ElementName>\n                    <rasd:InstanceID>4</rasd:InstanceID>\n
-        \                   <rasd:Reservation>0</rasd:Reservation>\n                    <rasd:ResourceType>3</rasd:ResourceType>\n
-        \                   <rasd:VirtualQuantity>2</rasd:VirtualQuantity>\n                    <rasd:Weight>0</rasd:Weight>\n
-        \                   <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/cpu\"
-        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                </ovf:Item>\n
-        \               <ovf:Item vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/memory\"
-        vcloud:type=\"application/vnd.vmware.vcloud.rasdItem+xml\">\n                    <rasd:AllocationUnits>byte
-        * 2^20</rasd:AllocationUnits>\n                    <rasd:Description>Memory
-        Size</rasd:Description>\n                    <rasd:ElementName>2048 MB of
-        memory</rasd:ElementName>\n                    <rasd:InstanceID>5</rasd:InstanceID>\n
-        \                   <rasd:Reservation>0</rasd:Reservation>\n                    <rasd:ResourceType>4</rasd:ResourceType>\n
-        \                   <rasd:VirtualQuantity>2048</rasd:VirtualQuantity>\n                    <rasd:Weight>0</rasd:Weight>\n
-        \                   <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/memory\"
-        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                </ovf:Item>\n
-        \               <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/\"
-        type=\"application/vnd.vmware.vcloud.virtualHardwareSection+xml\"/>\n                <Link
-        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/cpu\"
-        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                <Link
-        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/cpu\"
-        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                <Link
-        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/memory\"
-        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                <Link
-        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/memory\"
-        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                <Link
-        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/disks\"
-        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
-        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/disks\"
-        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
-        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/media\"
-        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
-        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/networkCards\"
-        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
-        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/networkCards\"
-        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
-        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/serialPorts\"
-        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
-        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/serialPorts\"
-        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n            </ovf:VirtualHardwareSection>\n
-        \           <ovf:OperatingSystemSection xmlns:vcloud=\"http://www.vmware.com/vcloud/v1.5\"
-        ovf:id=\"101\" vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/operatingSystemSection/\"
-        vcloud:type=\"application/vnd.vmware.vcloud.operatingSystemSection+xml\" vmw:osType=\"centos64Guest\">\n
-        \               <ovf:Info>Specifies the operating system installed</ovf:Info>\n
-        \               <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>\n
-        \               <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/operatingSystemSection/\"
-        type=\"application/vnd.vmware.vcloud.operatingSystemSection+xml\"/>\n            </ovf:OperatingSystemSection>\n
-        \           <NetworkConnectionSection href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/networkConnectionSection/\"
-        type=\"application/vnd.vmware.vcloud.networkConnectionSection+xml\" ovf:required=\"false\">\n
-        \               <ovf:Info>Specifies the available VM network connections</ovf:Info>\n
-        \               <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>\n
-        \               <NetworkConnection needsCustomization=\"true\" network=\"INT_192.168.10.0m24\">\n
-        \                   <NetworkConnectionIndex>0</NetworkConnectionIndex>\n                    <IpAddress>192.168.10.100</IpAddress>\n
-        \                   <IsConnected>true</IsConnected>\n                    <MACAddress>00:50:56:01:00:64</MACAddress>\n
-        \                   <IpAddressAllocationMode>POOL</IpAddressAllocationMode>\n
-        \               </NetworkConnection>\n                <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/networkConnectionSection/\"
-        type=\"application/vnd.vmware.vcloud.networkConnectionSection+xml\"/>\n            </NetworkConnectionSection>\n
-        \           <GuestCustomizationSection href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/guestCustomizationSection/\"
-        type=\"application/vnd.vmware.vcloud.guestCustomizationSection+xml\" ovf:required=\"false\">\n
-        \               <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>\n
-        \               <Enabled>false</Enabled>\n                <ChangeSid>false</ChangeSid>\n
-        \               <VirtualMachineId>f9ceb77c-b9d9-400c-8c06-72c785e884af</VirtualMachineId>\n
-        \               <JoinDomainEnabled>false</JoinDomainEnabled>\n                <UseOrgSettings>false</UseOrgSettings>\n
-        \               <AdminPasswordEnabled>true</AdminPasswordEnabled>\n                <AdminPasswordAuto>true</AdminPasswordAuto>\n
-        \               <ResetPasswordRequired>false</ResetPasswordRequired>\n                <ComputerName>CentOS7-0</ComputerName>\n
-        \               <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/guestCustomizationSection/\"
-        type=\"application/vnd.vmware.vcloud.guestCustomizationSection+xml\"/>\n            </GuestCustomizationSection>\n
-        \           <RuntimeInfoSection xmlns:vcloud=\"http://www.vmware.com/vcloud/v1.5\"
-        vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/runtimeInfoSection\"
-        vcloud:type=\"application/vnd.vmware.vcloud.virtualHardwareSection+xml\">\n
-        \               <ovf:Info>Specifies Runtime info</ovf:Info>\n                <VMWareTools
-        version=\"10240\"/>\n            </RuntimeInfoSection>\n            <SnapshotSection
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/snapshotSection\"
-        type=\"application/vnd.vmware.vcloud.snapshotSection+xml\" ovf:required=\"false\">\n
-        \               <ovf:Info>Snapshot information section</ovf:Info>\n            </SnapshotSection>\n
-        \           <DateCreated>2016-09-16T11:45:30.557+03:00</DateCreated>\n            <VAppScopedLocalId>7ff5cc28-e2e0-4466-bf78-e39a3522d539</VAppScopedLocalId>\n
-        \           <ovfenv:Environment xmlns:ns11=\"http://www.vmware.com/schema/ovfenv\"
-        ovfenv:id=\"\" ns11:vCenterId=\"vm-589\">\n                <ovfenv:PlatformSection>\n
-        \                   <ovfenv:Kind>VMware ESXi</ovfenv:Kind>\n                    <ovfenv:Version>6.0.0</ovfenv:Version>\n
-        \                   <ovfenv:Vendor>VMware, Inc.</ovfenv:Vendor>\n                    <ovfenv:Locale>en</ovfenv:Locale>\n
-        \               </ovfenv:PlatformSection>\n                <ve:EthernetAdapterSection
-        xmlns:ve=\"http://www.vmware.com/schema/ovfenv\" xmlns=\"http://schemas.dmtf.org/ovf/environment/1\"
-        xmlns:oe=\"http://schemas.dmtf.org/ovf/environment/1\">\n                    <ve:Adapter
-        ve:mac=\"00:50:56:01:00:64\" ve:network=\"vxw-dvs-128-virtualwire-18-sid-5004-dvs.VCDVSINT_192.168.10.0m24-55dcece1-954f-4\"
-        ve:unitNumber=\"7\"/>\n   \n                </ve:EthernetAdapterSection>\n
-        \           </ovfenv:Environment>\n            <VmCapabilities href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/vmCapabilities/\"
-        type=\"application/vnd.vmware.vcloud.vmCapabilitiesSection+xml\">\n                <Link
-        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/vmCapabilities/\"
-        type=\"application/vnd.vmware.vcloud.vmCapabilitiesSection+xml\"/>\n                <MemoryHotAddEnabled>false</MemoryHotAddEnabled>\n
-        \               <CpuHotAddEnabled>false</CpuHotAddEnabled>\n            </VmCapabilities>\n
-        \           <StorageProfile href=\"https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8\"
-        name=\"Dual site - Tier 1\" type=\"application/vnd.vmware.vcloud.vdcStorageProfile+xml\"/>\n
-        \       </Vm>\n    </Children>\n</VApp>\n"
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:52:08 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:52:13 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 61b8690b-d111-4af9-9e4f-f82ae31f670a
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '145'
-      Content-Type:
-      - application/vnd.vmware.vcloud.vapp+xml;version=5.1
+      - '155'
       Vary:
       - Accept-Encoding, User-Agent
     body:
       encoding: ASCII-8BIT
       string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovfDescriptorUploaded="true" deployed="false" status="3" name="vApp_system_4" id="urn:vcloud:vapp:6aa2d7ae-5245-45a0-82e8-4984e759ba5d" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d" type="application/vnd.vmware.vcloud.vApp+xml" xsi:schemaLocation="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
-            <Link rel="power:powerOn" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/power/action/powerOn"/>
-            <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-            <Link rel="discardState" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/action/discardSuspendedState"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/network/82759035-35af-4b27-a273-65e3dcaefb73" name="testnet" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="controlAccess" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="recompose" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/action/recomposeVApp" type="application/vnd.vmware.vcloud.recomposeVAppParams+xml"/>
-            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d" type="application/vnd.vmware.vcloud.vApp+xml"/>
-            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/ovf" type="text/xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
-            <Description/>
-            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" ovfDescriptorUploaded="true" deployed="true" status="4" name="spec1-vapp" id="urn:vcloud:vapp:a715dec5-7ab1-487e-993b-82fcd7eb8172" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172" type="application/vnd.vmware.vcloud.vApp+xml">
+            <Link rel="power:powerOff" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/power/action/powerOff"/>
+            <Link rel="power:reboot" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/power/action/reboot"/>
+            <Link rel="power:reset" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/power/action/reset"/>
+            <Link rel="power:shutdown" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/power/action/shutdown"/>
+            <Link rel="power:suspend" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/power/action/suspend"/>
+            <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
+            <Link rel="undeploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/action/undeploy" type="application/vnd.vmware.vcloud.undeployVAppParams+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/network/479eadc5-a17f-46b4-b580-6e2fb87971c9" name="spec1-network" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="controlAccess" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="recompose" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/action/recomposeVApp" type="application/vnd.vmware.vcloud.recomposeVAppParams+xml"/>
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172" type="application/vnd.vmware.vcloud.vApp+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/ovf" type="text/xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+            <Description></Description>
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
                 <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
-                <DeploymentLeaseInSeconds>604800</DeploymentLeaseInSeconds>
-                <StorageLeaseInSeconds>2592000</StorageLeaseInSeconds>
-                <StorageLeaseExpiration>2016-10-15T16:56:20.453+03:00</StorageLeaseExpiration>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <DeploymentLeaseInSeconds>2592000</DeploymentLeaseInSeconds>
+                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
+                <DeploymentLeaseExpiration>2018-04-12T11:18:05.418+02:00</DeploymentLeaseExpiration>
             </LeaseSettingsSection>
-            <ovf:StartupSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/startupSection/" vcloud:type="application/vnd.vmware.vcloud.startupSection+xml">
+            <ovf:StartupSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.startupSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/startupSection/">
                 <ovf:Info>VApp startup section</ovf:Info>
-                <ovf:Item ovf:id="CentOS7" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
+                <ovf:Item ovf:id="spec1-vm1" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
             </ovf:StartupSection>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
+            <ovf:NetworkSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.networkSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/networkSection/">
                 <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="testnet">
-                    <ovf:Description/>
+                <ovf:Network ovf:name="spec1-network">
+                    <ovf:Description></ovf:Description>
                 </ovf:Network>
             </ovf:NetworkSection>
-            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
                 <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
-                <NetworkConfig networkName="testnet">
-                    <Link rel="repair" href="https://VMWARE_CLOUD_HOST/api/admin/network/82759035-35af-4b27-a273-65e3dcaefb73/action/reset"/>
-                    <Description/>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
+                <NetworkConfig networkName="spec1-network">
+                    <Link rel="repair" href="https://VMWARE_CLOUD_HOST/api/admin/network/479eadc5-a17f-46b4-b580-6e2fb87971c9/action/reset"/>
+                    <Description></Description>
                     <Configuration>
                         <IpScopes>
                             <IpScope>
@@ -669,837 +343,840 @@ http_interactions:
                                 <IsEnabled>true</IsEnabled>
                                 <IpRanges>
                                     <IpRange>
-                                        <StartAddress>192.168.2.100</StartAddress>
-                                        <EndAddress>192.168.2.199</EndAddress>
+        <StartAddress>192.168.2.100</StartAddress>
+        <EndAddress>192.168.2.199</EndAddress>
                                     </IpRange>
                                 </IpRanges>
                             </IpScope>
                         </IpScopes>
                         <FenceMode>isolated</FenceMode>
                         <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
+                        <Features>
+                            <DhcpService>
+                                <IsEnabled>false</IsEnabled>
+                                <DefaultLeaseTime>3600</DefaultLeaseTime>
+                                <MaxLeaseTime>7200</MaxLeaseTime>
+                            </DhcpService>
+                        </Features>
                     </Configuration>
-                    <IsDeployed>false</IsDeployed>
+                    <IsDeployed>true</IsDeployed>
                 </NetworkConfig>
             </NetworkConfigSection>
-            <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+            <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
                 <ovf:Info>Snapshot information section</ovf:Info>
             </SnapshotSection>
-            <DateCreated>2016-09-08T16:48:46.357+03:00</DateCreated>
+            <DateCreated>2018-03-09T13:36:41.966+01:00</DateCreated>
             <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/3fde93ae-0521-4a75-8dec-cb4bcb7dcbb0" name="system" type="application/vnd.vmware.admin.user+xml"/>
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/f3555478-d7ea-4d9c-9b48-4bced57539e3" name="system" type="application/vnd.vmware.admin.user+xml"/>
             </Owner>
             <InMaintenanceMode>false</InMaintenanceMode>
             <Children>
-                <Vm needsCustomization="false" nestedHypervisorEnabled="false" deployed="false" status="3" name="CentOS7" id="urn:vcloud:vm:8df2faf3-fd33-40de-9b26-da34c146f55d" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="power:powerOn" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/power/action/powerOn"/>
-                    <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-                    <Link rel="discardState" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/action/discardSuspendedState"/>
-                    <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Link rel="screen:thumbnail" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/screen"/>
-                    <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/action/enableNestedHypervisor"/>
-                    <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
-                    <Link rel="reconfigureVm" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/action/reconfigureVm" name="CentOS7" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d" type="application/vnd.vmware.vcloud.vApp+xml"/>
-                    <Description/>
-                    <ovf:VirtualHardwareSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:transport="" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml">
+                <Vm needsCustomization="true" nestedHypervisorEnabled="false" deployed="true" status="4" name="spec1-vm1" id="urn:vcloud:vm:84faa107-c0b9-4a21-adc5-b17e0c5355a2" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="power:powerOff" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/power/action/powerOff"/>
+                    <Link rel="power:reboot" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/power/action/reboot"/>
+                    <Link rel="power:reset" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/power/action/reset"/>
+                    <Link rel="power:shutdown" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/power/action/shutdown"/>
+                    <Link rel="power:suspend" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/power/action/suspend"/>
+                    <Link rel="undeploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/action/undeploy" type="application/vnd.vmware.vcloud.undeployVAppParams+xml"/>
+                    <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Link rel="screen:thumbnail" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/screen"/>
+                    <Link rel="screen:acquireTicket" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/screen/action/acquireTicket"/>
+                    <Link rel="media:insertMedia" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
+                    <Link rel="media:ejectMedia" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
+                    <Link rel="disk:attach" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
+                    <Link rel="disk:detach" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
+                    <Link rel="installVmwareTools" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/action/installVMwareTools"/>
+                    <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+                    <Link rel="reconfigureVm" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/action/reconfigureVm" name="spec1-vm1" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172" type="application/vnd.vmware.vcloud.vApp+xml"/>
+                    <Description></Description>
+                    <ovf:VirtualHardwareSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ovf:transport="" ns13:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/">
                         <ovf:Info>Virtual hardware requirements</ovf:Info>
                         <ovf:System>
+                            <vssd:AutomaticRecoveryAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticShutdownAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticStartupAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticStartupActionDelay xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticStartupActionSequenceNumber xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:CreationTime xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:Description xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+                            <vssd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <vssd:InstanceID>0</vssd:InstanceID>
-                            <vssd:VirtualSystemIdentifier>CentOS7</vssd:VirtualSystemIdentifier>
-                            <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
+                            <vssd:LogDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:RecoveryFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:SnapshotDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:SuspendDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:SwapFileDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:VirtualSystemIdentifier>spec1-vm1</vssd:VirtualSystemIdentifier>
+                            <vssd:VirtualSystemType>vmx-13</vssd:VirtualSystemType>
                         </ovf:System>
                         <ovf:Item>
-                            <rasd:Address>00:50:56:01:00:4a</rasd:Address>
+                            <rasd:Address>00:50:56:01:00:d8</rasd:Address>
                             <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
-                            <rasd:Connection vcloud:ipAddress="192.168.2.100" vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="POOL">testnet</rasd:Connection>
-                            <rasd:Description>Vmxnet3 ethernet adapter on "testnet"</rasd:Description>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Connection ns13:ipAddressingMode="POOL" ns13:ipAddress="192.168.2.100" ns13:primaryNetworkConnection="true">spec1-network</rasd:Connection>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>E1000s ethernet adapter on "spec1-network"</rasd:Description>
                             <rasd:ElementName>Network adapter 0</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:InstanceID>1</rasd:InstanceID>
-                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType>E1000E</rasd:ResourceSubType>
                             <rasd:ResourceType>10</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                         </ovf:Item>
                         <ovf:Item>
                             <rasd:Address>0</rasd:Address>
+                            <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Description>SCSI Controller</rasd:Description>
                             <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:InstanceID>2</rasd:InstanceID>
-                            <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType>lsilogicsas</rasd:ResourceSubType>
                             <rasd:ResourceType>6</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                         </ovf:Item>
                         <ovf:Item>
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Description>Hard disk</rasd:Description>
                             <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                            <rasd:HostResource vcloud:capacity="16384" vcloud:busSubType="lsilogic" vcloud:busType="6"/>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:HostResource ns13:busType="6" ns13:busSubType="lsilogicsas" ns13:capacity="10240"></rasd:HostResource>
                             <rasd:InstanceID>2000</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Parent>2</rasd:Parent>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:ResourceType>17</rasd:ResourceType>
-                            <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>10737418240</rasd:VirtualQuantity>
                             <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                         </ovf:Item>
                         <ovf:Item>
                             <rasd:Address>0</rasd:Address>
+                            <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Description>IDE Controller</rasd:Description>
                             <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:InstanceID>3</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:ResourceType>5</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                         </ovf:Item>
                         <ovf:Item>
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Description>CD/DVD Drive</rasd:Description>
                             <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:HostResource></rasd:HostResource>
                             <rasd:InstanceID>3000</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Parent>3</rasd:Parent>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:ResourceType>15</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                         </ovf:Item>
                         <ovf:Item>
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Description>Floppy Drive</rasd:Description>
                             <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:HostResource></rasd:HostResource>
                             <rasd:InstanceID>8000</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:ResourceType>14</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                         </ovf:Item>
-                        <ovf:Item vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/cpu" vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml">
+                        <ovf:Item ns13:type="application/vnd.vmware.vcloud.rasdItem+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/cpu">
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Description>Number of Virtual CPUs</rasd:Description>
-                            <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
+                            <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:InstanceID>4</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:ResourceType>3</rasd:ResourceType>
-                            <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
                         </ovf:Item>
-                        <ovf:Item vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/memory" vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml">
+                        <ovf:Item ns13:type="application/vnd.vmware.vcloud.rasdItem+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/memory">
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Description>Memory Size</rasd:Description>
-                            <rasd:ElementName>2048 MB of memory</rasd:ElementName>
+                            <rasd:ElementName>512 MB of memory</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:InstanceID>5</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:ResourceType>4</rasd:ResourceType>
-                            <rasd:VirtualQuantity>2048</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>512</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
                         </ovf:Item>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
                     </ovf:VirtualHardwareSection>
-                    <ovf:OperatingSystemSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:id="101" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/operatingSystemSection/" vcloud:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="centos64Guest">
+                    <ovf:OperatingSystemSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ovf:id="102" ns13:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="windows9Server64Guest" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/operatingSystemSection/">
                         <ovf:Info>Specifies the operating system installed</ovf:Info>
-                        <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
+                        <ovf:Description>Microsoft Windows Server 2016 (64-bit)</ovf:Description>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
                     </ovf:OperatingSystemSection>
-                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
                         <ovf:Info>Specifies the available VM network connections</ovf:Info>
                         <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="false" network="testnet">
+                        <NetworkConnection needsCustomization="true" network="spec1-network">
                             <NetworkConnectionIndex>0</NetworkConnectionIndex>
                             <IpAddress>192.168.2.100</IpAddress>
                             <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:4a</MACAddress>
+                            <MACAddress>00:50:56:01:00:d8</MACAddress>
                             <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
                         </NetworkConnection>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
                     </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
                         <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <Enabled>true</Enabled>
-                        <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>8df2faf3-fd33-40de-9b26-da34c146f55d</VirtualMachineId>
+                        <Enabled>false</Enabled>
+                        <ChangeSid>true</ChangeSid>
+                        <VirtualMachineId>84faa107-c0b9-4a21-adc5-b17e0c5355a2</VirtualMachineId>
                         <JoinDomainEnabled>false</JoinDomainEnabled>
                         <UseOrgSettings>false</UseOrgSettings>
                         <AdminPasswordEnabled>true</AdminPasswordEnabled>
                         <AdminPasswordAuto>true</AdminPasswordAuto>
-                        <AdminPassword>nN%9oQTG</AdminPassword>
                         <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>CentOS7-0</ComputerName>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+                        <ComputerName>spec1-vm1</ComputerName>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
                     </GuestCustomizationSection>
-                    <RuntimeInfoSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/runtimeInfoSection" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml">
+                    <RuntimeInfoSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/runtimeInfoSection">
                         <ovf:Info>Specifies Runtime info</ovf:Info>
-                        <VMWareTools version="10240"/>
                     </RuntimeInfoSection>
-                    <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+                    <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
                         <ovf:Info>Snapshot information section</ovf:Info>
                     </SnapshotSection>
-                    <DateCreated>2016-09-08T16:48:57.753+03:00</DateCreated>
-                    <VAppScopedLocalId>7ff5cc28-e2e0-4466-bf78-e39a3522d539</VAppScopedLocalId>
-                    <VmCapabilities href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
+                    <DateCreated>2018-03-09T13:36:47.296+01:00</DateCreated>
+                    <VAppScopedLocalId>c209ef9f-25c8-4fe5-a7f4-c522fbd45ea7</VAppScopedLocalId>
+                    <VmCapabilities href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
                         <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
                         <CpuHotAddEnabled>false</CpuHotAddEnabled>
                     </VmCapabilities>
-                    <StorageProfile href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <StorageProfile href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/b652f213-33aa-4c1f-8f30-ea2919a30843" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
                 </Vm>
             </Children>
         </VApp>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:52:14 GMT
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:30 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.42.0
+      - fog-core/1.45.0
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Date:
-      - Fri, 16 Sep 2016 08:52:19 GMT
+      - Wed, 14 Mar 2018 10:54:30 GMT
       X-Vmware-Vcloud-Request-Id:
-      - de2c3411-6ab5-4911-b92c-173f829ae43d
+      - 68c353d1-6ec5-46da-9e3f-58627f6910ba
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
       Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '166'
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
       Content-Type:
       - application/vnd.vmware.vcloud.vapp+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '189'
       Vary:
       - Accept-Encoding, User-Agent
     body:
       encoding: ASCII-8BIT
       string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovfDescriptorUploaded="true" deployed="false" status="8" name="spec2" id="urn:vcloud:vapp:f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd" type="application/vnd.vmware.vcloud.vApp+xml" xsi:schemaLocation="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
-            <Link rel="power:powerOn" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/power/action/powerOn"/>
-            <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/network/d91117a6-33d6-4a51-96e3-8d761b145726" name="INT_192.168.10.0m24" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="controlAccess" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="recompose" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/recomposeVApp" type="application/vnd.vmware.vcloud.recomposeVAppParams+xml"/>
-            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd" type="application/vnd.vmware.vcloud.vApp+xml"/>
-            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd"/>
-            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/enableDownload"/>
-            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/disableDownload"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/ovf" type="text/xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
-            <Description/>
-            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" ovfDescriptorUploaded="true" deployed="true" status="4" name="miq-devel-vm" id="urn:vcloud:vapp:2c385915-c0c5-4cfe-81ca-ce8f59b21dd1" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1" type="application/vnd.vmware.vcloud.vApp+xml">
+            <Link rel="power:powerOff" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/power/action/powerOff"/>
+            <Link rel="power:reboot" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/power/action/reboot"/>
+            <Link rel="power:reset" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/power/action/reset"/>
+            <Link rel="power:shutdown" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/power/action/shutdown"/>
+            <Link rel="power:suspend" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/power/action/suspend"/>
+            <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
+            <Link rel="undeploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/action/undeploy" type="application/vnd.vmware.vcloud.undeployVAppParams+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/network/3ce8a1be-aa11-476b-8afc-642a25a9dfa0" name="ManageIQ Dev external network" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/network/af20c7e3-79aa-4cdb-bd94-935e4f43d3d3" name="VM Network" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="controlAccess" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="recompose" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/action/recomposeVApp" type="application/vnd.vmware.vcloud.recomposeVAppParams+xml"/>
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1" type="application/vnd.vmware.vcloud.vApp+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/ovf" type="text/xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+            <Description></Description>
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
                 <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
-                <DeploymentLeaseInSeconds>604800</DeploymentLeaseInSeconds>
-                <StorageLeaseInSeconds>2592000</StorageLeaseInSeconds>
-                <StorageLeaseExpiration>2016-10-16T11:46:10.463+03:00</StorageLeaseExpiration>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <DeploymentLeaseInSeconds>2592000</DeploymentLeaseInSeconds>
+                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
+                <DeploymentLeaseExpiration>2018-03-22T12:27:19.638+01:00</DeploymentLeaseExpiration>
             </LeaseSettingsSection>
-            <ovf:StartupSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/startupSection/" vcloud:type="application/vnd.vmware.vcloud.startupSection+xml">
+            <ovf:StartupSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.startupSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/startupSection/">
                 <ovf:Info>VApp startup section</ovf:Info>
-                <ovf:Item ovf:id="spec2-vm1" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
+                <ovf:Item ovf:id="93e8f5e5-7b61-40ed-ae94-4193eda19fec" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
             </ovf:StartupSection>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
+            <ovf:NetworkSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.networkSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/networkSection/">
                 <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="INT_192.168.10.0m24">
-                    <ovf:Description/>
+                <ovf:Network ovf:name="ManageIQ Dev external network">
+                    <ovf:Description></ovf:Description>
+                </ovf:Network>
+                <ovf:Network ovf:name="VM Network">
+                    <ovf:Description>The VM Network network</ovf:Description>
                 </ovf:Network>
             </ovf:NetworkSection>
-            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
                 <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
-                <NetworkConfig networkName="INT_192.168.10.0m24">
-                    <Link rel="repair" href="https://VMWARE_CLOUD_HOST/api/admin/network/d91117a6-33d6-4a51-96e3-8d761b145726/action/reset"/>
-                    <Description/>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
+                <NetworkConfig networkName="ManageIQ Dev external network">
+                    <Link rel="repair" href="https://VMWARE_CLOUD_HOST/api/admin/network/3ce8a1be-aa11-476b-8afc-642a25a9dfa0/action/reset"/>
+                    <Description></Description>
                     <Configuration>
                         <IpScopes>
                             <IpScope>
                                 <IsInherited>true</IsInherited>
-                                <Gateway>192.168.10.1</Gateway>
-                                <Netmask>255.255.255.0</Netmask>
-                                <Dns1>192.168.10.1</Dns1>
-                                <DnsSuffix>test.local</DnsSuffix>
+                                <Gateway>10.12.0.24</Gateway>
+                                <Netmask>255.255.0.0</Netmask>
+                                <Dns1>10.12.0.13</Dns1>
+                                <DnsSuffix>redhat.xlab.si</DnsSuffix>
                                 <IsEnabled>true</IsEnabled>
                                 <IpRanges>
                                     <IpRange>
-                                        <StartAddress>192.168.10.100</StartAddress>
-                                        <EndAddress>192.168.10.199</EndAddress>
+        <StartAddress>10.12.6.10</StartAddress>
+        <EndAddress>10.12.6.100</EndAddress>
                                     </IpRange>
                                 </IpRanges>
                             </IpScope>
                         </IpScopes>
-                        <ParentNetwork href="https://VMWARE_CLOUD_HOST/api/admin/network/5ae840de-198e-4a34-a30a-6c36377460c6" id="5ae840de-198e-4a34-a30a-6c36377460c6" name="INT_192.168.10.0m24"/>
+                        <ParentNetwork href="https://VMWARE_CLOUD_HOST/api/admin/network/5038b60d-fbb8-42e8-8bf3-e711f703507c" id="5038b60d-fbb8-42e8-8bf3-e711f703507c" name="ManageIQ Dev external network"/>
                         <FenceMode>bridged</FenceMode>
                         <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
                     </Configuration>
-                    <IsDeployed>false</IsDeployed>
+                    <IsDeployed>true</IsDeployed>
+                </NetworkConfig>
+                <NetworkConfig networkName="VM Network">
+                    <Link rel="repair" href="https://VMWARE_CLOUD_HOST/api/admin/network/af20c7e3-79aa-4cdb-bd94-935e4f43d3d3/action/reset"/>
+                    <Description>The VM Network network</Description>
+                    <Configuration>
+                        <IpScopes>
+                            <IpScope>
+                                <IsInherited>false</IsInherited>
+                                <Gateway>192.168.254.1</Gateway>
+                                <Netmask>255.255.255.0</Netmask>
+                                <IsEnabled>true</IsEnabled>
+                                <IpRanges>
+                                    <IpRange>
+        <StartAddress>192.168.254.100</StartAddress>
+        <EndAddress>192.168.254.199</EndAddress>
+                                    </IpRange>
+                                </IpRanges>
+                            </IpScope>
+                        </IpScopes>
+                        <FenceMode>isolated</FenceMode>
+                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
+                    </Configuration>
+                    <IsDeployed>true</IsDeployed>
                 </NetworkConfig>
             </NetworkConfigSection>
-            <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+            <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
                 <ovf:Info>Snapshot information section</ovf:Info>
             </SnapshotSection>
-            <DateCreated>2016-09-16T11:46:10.347+03:00</DateCreated>
+            <DateCreated>2018-02-20T12:19:04.030+01:00</DateCreated>
             <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/81585659-9eaa-46e7-8100-3b0ea0aa4fd6" name="bergigre_remote" type="application/vnd.vmware.admin.user+xml"/>
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/a4a18dd6-d9aa-4d4e-a024-653b924e7091" name="administrator" type="application/vnd.vmware.admin.user+xml"/>
             </Owner>
             <InMaintenanceMode>false</InMaintenanceMode>
             <Children>
-                <Vm needsCustomization="false" nestedHypervisorEnabled="false" deployed="false" status="8" name="spec2-vm1" id="urn:vcloud:vm:a28be0c0-d70d-4047-92f8-fc217bbaa7f6" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="power:powerOn" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/power/action/powerOn"/>
-                    <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-                    <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Link rel="screen:thumbnail" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/screen"/>
-                    <Link rel="media:insertMedia" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
-                    <Link rel="media:ejectMedia" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
-                    <Link rel="disk:attach" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
-                    <Link rel="disk:detach" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
-                    <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/action/enableNestedHypervisor"/>
-                    <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
-                    <Link rel="reconfigureVm" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/action/reconfigureVm" name="spec2-vm1" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd" type="application/vnd.vmware.vcloud.vApp+xml"/>
-                    <Description/>
-                    <ovf:VirtualHardwareSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:transport="" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml">
+                <Vm needsCustomization="true" deployed="true" status="4" name="93e8f5e5-7b61-40ed-ae94-4193eda19fec" id="urn:vcloud:vm:350947aa-c16e-4eb3-98c1-fced9dac6dbc" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="power:powerOff" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/power/action/powerOff"/>
+                    <Link rel="power:reboot" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/power/action/reboot"/>
+                    <Link rel="power:reset" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/power/action/reset"/>
+                    <Link rel="power:shutdown" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/power/action/shutdown"/>
+                    <Link rel="power:suspend" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/power/action/suspend"/>
+                    <Link rel="undeploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/action/undeploy" type="application/vnd.vmware.vcloud.undeployVAppParams+xml"/>
+                    <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Link rel="screen:thumbnail" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/screen"/>
+                    <Link rel="screen:acquireTicket" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/screen/action/acquireTicket"/>
+                    <Link rel="media:insertMedia" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
+                    <Link rel="media:ejectMedia" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
+                    <Link rel="disk:attach" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
+                    <Link rel="disk:detach" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
+                    <Link rel="installVmwareTools" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/action/installVMwareTools"/>
+                    <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+                    <Link rel="reconfigureVm" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/action/reconfigureVm" name="93e8f5e5-7b61-40ed-ae94-4193eda19fec" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1" type="application/vnd.vmware.vcloud.vApp+xml"/>
+                    <Description></Description>
+                    <ovf:VirtualHardwareSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ovf:transport="" ns13:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/">
                         <ovf:Info>Virtual hardware requirements</ovf:Info>
                         <ovf:System>
+                            <vssd:AutomaticRecoveryAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticShutdownAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticStartupAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticStartupActionDelay xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticStartupActionSequenceNumber xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:CreationTime xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:Description xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+                            <vssd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <vssd:InstanceID>0</vssd:InstanceID>
-                            <vssd:VirtualSystemIdentifier>spec2-vm1</vssd:VirtualSystemIdentifier>
-                            <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
+                            <vssd:LogDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:RecoveryFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:SnapshotDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:SuspendDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:SwapFileDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:VirtualSystemIdentifier>93e8f5e5-7b61-40ed-ae94-4193eda19fec</vssd:VirtualSystemIdentifier>
+                            <vssd:VirtualSystemType>vmx-08</vssd:VirtualSystemType>
                         </ovf:System>
                         <ovf:Item>
-                            <rasd:Address>00:50:56:01:00:65</rasd:Address>
+                            <rasd:Address>00:50:56:01:00:66</rasd:Address>
                             <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
-                            <rasd:Connection vcloud:ipAddress="192.168.10.101" vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="POOL">INT_192.168.10.0m24</rasd:Connection>
-                            <rasd:Description>Vmxnet3 ethernet adapter on "INT_192.168.10.0m24"</rasd:Description>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Connection ns13:ipAddressingMode="DHCP" ns13:ipAddress="10.12.6.23" ns13:primaryNetworkConnection="true">ManageIQ Dev external network</rasd:Connection>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>E1000 ethernet adapter on "ManageIQ Dev external network"</rasd:Description>
                             <rasd:ElementName>Network adapter 0</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:InstanceID>1</rasd:InstanceID>
-                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType>E1000</rasd:ResourceSubType>
                             <rasd:ResourceType>10</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                         </ovf:Item>
                         <ovf:Item>
                             <rasd:Address>0</rasd:Address>
+                            <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Description>SCSI Controller</rasd:Description>
                             <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:InstanceID>2</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
                             <rasd:ResourceType>6</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                         </ovf:Item>
                         <ovf:Item>
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Description>Hard disk</rasd:Description>
                             <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                            <rasd:HostResource vcloud:capacity="16384" vcloud:busSubType="lsilogic" vcloud:busType="6"/>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:HostResource ns13:busType="6" ns13:busSubType="lsilogic" ns13:capacity="67584"></rasd:HostResource>
                             <rasd:InstanceID>2000</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Parent>2</rasd:Parent>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:ResourceType>17</rasd:ResourceType>
-                            <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>70866960384</rasd:VirtualQuantity>
                             <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                         </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>IDE Controller</rasd:Description>
-                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>3</rasd:InstanceID>
-                            <rasd:ResourceType>5</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>CD/DVD Drive</rasd:Description>
-                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>3000</rasd:InstanceID>
-                            <rasd:Parent>3</rasd:Parent>
-                            <rasd:ResourceType>15</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>Floppy Drive</rasd:Description>
-                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>8000</rasd:InstanceID>
-                            <rasd:ResourceType>14</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/cpu" vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml">
+                        <ovf:Item ns13:type="application/vnd.vmware.vcloud.rasdItem+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/cpu">
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Description>Number of Virtual CPUs</rasd:Description>
-                            <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
-                            <rasd:InstanceID>4</rasd:InstanceID>
+                            <rasd:ElementName>4 virtual CPU(s)</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:InstanceID>3</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:ResourceType>3</rasd:ResourceType>
-                            <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>4</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
                         </ovf:Item>
-                        <ovf:Item vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/memory" vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml">
+                        <ovf:Item ns13:type="application/vnd.vmware.vcloud.rasdItem+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/memory">
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Description>Memory Size</rasd:Description>
-                            <rasd:ElementName>2048 MB of memory</rasd:ElementName>
-                            <rasd:InstanceID>5</rasd:InstanceID>
+                            <rasd:ElementName>6144 MB of memory</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:InstanceID>4</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:ResourceType>4</rasd:ResourceType>
-                            <rasd:VirtualQuantity>2048</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>6144</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
                         </ovf:Item>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
                     </ovf:VirtualHardwareSection>
-                    <ovf:OperatingSystemSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:id="101" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/operatingSystemSection/" vcloud:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="centos64Guest">
+                    <ovf:OperatingSystemSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ovf:id="102" ns13:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="rhel6_64Guest" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/operatingSystemSection/">
                         <ovf:Info>Specifies the operating system installed</ovf:Info>
-                        <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
+                        <ovf:Description>Red Hat Enterprise Linux 6 (64-bit)</ovf:Description>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
                     </ovf:OperatingSystemSection>
-                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
                         <ovf:Info>Specifies the available VM network connections</ovf:Info>
                         <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="INT_192.168.10.0m24">
+                        <NetworkConnection needsCustomization="true" network="ManageIQ Dev external network">
                             <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IpAddress>192.168.10.101</IpAddress>
+                            <IpAddress>10.12.6.23</IpAddress>
                             <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:65</MACAddress>
-                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
+                            <MACAddress>00:50:56:01:00:66</MACAddress>
+                            <IpAddressAllocationMode>DHCP</IpAddressAllocationMode>
                         </NetworkConnection>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
                     </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
                         <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
                         <Enabled>false</Enabled>
                         <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>a28be0c0-d70d-4047-92f8-fc217bbaa7f6</VirtualMachineId>
+                        <VirtualMachineId>350947aa-c16e-4eb3-98c1-fced9dac6dbc</VirtualMachineId>
                         <JoinDomainEnabled>false</JoinDomainEnabled>
                         <UseOrgSettings>false</UseOrgSettings>
                         <AdminPasswordEnabled>true</AdminPasswordEnabled>
                         <AdminPasswordAuto>true</AdminPasswordAuto>
                         <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>CentOS7-0</ComputerName>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+                        <ComputerName>93e8f5e5-7b-001</ComputerName>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
                     </GuestCustomizationSection>
-                    <RuntimeInfoSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/runtimeInfoSection" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml">
+                    <ovf:ProductSection ovf:class="" ovf:instance="" ovf:required="true">
+                        <ovf:Info>Information about the installed software</ovf:Info>
+                        <ovf:Product>ManageIQ</ovf:Product>
+                        <ovf:Vendor>ManageIQ</ovf:Vendor>
+                        <ovf:Version>gaprindashvili</ovf:Version>
+                    </ovf:ProductSection>
+                    <RuntimeInfoSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/runtimeInfoSection">
                         <ovf:Info>Specifies Runtime info</ovf:Info>
-                        <VMWareTools version="10240"/>
+                        <VMWareTools version="10277"/>
                     </RuntimeInfoSection>
-                    <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+                    <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
                         <ovf:Info>Snapshot information section</ovf:Info>
                     </SnapshotSection>
-                    <DateCreated>2016-09-16T11:46:14.080+03:00</DateCreated>
-                    <VAppScopedLocalId>7ff5cc28-e2e0-4466-bf78-e39a3522d539</VAppScopedLocalId>
-                    <VmCapabilities href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
+                    <DateCreated>2018-02-20T12:19:59.892+01:00</DateCreated>
+                    <VAppScopedLocalId>93e8f5e5-7b61-40ed-ae94-4193eda19fec</VAppScopedLocalId>
+                    <ovfenv:Environment xmlns:ve="http://www.vmware.com/schema/ovfenv" ovfenv:id="" ve:vCenterId="vm-609">
+                        <ovfenv:PlatformSection>
+                            <ovfenv:Kind>VMware ESXi</ovfenv:Kind>
+                            <ovfenv:Version>6.5.0</ovfenv:Version>
+                            <ovfenv:Vendor>VMware, Inc.</ovfenv:Vendor>
+                            <ovfenv:Locale>en</ovfenv:Locale>
+                        </ovfenv:PlatformSection>
+                        <ve:EthernetAdapterSection xmlns="http://schemas.dmtf.org/ovf/environment/1" xmlns:oe="http://schemas.dmtf.org/ovf/environment/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                            <ve:Adapter ve:mac="00:50:56:01:00:66" ve:network="VM Network" ve:unitNumber="7"/>
+           </ve:EthernetAdapterSection>
+                    </ovfenv:Environment>
+                    <VmCapabilities href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
                         <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
                         <CpuHotAddEnabled>false</CpuHotAddEnabled>
                     </VmCapabilities>
-                    <StorageProfile href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <StorageProfile href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/b652f213-33aa-4c1f-8f30-ea2919a30843" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
                 </Vm>
             </Children>
         </VApp>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:52:19 GMT
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:30 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.42.0
+      - fog-core/1.45.0
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Date:
-      - Fri, 16 Sep 2016 08:52:24 GMT
+      - Wed, 14 Mar 2018 10:54:30 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 49618612-4f80-4e01-bd82-b1c762a59b52
+      - 826936e7-4744-4144-8cfd-d5b83cca7ffb
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
       Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '202'
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
       Content-Type:
       - application/vnd.vmware.vcloud.vapp+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-    body:
-      encoding: ASCII-8BIT
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VApp xmlns=\"http://www.vmware.com/vcloud/v1.5\"
-        xmlns:ovf=\"http://schemas.dmtf.org/ovf/envelope/1\" xmlns:vssd=\"http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData\"
-        xmlns:rasd=\"http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData\"
-        xmlns:vmw=\"http://www.vmware.com/schema/ovf\" xmlns:ovfenv=\"http://schemas.dmtf.org/ovf/environment/1\"
-        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" ovfDescriptorUploaded=\"true\"
-        deployed=\"true\" status=\"4\" name=\"spec-1\" id=\"urn:vcloud:vapp:0d7614c3-a61d-4d11-a733-aa2a8f6038b4\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4\"
-        type=\"application/vnd.vmware.vcloud.vApp+xml\" xsi:schemaLocation=\"http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData
-        http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd
-        http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1
-        http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://schemas.dmtf.org/ovf/environment/1
-        http://schemas.dmtf.org/ovf/envelope/1/dsp8027_1.1.0.xsd http://www.vmware.com/vcloud/v1.5
-        http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData
-        http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd\">\n
-        \   <Link rel=\"power:powerOff\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/power/action/powerOff\"/>\n
-        \   <Link rel=\"power:reboot\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/power/action/reboot\"/>\n
-        \   <Link rel=\"power:reset\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/power/action/reset\"/>\n
-        \   <Link rel=\"power:shutdown\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/power/action/shutdown\"/>\n
-        \   <Link rel=\"power:suspend\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/power/action/suspend\"/>\n
-        \   <Link rel=\"deploy\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/action/deploy\"
-        type=\"application/vnd.vmware.vcloud.deployVAppParams+xml\"/>\n    <Link rel=\"undeploy\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/action/undeploy\"
-        type=\"application/vnd.vmware.vcloud.undeployVAppParams+xml\"/>\n    <Link
-        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/network/a0912234-e83d-4162-aef1-b48556cef93f\"
-        name=\"INT_192.168.10.0m24\" type=\"application/vnd.vmware.vcloud.vAppNetwork+xml\"/>\n
-        \   <Link rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/controlAccess/\"
-        type=\"application/vnd.vmware.vcloud.controlAccess+xml\"/>\n    <Link rel=\"controlAccess\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/action/controlAccess\"
-        type=\"application/vnd.vmware.vcloud.controlAccess+xml\"/>\n    <Link rel=\"up\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676\"
-        type=\"application/vnd.vmware.vcloud.vdc+xml\"/>\n    <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4\"
-        type=\"application/vnd.vmware.vcloud.vApp+xml\"/>\n    <Link rel=\"down\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/owner\"
-        type=\"application/vnd.vmware.vcloud.owner+xml\"/>\n    <Link rel=\"down\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/metadata\"
-        type=\"application/vnd.vmware.vcloud.metadata+xml\"/>\n    <Link rel=\"ovf\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/ovf\"
-        type=\"text/xml\"/>\n    <Link rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/productSections/\"
-        type=\"application/vnd.vmware.vcloud.productSections+xml\"/>\n    <Link rel=\"snapshot:create\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/action/createSnapshot\"
-        type=\"application/vnd.vmware.vcloud.createSnapshotParams+xml\"/>\n    <Description/>\n
-        \   <LeaseSettingsSection href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/leaseSettingsSection/\"
-        type=\"application/vnd.vmware.vcloud.leaseSettingsSection+xml\" ovf:required=\"false\">\n
-        \       <ovf:Info>Lease settings section</ovf:Info>\n        <Link rel=\"edit\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/leaseSettingsSection/\"
-        type=\"application/vnd.vmware.vcloud.leaseSettingsSection+xml\"/>\n        <DeploymentLeaseInSeconds>604800</DeploymentLeaseInSeconds>\n
-        \       <StorageLeaseInSeconds>2592000</StorageLeaseInSeconds>\n        <DeploymentLeaseExpiration>2016-09-23T11:46:52.987+03:00</DeploymentLeaseExpiration>\n
-        \   </LeaseSettingsSection>\n    <ovf:StartupSection xmlns:vcloud=\"http://www.vmware.com/vcloud/v1.5\"
-        vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/startupSection/\"
-        vcloud:type=\"application/vnd.vmware.vcloud.startupSection+xml\">\n        <ovf:Info>VApp
-        startup section</ovf:Info>\n        <ovf:Item ovf:id=\"spec1-vm1\" ovf:order=\"0\"
-        ovf:startAction=\"powerOn\" ovf:startDelay=\"0\" ovf:stopAction=\"powerOff\"
-        ovf:stopDelay=\"0\"/>\n        <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/startupSection/\"
-        type=\"application/vnd.vmware.vcloud.startupSection+xml\"/>\n    </ovf:StartupSection>\n
-        \   <ovf:NetworkSection xmlns:vcloud=\"http://www.vmware.com/vcloud/v1.5\"
-        vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/networkSection/\"
-        vcloud:type=\"application/vnd.vmware.vcloud.networkSection+xml\">\n        <ovf:Info>The
-        list of logical networks</ovf:Info>\n        <ovf:Network ovf:name=\"INT_192.168.10.0m24\">\n
-        \           <ovf:Description/>\n        </ovf:Network>\n    </ovf:NetworkSection>\n
-        \   <NetworkConfigSection href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/networkConfigSection/\"
-        type=\"application/vnd.vmware.vcloud.networkConfigSection+xml\" ovf:required=\"false\">\n
-        \       <ovf:Info>The configuration parameters for logical networks</ovf:Info>\n
-        \       <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/networkConfigSection/\"
-        type=\"application/vnd.vmware.vcloud.networkConfigSection+xml\"/>\n        <NetworkConfig
-        networkName=\"INT_192.168.10.0m24\">\n            <Link rel=\"repair\" href=\"https://VMWARE_CLOUD_HOST/api/admin/network/a0912234-e83d-4162-aef1-b48556cef93f/action/reset\"/>\n
-        \           <Description/>\n            <Configuration>\n                <IpScopes>\n
-        \                   <IpScope>\n                        <IsInherited>true</IsInherited>\n
-        \                       <Gateway>192.168.10.1</Gateway>\n                        <Netmask>255.255.255.0</Netmask>\n
-        \                       <Dns1>192.168.10.1</Dns1>\n                        <DnsSuffix>test.local</DnsSuffix>\n
-        \                       <IsEnabled>true</IsEnabled>\n                        <IpRanges>\n
-        \                           <IpRange>\n                                <StartAddress>192.168.10.100</StartAddress>\n
-        \                               <EndAddress>192.168.10.199</EndAddress>\n
-        \                           </IpRange>\n                        </IpRanges>\n
-        \                   </IpScope>\n                </IpScopes>\n                <ParentNetwork
-        href=\"https://VMWARE_CLOUD_HOST/api/admin/network/5ae840de-198e-4a34-a30a-6c36377460c6\"
-        id=\"5ae840de-198e-4a34-a30a-6c36377460c6\" name=\"INT_192.168.10.0m24\"/>\n
-        \               <FenceMode>bridged</FenceMode>\n                <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>\n
-        \           </Configuration>\n            <IsDeployed>true</IsDeployed>\n
-        \       </NetworkConfig>\n    </NetworkConfigSection>\n    <SnapshotSection
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/snapshotSection\"
-        type=\"application/vnd.vmware.vcloud.snapshotSection+xml\" ovf:required=\"false\">\n
-        \       <ovf:Info>Snapshot information section</ovf:Info>\n    </SnapshotSection>\n
-        \   <DateCreated>2016-09-16T11:45:24.897+03:00</DateCreated>\n    <Owner type=\"application/vnd.vmware.vcloud.owner+xml\">\n
-        \       <User href=\"https://VMWARE_CLOUD_HOST/api/admin/user/81585659-9eaa-46e7-8100-3b0ea0aa4fd6\"
-        name=\"bergigre_remote\" type=\"application/vnd.vmware.admin.user+xml\"/>\n
-        \   </Owner>\n    <InMaintenanceMode>false</InMaintenanceMode>\n    <Children>\n
-        \       <Vm needsCustomization=\"false\" nestedHypervisorEnabled=\"false\"
-        deployed=\"true\" status=\"4\" name=\"spec1-vm1\" id=\"urn:vcloud:vm:f9ceb77c-b9d9-400c-8c06-72c785e884af\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af\"
-        type=\"application/vnd.vmware.vcloud.vm+xml\">\n            <Link rel=\"power:powerOff\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/power/action/powerOff\"/>\n
-        \           <Link rel=\"power:reboot\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/power/action/reboot\"/>\n
-        \           <Link rel=\"power:reset\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/power/action/reset\"/>\n
-        \           <Link rel=\"power:shutdown\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/power/action/shutdown\"/>\n
-        \           <Link rel=\"power:suspend\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/power/action/suspend\"/>\n
-        \           <Link rel=\"undeploy\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/action/undeploy\"
-        type=\"application/vnd.vmware.vcloud.undeployVAppParams+xml\"/>\n            <Link
-        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af\"
-        type=\"application/vnd.vmware.vcloud.vm+xml\"/>\n            <Link rel=\"down\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/metadata\"
-        type=\"application/vnd.vmware.vcloud.metadata+xml\"/>\n            <Link rel=\"down\"
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/productSections/\"
-        type=\"application/vnd.vmware.vcloud.productSections+xml\"/>\n            <Link
-        rel=\"screen:thumbnail\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/screen\"/>\n
-        \           <Link rel=\"screen:acquireTicket\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/screen/action/acquireTicket\"/>\n
-        \           <Link rel=\"media:insertMedia\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/media/action/insertMedia\"
-        type=\"application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml\"/>\n            <Link
-        rel=\"media:ejectMedia\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/media/action/ejectMedia\"
-        type=\"application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml\"/>\n            <Link
-        rel=\"disk:attach\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/disk/action/attach\"
-        type=\"application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml\"/>\n            <Link
-        rel=\"disk:detach\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/disk/action/detach\"
-        type=\"application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml\"/>\n            <Link
-        rel=\"installVmwareTools\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/action/installVMwareTools\"/>\n
-        \           <Link rel=\"snapshot:create\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/action/createSnapshot\"
-        type=\"application/vnd.vmware.vcloud.createSnapshotParams+xml\"/>\n            <Link
-        rel=\"reconfigureVm\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/action/reconfigureVm\"
-        name=\"spec1-vm1\" type=\"application/vnd.vmware.vcloud.vm+xml\"/>\n            <Link
-        rel=\"up\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4\"
-        type=\"application/vnd.vmware.vcloud.vApp+xml\"/>\n            <Description/>\n
-        \           <ovf:VirtualHardwareSection xmlns:vcloud=\"http://www.vmware.com/vcloud/v1.5\"
-        ovf:transport=\"\" vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/\"
-        vcloud:type=\"application/vnd.vmware.vcloud.virtualHardwareSection+xml\">\n
-        \               <ovf:Info>Virtual hardware requirements</ovf:Info>\n                <ovf:System>\n
-        \                   <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>\n
-        \                   <vssd:InstanceID>0</vssd:InstanceID>\n                    <vssd:VirtualSystemIdentifier>spec1-vm1</vssd:VirtualSystemIdentifier>\n
-        \                   <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>\n
-        \               </ovf:System>\n                <ovf:Item>\n                    <rasd:Address>00:50:56:01:00:64</rasd:Address>\n
-        \                   <rasd:AddressOnParent>0</rasd:AddressOnParent>\n                    <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>\n
-        \                   <rasd:Connection vcloud:ipAddress=\"192.168.10.100\" vcloud:primaryNetworkConnection=\"true\"
-        vcloud:ipAddressingMode=\"POOL\">INT_192.168.10.0m24</rasd:Connection>\n                    <rasd:Description>Vmxnet3
-        ethernet adapter on \"INT_192.168.10.0m24\"</rasd:Description>\n                    <rasd:ElementName>Network
-        adapter 0</rasd:ElementName>\n                    <rasd:InstanceID>1</rasd:InstanceID>\n
-        \                   <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>\n
-        \                   <rasd:ResourceType>10</rasd:ResourceType>\n                </ovf:Item>\n
-        \               <ovf:Item>\n                    <rasd:Address>0</rasd:Address>\n
-        \                   <rasd:Description>SCSI Controller</rasd:Description>\n
-        \                   <rasd:ElementName>SCSI Controller 0</rasd:ElementName>\n
-        \                   <rasd:InstanceID>2</rasd:InstanceID>\n                    <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>\n
-        \                   <rasd:ResourceType>6</rasd:ResourceType>\n                </ovf:Item>\n
-        \               <ovf:Item>\n                    <rasd:AddressOnParent>0</rasd:AddressOnParent>\n
-        \                   <rasd:Description>Hard disk</rasd:Description>\n                    <rasd:ElementName>Hard
-        disk 1</rasd:ElementName>\n                    <rasd:HostResource vcloud:capacity=\"16384\"
-        vcloud:busSubType=\"lsilogic\" vcloud:busType=\"6\"/>\n                    <rasd:InstanceID>2000</rasd:InstanceID>\n
-        \                   <rasd:Parent>2</rasd:Parent>\n                    <rasd:ResourceType>17</rasd:ResourceType>\n
-        \                   <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>\n
-        \                   <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>\n
-        \               </ovf:Item>\n                <ovf:Item>\n                    <rasd:Address>0</rasd:Address>\n
-        \                   <rasd:Description>IDE Controller</rasd:Description>\n
-        \                   <rasd:ElementName>IDE Controller 0</rasd:ElementName>\n
-        \                   <rasd:InstanceID>3</rasd:InstanceID>\n                    <rasd:ResourceType>5</rasd:ResourceType>\n
-        \               </ovf:Item>\n                <ovf:Item>\n                    <rasd:AddressOnParent>0</rasd:AddressOnParent>\n
-        \                   <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>\n
-        \                   <rasd:Description>CD/DVD Drive</rasd:Description>\n                    <rasd:ElementName>CD/DVD
-        Drive 1</rasd:ElementName>\n                    <rasd:HostResource/>\n                    <rasd:InstanceID>3000</rasd:InstanceID>\n
-        \                   <rasd:Parent>3</rasd:Parent>\n                    <rasd:ResourceType>15</rasd:ResourceType>\n
-        \               </ovf:Item>\n                <ovf:Item>\n                    <rasd:AddressOnParent>0</rasd:AddressOnParent>\n
-        \                   <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>\n
-        \                   <rasd:Description>Floppy Drive</rasd:Description>\n                    <rasd:ElementName>Floppy
-        Drive 1</rasd:ElementName>\n                    <rasd:HostResource/>\n                    <rasd:InstanceID>8000</rasd:InstanceID>\n
-        \                   <rasd:ResourceType>14</rasd:ResourceType>\n                </ovf:Item>\n
-        \               <ovf:Item vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/cpu\"
-        vcloud:type=\"application/vnd.vmware.vcloud.rasdItem+xml\">\n                    <rasd:AllocationUnits>hertz
-        * 10^6</rasd:AllocationUnits>\n                    <rasd:Description>Number
-        of Virtual CPUs</rasd:Description>\n                    <rasd:ElementName>2
-        virtual CPU(s)</rasd:ElementName>\n                    <rasd:InstanceID>4</rasd:InstanceID>\n
-        \                   <rasd:Reservation>0</rasd:Reservation>\n                    <rasd:ResourceType>3</rasd:ResourceType>\n
-        \                   <rasd:VirtualQuantity>2</rasd:VirtualQuantity>\n                    <rasd:Weight>0</rasd:Weight>\n
-        \                   <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/cpu\"
-        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                </ovf:Item>\n
-        \               <ovf:Item vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/memory\"
-        vcloud:type=\"application/vnd.vmware.vcloud.rasdItem+xml\">\n                    <rasd:AllocationUnits>byte
-        * 2^20</rasd:AllocationUnits>\n                    <rasd:Description>Memory
-        Size</rasd:Description>\n                    <rasd:ElementName>2048 MB of
-        memory</rasd:ElementName>\n                    <rasd:InstanceID>5</rasd:InstanceID>\n
-        \                   <rasd:Reservation>0</rasd:Reservation>\n                    <rasd:ResourceType>4</rasd:ResourceType>\n
-        \                   <rasd:VirtualQuantity>2048</rasd:VirtualQuantity>\n                    <rasd:Weight>0</rasd:Weight>\n
-        \                   <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/memory\"
-        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                </ovf:Item>\n
-        \               <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/\"
-        type=\"application/vnd.vmware.vcloud.virtualHardwareSection+xml\"/>\n                <Link
-        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/cpu\"
-        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                <Link
-        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/cpu\"
-        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                <Link
-        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/memory\"
-        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                <Link
-        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/memory\"
-        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                <Link
-        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/disks\"
-        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
-        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/disks\"
-        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
-        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/media\"
-        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
-        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/networkCards\"
-        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
-        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/networkCards\"
-        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
-        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/serialPorts\"
-        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
-        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/serialPorts\"
-        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n            </ovf:VirtualHardwareSection>\n
-        \           <ovf:OperatingSystemSection xmlns:vcloud=\"http://www.vmware.com/vcloud/v1.5\"
-        ovf:id=\"101\" vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/operatingSystemSection/\"
-        vcloud:type=\"application/vnd.vmware.vcloud.operatingSystemSection+xml\" vmw:osType=\"centos64Guest\">\n
-        \               <ovf:Info>Specifies the operating system installed</ovf:Info>\n
-        \               <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>\n
-        \               <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/operatingSystemSection/\"
-        type=\"application/vnd.vmware.vcloud.operatingSystemSection+xml\"/>\n            </ovf:OperatingSystemSection>\n
-        \           <NetworkConnectionSection href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/networkConnectionSection/\"
-        type=\"application/vnd.vmware.vcloud.networkConnectionSection+xml\" ovf:required=\"false\">\n
-        \               <ovf:Info>Specifies the available VM network connections</ovf:Info>\n
-        \               <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>\n
-        \               <NetworkConnection needsCustomization=\"true\" network=\"INT_192.168.10.0m24\">\n
-        \                   <NetworkConnectionIndex>0</NetworkConnectionIndex>\n                    <IpAddress>192.168.10.100</IpAddress>\n
-        \                   <IsConnected>true</IsConnected>\n                    <MACAddress>00:50:56:01:00:64</MACAddress>\n
-        \                   <IpAddressAllocationMode>POOL</IpAddressAllocationMode>\n
-        \               </NetworkConnection>\n                <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/networkConnectionSection/\"
-        type=\"application/vnd.vmware.vcloud.networkConnectionSection+xml\"/>\n            </NetworkConnectionSection>\n
-        \           <GuestCustomizationSection href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/guestCustomizationSection/\"
-        type=\"application/vnd.vmware.vcloud.guestCustomizationSection+xml\" ovf:required=\"false\">\n
-        \               <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>\n
-        \               <Enabled>false</Enabled>\n                <ChangeSid>false</ChangeSid>\n
-        \               <VirtualMachineId>f9ceb77c-b9d9-400c-8c06-72c785e884af</VirtualMachineId>\n
-        \               <JoinDomainEnabled>false</JoinDomainEnabled>\n                <UseOrgSettings>false</UseOrgSettings>\n
-        \               <AdminPasswordEnabled>true</AdminPasswordEnabled>\n                <AdminPasswordAuto>true</AdminPasswordAuto>\n
-        \               <ResetPasswordRequired>false</ResetPasswordRequired>\n                <ComputerName>CentOS7-0</ComputerName>\n
-        \               <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/guestCustomizationSection/\"
-        type=\"application/vnd.vmware.vcloud.guestCustomizationSection+xml\"/>\n            </GuestCustomizationSection>\n
-        \           <RuntimeInfoSection xmlns:vcloud=\"http://www.vmware.com/vcloud/v1.5\"
-        vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/runtimeInfoSection\"
-        vcloud:type=\"application/vnd.vmware.vcloud.virtualHardwareSection+xml\">\n
-        \               <ovf:Info>Specifies Runtime info</ovf:Info>\n                <VMWareTools
-        version=\"10240\"/>\n            </RuntimeInfoSection>\n            <SnapshotSection
-        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/snapshotSection\"
-        type=\"application/vnd.vmware.vcloud.snapshotSection+xml\" ovf:required=\"false\">\n
-        \               <ovf:Info>Snapshot information section</ovf:Info>\n            </SnapshotSection>\n
-        \           <DateCreated>2016-09-16T11:45:30.557+03:00</DateCreated>\n            <VAppScopedLocalId>7ff5cc28-e2e0-4466-bf78-e39a3522d539</VAppScopedLocalId>\n
-        \           <ovfenv:Environment xmlns:ns11=\"http://www.vmware.com/schema/ovfenv\"
-        ovfenv:id=\"\" ns11:vCenterId=\"vm-589\">\n                <ovfenv:PlatformSection>\n
-        \                   <ovfenv:Kind>VMware ESXi</ovfenv:Kind>\n                    <ovfenv:Version>6.0.0</ovfenv:Version>\n
-        \                   <ovfenv:Vendor>VMware, Inc.</ovfenv:Vendor>\n                    <ovfenv:Locale>en</ovfenv:Locale>\n
-        \               </ovfenv:PlatformSection>\n                <ve:EthernetAdapterSection
-        xmlns:ve=\"http://www.vmware.com/schema/ovfenv\" xmlns=\"http://schemas.dmtf.org/ovf/environment/1\"
-        xmlns:oe=\"http://schemas.dmtf.org/ovf/environment/1\">\n                    <ve:Adapter
-        ve:mac=\"00:50:56:01:00:64\" ve:network=\"vxw-dvs-128-virtualwire-18-sid-5004-dvs.VCDVSINT_192.168.10.0m24-55dcece1-954f-4\"
-        ve:unitNumber=\"7\"/>\n   \n                </ve:EthernetAdapterSection>\n
-        \           </ovfenv:Environment>\n            <VmCapabilities href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/vmCapabilities/\"
-        type=\"application/vnd.vmware.vcloud.vmCapabilitiesSection+xml\">\n                <Link
-        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/vmCapabilities/\"
-        type=\"application/vnd.vmware.vcloud.vmCapabilitiesSection+xml\"/>\n                <MemoryHotAddEnabled>false</MemoryHotAddEnabled>\n
-        \               <CpuHotAddEnabled>false</CpuHotAddEnabled>\n            </VmCapabilities>\n
-        \           <StorageProfile href=\"https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8\"
-        name=\"Dual site - Tier 1\" type=\"application/vnd.vmware.vcloud.vdcStorageProfile+xml\"/>\n
-        \       </Vm>\n    </Children>\n</VApp>\n"
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:52:25 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:52:30 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - b8589d88-f899-4e82-a6df-6886e1e71a6b
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '275'
-      Content-Type:
-      - application/vnd.vmware.vcloud.vapp+xml;version=5.1
+      - '109'
       Vary:
       - Accept-Encoding, User-Agent
     body:
       encoding: ASCII-8BIT
       string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovfDescriptorUploaded="true" deployed="false" status="3" name="vApp_system_4" id="urn:vcloud:vapp:6aa2d7ae-5245-45a0-82e8-4984e759ba5d" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d" type="application/vnd.vmware.vcloud.vApp+xml" xsi:schemaLocation="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
-            <Link rel="power:powerOn" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/power/action/powerOn"/>
-            <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-            <Link rel="discardState" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/action/discardSuspendedState"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/network/82759035-35af-4b27-a273-65e3dcaefb73" name="testnet" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="controlAccess" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="recompose" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/action/recomposeVApp" type="application/vnd.vmware.vcloud.recomposeVAppParams+xml"/>
-            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d" type="application/vnd.vmware.vcloud.vApp+xml"/>
-            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/ovf" type="text/xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
-            <Description/>
-            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" ovfDescriptorUploaded="true" deployed="false" status="8" name="spec2-vapp" id="urn:vcloud:vapp:0e8b6b49-f42f-43c0-9c15-368d01c222c9" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9" type="application/vnd.vmware.vcloud.vApp+xml">
+            <Link rel="power:powerOn" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/power/action/powerOn"/>
+            <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/network/bff5aa08-9e67-45ce-a02e-a10eb64b292a" name="spec2-network" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="controlAccess" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="recompose" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/action/recomposeVApp" type="application/vnd.vmware.vcloud.recomposeVAppParams+xml"/>
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9" type="application/vnd.vmware.vcloud.vApp+xml"/>
+            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9"/>
+            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/action/enableDownload"/>
+            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/action/disableDownload"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/ovf" type="text/xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+            <Link rel="snapshot:revertToCurrent" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/action/revertToCurrentSnapshot"/>
+            <Link rel="snapshot:removeAll" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/action/removeAllSnapshots"/>
+            <Description></Description>
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
                 <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
-                <DeploymentLeaseInSeconds>604800</DeploymentLeaseInSeconds>
-                <StorageLeaseInSeconds>2592000</StorageLeaseInSeconds>
-                <StorageLeaseExpiration>2016-10-15T16:56:20.453+03:00</StorageLeaseExpiration>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <DeploymentLeaseInSeconds>2592000</DeploymentLeaseInSeconds>
+                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
+                <StorageLeaseExpiration>2018-06-07T14:54:52.870+02:00</StorageLeaseExpiration>
             </LeaseSettingsSection>
-            <ovf:StartupSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/startupSection/" vcloud:type="application/vnd.vmware.vcloud.startupSection+xml">
+            <ovf:StartupSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.startupSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/startupSection/">
                 <ovf:Info>VApp startup section</ovf:Info>
-                <ovf:Item ovf:id="CentOS7" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
+                <ovf:Item ovf:id="spec2-vm1" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
             </ovf:StartupSection>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
+            <ovf:NetworkSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.networkSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/networkSection/">
                 <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="testnet">
-                    <ovf:Description/>
+                <ovf:Network ovf:name="spec2-network">
+                    <ovf:Description></ovf:Description>
                 </ovf:Network>
             </ovf:NetworkSection>
-            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
                 <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
-                <NetworkConfig networkName="testnet">
-                    <Link rel="repair" href="https://VMWARE_CLOUD_HOST/api/admin/network/82759035-35af-4b27-a273-65e3dcaefb73/action/reset"/>
-                    <Description/>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
+                <NetworkConfig networkName="spec2-network">
+                    <Link rel="repair" href="https://VMWARE_CLOUD_HOST/api/admin/network/bff5aa08-9e67-45ce-a02e-a10eb64b292a/action/reset"/>
+                    <Description></Description>
                     <Configuration>
                         <IpScopes>
                             <IpScope>
@@ -1509,8 +1186,894 @@ http_interactions:
                                 <IsEnabled>true</IsEnabled>
                                 <IpRanges>
                                     <IpRange>
-                                        <StartAddress>192.168.2.100</StartAddress>
-                                        <EndAddress>192.168.2.199</EndAddress>
+        <StartAddress>192.168.2.100</StartAddress>
+        <EndAddress>192.168.2.199</EndAddress>
+                                    </IpRange>
+                                </IpRanges>
+                            </IpScope>
+                        </IpScopes>
+                        <FenceMode>isolated</FenceMode>
+                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
+                        <Features>
+                            <DhcpService>
+                                <IsEnabled>false</IsEnabled>
+                                <DefaultLeaseTime>3600</DefaultLeaseTime>
+                                <MaxLeaseTime>7200</MaxLeaseTime>
+                            </DhcpService>
+                        </Features>
+                    </Configuration>
+                    <IsDeployed>false</IsDeployed>
+                </NetworkConfig>
+            </NetworkConfigSection>
+            <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+                <ovf:Info>Snapshot information section</ovf:Info>
+                <Snapshot created="2018-03-12T15:43:30.986+01:00" poweredOn="false" size="17179869184"/>
+            </SnapshotSection>
+            <DateCreated>2018-03-09T13:39:00.260+01:00</DateCreated>
+            <Owner type="application/vnd.vmware.vcloud.owner+xml">
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/f3555478-d7ea-4d9c-9b48-4bced57539e3" name="system" type="application/vnd.vmware.admin.user+xml"/>
+            </Owner>
+            <InMaintenanceMode>false</InMaintenanceMode>
+            <Children>
+                <Vm needsCustomization="false" nestedHypervisorEnabled="false" deployed="false" status="8" name="spec2-vm1" id="urn:vcloud:vm:aaf94123-cbf9-4de9-841c-41dd41ac310e" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="power:powerOn" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/power/action/powerOn"/>
+                    <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
+                    <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Link rel="screen:thumbnail" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/screen"/>
+                    <Link rel="media:insertMedia" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
+                    <Link rel="media:ejectMedia" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
+                    <Link rel="disk:attach" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
+                    <Link rel="disk:detach" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
+                    <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/action/enableNestedHypervisor"/>
+                    <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+                    <Link rel="snapshot:revertToCurrent" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/action/revertToCurrentSnapshot"/>
+                    <Link rel="snapshot:removeAll" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/action/removeAllSnapshots"/>
+                    <Link rel="reconfigureVm" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/action/reconfigureVm" name="spec2-vm1" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9" type="application/vnd.vmware.vcloud.vApp+xml"/>
+                    <Description></Description>
+                    <ovf:VirtualHardwareSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ovf:transport="" ns13:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/">
+                        <ovf:Info>Virtual hardware requirements</ovf:Info>
+                        <ovf:System>
+                            <vssd:AutomaticRecoveryAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticShutdownAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticStartupAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticStartupActionDelay xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticStartupActionSequenceNumber xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:CreationTime xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:Description xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+                            <vssd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:InstanceID>0</vssd:InstanceID>
+                            <vssd:LogDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:RecoveryFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:SnapshotDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:SuspendDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:SwapFileDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:VirtualSystemIdentifier>spec2-vm1</vssd:VirtualSystemIdentifier>
+                            <vssd:VirtualSystemType>vmx-13</vssd:VirtualSystemType>
+                        </ovf:System>
+                        <ovf:Item>
+                            <rasd:Address>00:50:56:01:00:d9</rasd:Address>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Connection ns13:ipAddressingMode="POOL" ns13:ipAddress="192.168.2.100" ns13:primaryNetworkConnection="true">spec2-network</rasd:Connection>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>Vmxnet3 ethernet adapter on "spec2-network"</rasd:Description>
+                            <rasd:ElementName>Network adapter 0</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:InstanceID>1</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
+                            <rasd:ResourceType>10</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address>0</rasd:Address>
+                            <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>SCSI Controller</rasd:Description>
+                            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:InstanceID>2</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType>VirtualSCSI</rasd:ResourceSubType>
+                            <rasd:ResourceType>6</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>Hard disk</rasd:Description>
+                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:HostResource ns13:busType="6" ns13:busSubType="VirtualSCSI" ns13:capacity="16384"></rasd:HostResource>
+                            <rasd:InstanceID>2000</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent>2</rasd:Parent>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceType>17</rasd:ResourceType>
+                            <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address>0</rasd:Address>
+                            <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>IDE Controller</rasd:Description>
+                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:InstanceID>3</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceType>5</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>CD/DVD Drive</rasd:Description>
+                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:HostResource></rasd:HostResource>
+                            <rasd:InstanceID>3000</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent>3</rasd:Parent>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceType>15</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>Floppy Drive</rasd:Description>
+                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:HostResource></rasd:HostResource>
+                            <rasd:InstanceID>8000</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceType>14</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                        </ovf:Item>
+                        <ovf:Item ns13:type="application/vnd.vmware.vcloud.rasdItem+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/cpu">
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>Number of Virtual CPUs</rasd:Description>
+                            <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:InstanceID>4</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceType>3</rasd:ResourceType>
+                            <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight>0</rasd:Weight>
+                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        </ovf:Item>
+                        <ovf:Item ns13:type="application/vnd.vmware.vcloud.rasdItem+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/memory">
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>Memory Size</rasd:Description>
+                            <rasd:ElementName>256 MB of memory</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:InstanceID>5</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceType>4</rasd:ResourceType>
+                            <rasd:VirtualQuantity>256</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight>0</rasd:Weight>
+                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        </ovf:Item>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                    </ovf:VirtualHardwareSection>
+                    <ovf:OperatingSystemSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ovf:id="102" ns13:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="vmwarePhoton64Guest" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/operatingSystemSection/">
+                        <ovf:Info>Specifies the operating system installed</ovf:Info>
+                        <ovf:Description>VMware Photon OS (64-bit)</ovf:Description>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
+                    </ovf:OperatingSystemSection>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+                        <NetworkConnection needsCustomization="false" network="spec2-network">
+                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IpAddress>192.168.2.100</IpAddress>
+                            <IsConnected>true</IsConnected>
+                            <MACAddress>00:50:56:01:00:d9</MACAddress>
+                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
+                        </NetworkConnection>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
+                    </NetworkConnectionSection>
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <Enabled>false</Enabled>
+                        <ChangeSid>false</ChangeSid>
+                        <VirtualMachineId>aaf94123-cbf9-4de9-841c-41dd41ac310e</VirtualMachineId>
+                        <JoinDomainEnabled>false</JoinDomainEnabled>
+                        <UseOrgSettings>false</UseOrgSettings>
+                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
+                        <AdminPasswordAuto>true</AdminPasswordAuto>
+                        <ResetPasswordRequired>false</ResetPasswordRequired>
+                        <ComputerName>spec2-vm1</ComputerName>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+                    </GuestCustomizationSection>
+                    <RuntimeInfoSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/runtimeInfoSection">
+                        <ovf:Info>Specifies Runtime info</ovf:Info>
+                    </RuntimeInfoSection>
+                    <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+                        <ovf:Info>Snapshot information section</ovf:Info>
+                        <Snapshot created="2018-03-12T15:43:30.986+01:00" poweredOn="false" size="17179869184"/>
+                    </SnapshotSection>
+                    <DateCreated>2018-03-09T13:39:02.741+01:00</DateCreated>
+                    <VAppScopedLocalId>0166f57b-6ae3-47fe-a68b-4f7bebb61074</VAppScopedLocalId>
+                    <VmCapabilities href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
+                        <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
+                        <CpuHotAddEnabled>false</CpuHotAddEnabled>
+                    </VmCapabilities>
+                    <StorageProfile href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/b652f213-33aa-4c1f-8f30-ea2919a30843" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                </Vm>
+            </Children>
+        </VApp>
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:30 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - ee9f52dbb4d245048614dba57e182fd3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 Mar 2018 10:54:30 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 0f494886-f7e4-4c19-af3e-520fe58dbf90
+      X-Vcloud-Authorization:
+      - ee9f52dbb4d245048614dba57e182fd3
+      Set-Cookie:
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapp+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '106'
+      Vary:
+      - Accept-Encoding, User-Agent
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" ovfDescriptorUploaded="true" deployed="true" status="4" name="spec1-vapp" id="urn:vcloud:vapp:a715dec5-7ab1-487e-993b-82fcd7eb8172" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172" type="application/vnd.vmware.vcloud.vApp+xml">
+            <Link rel="power:powerOff" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/power/action/powerOff"/>
+            <Link rel="power:reboot" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/power/action/reboot"/>
+            <Link rel="power:reset" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/power/action/reset"/>
+            <Link rel="power:shutdown" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/power/action/shutdown"/>
+            <Link rel="power:suspend" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/power/action/suspend"/>
+            <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
+            <Link rel="undeploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/action/undeploy" type="application/vnd.vmware.vcloud.undeployVAppParams+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/network/479eadc5-a17f-46b4-b580-6e2fb87971c9" name="spec1-network" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="controlAccess" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="recompose" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/action/recomposeVApp" type="application/vnd.vmware.vcloud.recomposeVAppParams+xml"/>
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172" type="application/vnd.vmware.vcloud.vApp+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/ovf" type="text/xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+            <Description></Description>
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+                <ovf:Info>Lease settings section</ovf:Info>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <DeploymentLeaseInSeconds>2592000</DeploymentLeaseInSeconds>
+                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
+                <DeploymentLeaseExpiration>2018-04-12T11:18:05.418+02:00</DeploymentLeaseExpiration>
+            </LeaseSettingsSection>
+            <ovf:StartupSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.startupSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/startupSection/">
+                <ovf:Info>VApp startup section</ovf:Info>
+                <ovf:Item ovf:id="spec1-vm1" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
+            </ovf:StartupSection>
+            <ovf:NetworkSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.networkSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/networkSection/">
+                <ovf:Info>The list of logical networks</ovf:Info>
+                <ovf:Network ovf:name="spec1-network">
+                    <ovf:Description></ovf:Description>
+                </ovf:Network>
+            </ovf:NetworkSection>
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
+                <NetworkConfig networkName="spec1-network">
+                    <Link rel="repair" href="https://VMWARE_CLOUD_HOST/api/admin/network/479eadc5-a17f-46b4-b580-6e2fb87971c9/action/reset"/>
+                    <Description></Description>
+                    <Configuration>
+                        <IpScopes>
+                            <IpScope>
+                                <IsInherited>false</IsInherited>
+                                <Gateway>192.168.2.1</Gateway>
+                                <Netmask>255.255.255.0</Netmask>
+                                <IsEnabled>true</IsEnabled>
+                                <IpRanges>
+                                    <IpRange>
+        <StartAddress>192.168.2.100</StartAddress>
+        <EndAddress>192.168.2.199</EndAddress>
+                                    </IpRange>
+                                </IpRanges>
+                            </IpScope>
+                        </IpScopes>
+                        <FenceMode>isolated</FenceMode>
+                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
+                        <Features>
+                            <DhcpService>
+                                <IsEnabled>false</IsEnabled>
+                                <DefaultLeaseTime>3600</DefaultLeaseTime>
+                                <MaxLeaseTime>7200</MaxLeaseTime>
+                            </DhcpService>
+                        </Features>
+                    </Configuration>
+                    <IsDeployed>true</IsDeployed>
+                </NetworkConfig>
+            </NetworkConfigSection>
+            <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+                <ovf:Info>Snapshot information section</ovf:Info>
+            </SnapshotSection>
+            <DateCreated>2018-03-09T13:36:41.966+01:00</DateCreated>
+            <Owner type="application/vnd.vmware.vcloud.owner+xml">
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/f3555478-d7ea-4d9c-9b48-4bced57539e3" name="system" type="application/vnd.vmware.admin.user+xml"/>
+            </Owner>
+            <InMaintenanceMode>false</InMaintenanceMode>
+            <Children>
+                <Vm needsCustomization="true" nestedHypervisorEnabled="false" deployed="true" status="4" name="spec1-vm1" id="urn:vcloud:vm:84faa107-c0b9-4a21-adc5-b17e0c5355a2" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="power:powerOff" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/power/action/powerOff"/>
+                    <Link rel="power:reboot" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/power/action/reboot"/>
+                    <Link rel="power:reset" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/power/action/reset"/>
+                    <Link rel="power:shutdown" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/power/action/shutdown"/>
+                    <Link rel="power:suspend" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/power/action/suspend"/>
+                    <Link rel="undeploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/action/undeploy" type="application/vnd.vmware.vcloud.undeployVAppParams+xml"/>
+                    <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Link rel="screen:thumbnail" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/screen"/>
+                    <Link rel="screen:acquireTicket" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/screen/action/acquireTicket"/>
+                    <Link rel="media:insertMedia" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
+                    <Link rel="media:ejectMedia" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
+                    <Link rel="disk:attach" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
+                    <Link rel="disk:detach" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
+                    <Link rel="installVmwareTools" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/action/installVMwareTools"/>
+                    <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+                    <Link rel="reconfigureVm" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/action/reconfigureVm" name="spec1-vm1" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-a715dec5-7ab1-487e-993b-82fcd7eb8172" type="application/vnd.vmware.vcloud.vApp+xml"/>
+                    <Description></Description>
+                    <ovf:VirtualHardwareSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ovf:transport="" ns13:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/">
+                        <ovf:Info>Virtual hardware requirements</ovf:Info>
+                        <ovf:System>
+                            <vssd:AutomaticRecoveryAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticShutdownAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticStartupAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticStartupActionDelay xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticStartupActionSequenceNumber xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:CreationTime xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:Description xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+                            <vssd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:InstanceID>0</vssd:InstanceID>
+                            <vssd:LogDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:RecoveryFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:SnapshotDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:SuspendDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:SwapFileDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:VirtualSystemIdentifier>spec1-vm1</vssd:VirtualSystemIdentifier>
+                            <vssd:VirtualSystemType>vmx-13</vssd:VirtualSystemType>
+                        </ovf:System>
+                        <ovf:Item>
+                            <rasd:Address>00:50:56:01:00:d8</rasd:Address>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Connection ns13:ipAddressingMode="POOL" ns13:ipAddress="192.168.2.100" ns13:primaryNetworkConnection="true">spec1-network</rasd:Connection>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>E1000s ethernet adapter on "spec1-network"</rasd:Description>
+                            <rasd:ElementName>Network adapter 0</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:InstanceID>1</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType>E1000E</rasd:ResourceSubType>
+                            <rasd:ResourceType>10</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address>0</rasd:Address>
+                            <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>SCSI Controller</rasd:Description>
+                            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:InstanceID>2</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType>lsilogicsas</rasd:ResourceSubType>
+                            <rasd:ResourceType>6</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>Hard disk</rasd:Description>
+                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:HostResource ns13:busType="6" ns13:busSubType="lsilogicsas" ns13:capacity="10240"></rasd:HostResource>
+                            <rasd:InstanceID>2000</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent>2</rasd:Parent>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceType>17</rasd:ResourceType>
+                            <rasd:VirtualQuantity>10737418240</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address>0</rasd:Address>
+                            <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>IDE Controller</rasd:Description>
+                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:InstanceID>3</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceType>5</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>CD/DVD Drive</rasd:Description>
+                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:HostResource></rasd:HostResource>
+                            <rasd:InstanceID>3000</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent>3</rasd:Parent>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceType>15</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>Floppy Drive</rasd:Description>
+                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:HostResource></rasd:HostResource>
+                            <rasd:InstanceID>8000</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceType>14</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                        </ovf:Item>
+                        <ovf:Item ns13:type="application/vnd.vmware.vcloud.rasdItem+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/cpu">
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>Number of Virtual CPUs</rasd:Description>
+                            <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:InstanceID>4</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceType>3</rasd:ResourceType>
+                            <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight>0</rasd:Weight>
+                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        </ovf:Item>
+                        <ovf:Item ns13:type="application/vnd.vmware.vcloud.rasdItem+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/memory">
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>Memory Size</rasd:Description>
+                            <rasd:ElementName>512 MB of memory</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:InstanceID>5</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceType>4</rasd:ResourceType>
+                            <rasd:VirtualQuantity>512</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight>0</rasd:Weight>
+                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        </ovf:Item>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                    </ovf:VirtualHardwareSection>
+                    <ovf:OperatingSystemSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ovf:id="102" ns13:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="windows9Server64Guest" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/operatingSystemSection/">
+                        <ovf:Info>Specifies the operating system installed</ovf:Info>
+                        <ovf:Description>Microsoft Windows Server 2016 (64-bit)</ovf:Description>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
+                    </ovf:OperatingSystemSection>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+                        <NetworkConnection needsCustomization="true" network="spec1-network">
+                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IpAddress>192.168.2.100</IpAddress>
+                            <IsConnected>true</IsConnected>
+                            <MACAddress>00:50:56:01:00:d8</MACAddress>
+                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
+                        </NetworkConnection>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
+                    </NetworkConnectionSection>
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <Enabled>false</Enabled>
+                        <ChangeSid>true</ChangeSid>
+                        <VirtualMachineId>84faa107-c0b9-4a21-adc5-b17e0c5355a2</VirtualMachineId>
+                        <JoinDomainEnabled>false</JoinDomainEnabled>
+                        <UseOrgSettings>false</UseOrgSettings>
+                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
+                        <AdminPasswordAuto>true</AdminPasswordAuto>
+                        <ResetPasswordRequired>false</ResetPasswordRequired>
+                        <ComputerName>spec1-vm1</ComputerName>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+                    </GuestCustomizationSection>
+                    <RuntimeInfoSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/runtimeInfoSection">
+                        <ovf:Info>Specifies Runtime info</ovf:Info>
+                    </RuntimeInfoSection>
+                    <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+                        <ovf:Info>Snapshot information section</ovf:Info>
+                    </SnapshotSection>
+                    <DateCreated>2018-03-09T13:36:47.296+01:00</DateCreated>
+                    <VAppScopedLocalId>c209ef9f-25c8-4fe5-a7f4-c522fbd45ea7</VAppScopedLocalId>
+                    <VmCapabilities href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
+                        <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
+                        <CpuHotAddEnabled>false</CpuHotAddEnabled>
+                    </VmCapabilities>
+                    <StorageProfile href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/b652f213-33aa-4c1f-8f30-ea2919a30843" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                </Vm>
+            </Children>
+        </VApp>
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:30 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - ee9f52dbb4d245048614dba57e182fd3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 Mar 2018 10:54:31 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 53d10d30-d320-4ee1-bfc6-02eb07353063
+      X-Vcloud-Authorization:
+      - ee9f52dbb4d245048614dba57e182fd3
+      Set-Cookie:
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapp+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '151'
+      Vary:
+      - Accept-Encoding, User-Agent
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" ovfDescriptorUploaded="true" deployed="true" status="4" name="miq-devel-vm" id="urn:vcloud:vapp:2c385915-c0c5-4cfe-81ca-ce8f59b21dd1" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1" type="application/vnd.vmware.vcloud.vApp+xml">
+            <Link rel="power:powerOff" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/power/action/powerOff"/>
+            <Link rel="power:reboot" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/power/action/reboot"/>
+            <Link rel="power:reset" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/power/action/reset"/>
+            <Link rel="power:shutdown" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/power/action/shutdown"/>
+            <Link rel="power:suspend" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/power/action/suspend"/>
+            <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
+            <Link rel="undeploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/action/undeploy" type="application/vnd.vmware.vcloud.undeployVAppParams+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/network/af20c7e3-79aa-4cdb-bd94-935e4f43d3d3" name="VM Network" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/network/3ce8a1be-aa11-476b-8afc-642a25a9dfa0" name="ManageIQ Dev external network" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="controlAccess" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="recompose" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/action/recomposeVApp" type="application/vnd.vmware.vcloud.recomposeVAppParams+xml"/>
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1" type="application/vnd.vmware.vcloud.vApp+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/ovf" type="text/xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+            <Description></Description>
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+                <ovf:Info>Lease settings section</ovf:Info>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <DeploymentLeaseInSeconds>2592000</DeploymentLeaseInSeconds>
+                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
+                <DeploymentLeaseExpiration>2018-03-22T12:27:19.638+01:00</DeploymentLeaseExpiration>
+            </LeaseSettingsSection>
+            <ovf:StartupSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.startupSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/startupSection/">
+                <ovf:Info>VApp startup section</ovf:Info>
+                <ovf:Item ovf:id="93e8f5e5-7b61-40ed-ae94-4193eda19fec" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
+            </ovf:StartupSection>
+            <ovf:NetworkSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.networkSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/networkSection/">
+                <ovf:Info>The list of logical networks</ovf:Info>
+                <ovf:Network ovf:name="VM Network">
+                    <ovf:Description>The VM Network network</ovf:Description>
+                </ovf:Network>
+                <ovf:Network ovf:name="ManageIQ Dev external network">
+                    <ovf:Description></ovf:Description>
+                </ovf:Network>
+            </ovf:NetworkSection>
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
+                <NetworkConfig networkName="VM Network">
+                    <Link rel="repair" href="https://VMWARE_CLOUD_HOST/api/admin/network/af20c7e3-79aa-4cdb-bd94-935e4f43d3d3/action/reset"/>
+                    <Description>The VM Network network</Description>
+                    <Configuration>
+                        <IpScopes>
+                            <IpScope>
+                                <IsInherited>false</IsInherited>
+                                <Gateway>192.168.254.1</Gateway>
+                                <Netmask>255.255.255.0</Netmask>
+                                <IsEnabled>true</IsEnabled>
+                                <IpRanges>
+                                    <IpRange>
+        <StartAddress>192.168.254.100</StartAddress>
+        <EndAddress>192.168.254.199</EndAddress>
                                     </IpRange>
                                 </IpRanges>
                             </IpScope>
@@ -1518,1008 +2081,386 @@ http_interactions:
                         <FenceMode>isolated</FenceMode>
                         <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
                     </Configuration>
-                    <IsDeployed>false</IsDeployed>
+                    <IsDeployed>true</IsDeployed>
                 </NetworkConfig>
-            </NetworkConfigSection>
-            <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
-                <ovf:Info>Snapshot information section</ovf:Info>
-            </SnapshotSection>
-            <DateCreated>2016-09-08T16:48:46.357+03:00</DateCreated>
-            <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/3fde93ae-0521-4a75-8dec-cb4bcb7dcbb0" name="system" type="application/vnd.vmware.admin.user+xml"/>
-            </Owner>
-            <InMaintenanceMode>false</InMaintenanceMode>
-            <Children>
-                <Vm needsCustomization="false" nestedHypervisorEnabled="false" deployed="false" status="3" name="CentOS7" id="urn:vcloud:vm:8df2faf3-fd33-40de-9b26-da34c146f55d" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="power:powerOn" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/power/action/powerOn"/>
-                    <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-                    <Link rel="discardState" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/action/discardSuspendedState"/>
-                    <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Link rel="screen:thumbnail" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/screen"/>
-                    <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/action/enableNestedHypervisor"/>
-                    <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
-                    <Link rel="reconfigureVm" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/action/reconfigureVm" name="CentOS7" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d" type="application/vnd.vmware.vcloud.vApp+xml"/>
-                    <Description/>
-                    <ovf:VirtualHardwareSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:transport="" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml">
-                        <ovf:Info>Virtual hardware requirements</ovf:Info>
-                        <ovf:System>
-                            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
-                            <vssd:InstanceID>0</vssd:InstanceID>
-                            <vssd:VirtualSystemIdentifier>CentOS7</vssd:VirtualSystemIdentifier>
-                            <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
-                        </ovf:System>
-                        <ovf:Item>
-                            <rasd:Address>00:50:56:01:00:4a</rasd:Address>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
-                            <rasd:Connection vcloud:ipAddress="192.168.2.100" vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="POOL">testnet</rasd:Connection>
-                            <rasd:Description>Vmxnet3 ethernet adapter on "testnet"</rasd:Description>
-                            <rasd:ElementName>Network adapter 0</rasd:ElementName>
-                            <rasd:InstanceID>1</rasd:InstanceID>
-                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
-                            <rasd:ResourceType>10</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>SCSI Controller</rasd:Description>
-                            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>2</rasd:InstanceID>
-                            <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
-                            <rasd:ResourceType>6</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:Description>Hard disk</rasd:Description>
-                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                            <rasd:HostResource vcloud:capacity="16384" vcloud:busSubType="lsilogic" vcloud:busType="6"/>
-                            <rasd:InstanceID>2000</rasd:InstanceID>
-                            <rasd:Parent>2</rasd:Parent>
-                            <rasd:ResourceType>17</rasd:ResourceType>
-                            <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
-                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>IDE Controller</rasd:Description>
-                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>3</rasd:InstanceID>
-                            <rasd:ResourceType>5</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>CD/DVD Drive</rasd:Description>
-                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>3000</rasd:InstanceID>
-                            <rasd:Parent>3</rasd:Parent>
-                            <rasd:ResourceType>15</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>Floppy Drive</rasd:Description>
-                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>8000</rasd:InstanceID>
-                            <rasd:ResourceType>14</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/cpu" vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml">
-                            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
-                            <rasd:Description>Number of Virtual CPUs</rasd:Description>
-                            <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
-                            <rasd:InstanceID>4</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>3</rasd:ResourceType>
-                            <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        </ovf:Item>
-                        <ovf:Item vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/memory" vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml">
-                            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
-                            <rasd:Description>Memory Size</rasd:Description>
-                            <rasd:ElementName>2048 MB of memory</rasd:ElementName>
-                            <rasd:InstanceID>5</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>4</rasd:ResourceType>
-                            <rasd:VirtualQuantity>2048</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        </ovf:Item>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                    </ovf:VirtualHardwareSection>
-                    <ovf:OperatingSystemSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:id="101" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/operatingSystemSection/" vcloud:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="centos64Guest">
-                        <ovf:Info>Specifies the operating system installed</ovf:Info>
-                        <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
-                    </ovf:OperatingSystemSection>
-                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="false" network="testnet">
-                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IpAddress>192.168.2.100</IpAddress>
-                            <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:4a</MACAddress>
-                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
-                        </NetworkConnection>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
-                    </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <Enabled>true</Enabled>
-                        <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>8df2faf3-fd33-40de-9b26-da34c146f55d</VirtualMachineId>
-                        <JoinDomainEnabled>false</JoinDomainEnabled>
-                        <UseOrgSettings>false</UseOrgSettings>
-                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
-                        <AdminPasswordAuto>true</AdminPasswordAuto>
-                        <AdminPassword>nN%9oQTG</AdminPassword>
-                        <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>CentOS7-0</ComputerName>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
-                    </GuestCustomizationSection>
-                    <RuntimeInfoSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/runtimeInfoSection" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml">
-                        <ovf:Info>Specifies Runtime info</ovf:Info>
-                        <VMWareTools version="10240"/>
-                    </RuntimeInfoSection>
-                    <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
-                        <ovf:Info>Snapshot information section</ovf:Info>
-                    </SnapshotSection>
-                    <DateCreated>2016-09-08T16:48:57.753+03:00</DateCreated>
-                    <VAppScopedLocalId>7ff5cc28-e2e0-4466-bf78-e39a3522d539</VAppScopedLocalId>
-                    <VmCapabilities href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
-                        <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
-                        <CpuHotAddEnabled>false</CpuHotAddEnabled>
-                    </VmCapabilities>
-                    <StorageProfile href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                </Vm>
-            </Children>
-        </VApp>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:52:31 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:52:36 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 077b9e5c-02b4-4a62-9d36-9f1e134fdcd8
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '138'
-      Content-Type:
-      - application/vnd.vmware.vcloud.vapp+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovfDescriptorUploaded="true" deployed="false" status="8" name="spec2" id="urn:vcloud:vapp:f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd" type="application/vnd.vmware.vcloud.vApp+xml" xsi:schemaLocation="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
-            <Link rel="power:powerOn" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/power/action/powerOn"/>
-            <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/network/d91117a6-33d6-4a51-96e3-8d761b145726" name="INT_192.168.10.0m24" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="controlAccess" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="recompose" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/recomposeVApp" type="application/vnd.vmware.vcloud.recomposeVAppParams+xml"/>
-            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd" type="application/vnd.vmware.vcloud.vApp+xml"/>
-            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd"/>
-            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/enableDownload"/>
-            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/disableDownload"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/ovf" type="text/xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
-            <Description/>
-            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
-                <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
-                <DeploymentLeaseInSeconds>604800</DeploymentLeaseInSeconds>
-                <StorageLeaseInSeconds>2592000</StorageLeaseInSeconds>
-                <StorageLeaseExpiration>2016-10-16T11:46:10.463+03:00</StorageLeaseExpiration>
-            </LeaseSettingsSection>
-            <ovf:StartupSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/startupSection/" vcloud:type="application/vnd.vmware.vcloud.startupSection+xml">
-                <ovf:Info>VApp startup section</ovf:Info>
-                <ovf:Item ovf:id="spec2-vm1" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
-            </ovf:StartupSection>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
-                <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="INT_192.168.10.0m24">
-                    <ovf:Description/>
-                </ovf:Network>
-            </ovf:NetworkSection>
-            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
-                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
-                <NetworkConfig networkName="INT_192.168.10.0m24">
-                    <Link rel="repair" href="https://VMWARE_CLOUD_HOST/api/admin/network/d91117a6-33d6-4a51-96e3-8d761b145726/action/reset"/>
-                    <Description/>
+                <NetworkConfig networkName="ManageIQ Dev external network">
+                    <Link rel="repair" href="https://VMWARE_CLOUD_HOST/api/admin/network/3ce8a1be-aa11-476b-8afc-642a25a9dfa0/action/reset"/>
+                    <Description></Description>
                     <Configuration>
                         <IpScopes>
                             <IpScope>
                                 <IsInherited>true</IsInherited>
-                                <Gateway>192.168.10.1</Gateway>
-                                <Netmask>255.255.255.0</Netmask>
-                                <Dns1>192.168.10.1</Dns1>
-                                <DnsSuffix>test.local</DnsSuffix>
+                                <Gateway>10.12.0.24</Gateway>
+                                <Netmask>255.255.0.0</Netmask>
+                                <Dns1>10.12.0.13</Dns1>
+                                <DnsSuffix>redhat.xlab.si</DnsSuffix>
                                 <IsEnabled>true</IsEnabled>
                                 <IpRanges>
                                     <IpRange>
-                                        <StartAddress>192.168.10.100</StartAddress>
-                                        <EndAddress>192.168.10.199</EndAddress>
+        <StartAddress>10.12.6.10</StartAddress>
+        <EndAddress>10.12.6.100</EndAddress>
                                     </IpRange>
                                 </IpRanges>
                             </IpScope>
                         </IpScopes>
-                        <ParentNetwork href="https://VMWARE_CLOUD_HOST/api/admin/network/5ae840de-198e-4a34-a30a-6c36377460c6" id="5ae840de-198e-4a34-a30a-6c36377460c6" name="INT_192.168.10.0m24"/>
+                        <ParentNetwork href="https://VMWARE_CLOUD_HOST/api/admin/network/5038b60d-fbb8-42e8-8bf3-e711f703507c" id="5038b60d-fbb8-42e8-8bf3-e711f703507c" name="ManageIQ Dev external network"/>
                         <FenceMode>bridged</FenceMode>
                         <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
                     </Configuration>
-                    <IsDeployed>false</IsDeployed>
+                    <IsDeployed>true</IsDeployed>
                 </NetworkConfig>
             </NetworkConfigSection>
-            <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+            <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
                 <ovf:Info>Snapshot information section</ovf:Info>
             </SnapshotSection>
-            <DateCreated>2016-09-16T11:46:10.347+03:00</DateCreated>
+            <DateCreated>2018-02-20T12:19:04.030+01:00</DateCreated>
             <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/81585659-9eaa-46e7-8100-3b0ea0aa4fd6" name="bergigre_remote" type="application/vnd.vmware.admin.user+xml"/>
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/a4a18dd6-d9aa-4d4e-a024-653b924e7091" name="administrator" type="application/vnd.vmware.admin.user+xml"/>
             </Owner>
             <InMaintenanceMode>false</InMaintenanceMode>
             <Children>
-                <Vm needsCustomization="false" nestedHypervisorEnabled="false" deployed="false" status="8" name="spec2-vm1" id="urn:vcloud:vm:a28be0c0-d70d-4047-92f8-fc217bbaa7f6" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="power:powerOn" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/power/action/powerOn"/>
-                    <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-                    <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Link rel="screen:thumbnail" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/screen"/>
-                    <Link rel="media:insertMedia" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
-                    <Link rel="media:ejectMedia" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
-                    <Link rel="disk:attach" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
-                    <Link rel="disk:detach" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
-                    <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/action/enableNestedHypervisor"/>
-                    <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
-                    <Link rel="reconfigureVm" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/action/reconfigureVm" name="spec2-vm1" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd" type="application/vnd.vmware.vcloud.vApp+xml"/>
-                    <Description/>
-                    <ovf:VirtualHardwareSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:transport="" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml">
+                <Vm needsCustomization="true" deployed="true" status="4" name="93e8f5e5-7b61-40ed-ae94-4193eda19fec" id="urn:vcloud:vm:350947aa-c16e-4eb3-98c1-fced9dac6dbc" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="power:powerOff" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/power/action/powerOff"/>
+                    <Link rel="power:reboot" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/power/action/reboot"/>
+                    <Link rel="power:reset" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/power/action/reset"/>
+                    <Link rel="power:shutdown" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/power/action/shutdown"/>
+                    <Link rel="power:suspend" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/power/action/suspend"/>
+                    <Link rel="undeploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/action/undeploy" type="application/vnd.vmware.vcloud.undeployVAppParams+xml"/>
+                    <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Link rel="screen:thumbnail" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/screen"/>
+                    <Link rel="screen:acquireTicket" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/screen/action/acquireTicket"/>
+                    <Link rel="media:insertMedia" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
+                    <Link rel="media:ejectMedia" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
+                    <Link rel="disk:attach" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
+                    <Link rel="disk:detach" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
+                    <Link rel="installVmwareTools" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/action/installVMwareTools"/>
+                    <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+                    <Link rel="reconfigureVm" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/action/reconfigureVm" name="93e8f5e5-7b61-40ed-ae94-4193eda19fec" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-2c385915-c0c5-4cfe-81ca-ce8f59b21dd1" type="application/vnd.vmware.vcloud.vApp+xml"/>
+                    <Description></Description>
+                    <ovf:VirtualHardwareSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ovf:transport="" ns13:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/">
                         <ovf:Info>Virtual hardware requirements</ovf:Info>
                         <ovf:System>
+                            <vssd:AutomaticRecoveryAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticShutdownAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticStartupAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticStartupActionDelay xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticStartupActionSequenceNumber xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:CreationTime xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:Description xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+                            <vssd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <vssd:InstanceID>0</vssd:InstanceID>
-                            <vssd:VirtualSystemIdentifier>spec2-vm1</vssd:VirtualSystemIdentifier>
-                            <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
+                            <vssd:LogDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:RecoveryFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:SnapshotDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:SuspendDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:SwapFileDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:VirtualSystemIdentifier>93e8f5e5-7b61-40ed-ae94-4193eda19fec</vssd:VirtualSystemIdentifier>
+                            <vssd:VirtualSystemType>vmx-08</vssd:VirtualSystemType>
                         </ovf:System>
                         <ovf:Item>
-                            <rasd:Address>00:50:56:01:00:65</rasd:Address>
+                            <rasd:Address>00:50:56:01:00:66</rasd:Address>
                             <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
-                            <rasd:Connection vcloud:ipAddress="192.168.10.101" vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="POOL">INT_192.168.10.0m24</rasd:Connection>
-                            <rasd:Description>Vmxnet3 ethernet adapter on "INT_192.168.10.0m24"</rasd:Description>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Connection ns13:ipAddressingMode="DHCP" ns13:ipAddress="10.12.6.23" ns13:primaryNetworkConnection="true">ManageIQ Dev external network</rasd:Connection>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>E1000 ethernet adapter on "ManageIQ Dev external network"</rasd:Description>
                             <rasd:ElementName>Network adapter 0</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:InstanceID>1</rasd:InstanceID>
-                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType>E1000</rasd:ResourceSubType>
                             <rasd:ResourceType>10</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                         </ovf:Item>
                         <ovf:Item>
                             <rasd:Address>0</rasd:Address>
+                            <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Description>SCSI Controller</rasd:Description>
                             <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:InstanceID>2</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
                             <rasd:ResourceType>6</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                         </ovf:Item>
                         <ovf:Item>
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Description>Hard disk</rasd:Description>
                             <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                            <rasd:HostResource vcloud:capacity="16384" vcloud:busSubType="lsilogic" vcloud:busType="6"/>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:HostResource ns13:busType="6" ns13:busSubType="lsilogic" ns13:capacity="67584"></rasd:HostResource>
                             <rasd:InstanceID>2000</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Parent>2</rasd:Parent>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:ResourceType>17</rasd:ResourceType>
-                            <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>70866960384</rasd:VirtualQuantity>
                             <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                         </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>IDE Controller</rasd:Description>
-                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>3</rasd:InstanceID>
-                            <rasd:ResourceType>5</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>CD/DVD Drive</rasd:Description>
-                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>3000</rasd:InstanceID>
-                            <rasd:Parent>3</rasd:Parent>
-                            <rasd:ResourceType>15</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>Floppy Drive</rasd:Description>
-                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>8000</rasd:InstanceID>
-                            <rasd:ResourceType>14</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/cpu" vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml">
+                        <ovf:Item ns13:type="application/vnd.vmware.vcloud.rasdItem+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/cpu">
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Description>Number of Virtual CPUs</rasd:Description>
-                            <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
-                            <rasd:InstanceID>4</rasd:InstanceID>
+                            <rasd:ElementName>4 virtual CPU(s)</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:InstanceID>3</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:ResourceType>3</rasd:ResourceType>
-                            <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>4</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
                         </ovf:Item>
-                        <ovf:Item vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/memory" vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml">
+                        <ovf:Item ns13:type="application/vnd.vmware.vcloud.rasdItem+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/memory">
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Description>Memory Size</rasd:Description>
-                            <rasd:ElementName>2048 MB of memory</rasd:ElementName>
-                            <rasd:InstanceID>5</rasd:InstanceID>
+                            <rasd:ElementName>6144 MB of memory</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:InstanceID>4</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:ResourceType>4</rasd:ResourceType>
-                            <rasd:VirtualQuantity>2048</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>6144</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
                         </ovf:Item>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
                     </ovf:VirtualHardwareSection>
-                    <ovf:OperatingSystemSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:id="101" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/operatingSystemSection/" vcloud:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="centos64Guest">
+                    <ovf:OperatingSystemSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ovf:id="102" ns13:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="rhel6_64Guest" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/operatingSystemSection/">
                         <ovf:Info>Specifies the operating system installed</ovf:Info>
-                        <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
+                        <ovf:Description>Red Hat Enterprise Linux 6 (64-bit)</ovf:Description>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
                     </ovf:OperatingSystemSection>
-                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
                         <ovf:Info>Specifies the available VM network connections</ovf:Info>
                         <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="INT_192.168.10.0m24">
+                        <NetworkConnection needsCustomization="true" network="ManageIQ Dev external network">
                             <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IpAddress>192.168.10.101</IpAddress>
+                            <IpAddress>10.12.6.23</IpAddress>
                             <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:65</MACAddress>
-                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
+                            <MACAddress>00:50:56:01:00:66</MACAddress>
+                            <IpAddressAllocationMode>DHCP</IpAddressAllocationMode>
                         </NetworkConnection>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
                     </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
                         <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
                         <Enabled>false</Enabled>
                         <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>a28be0c0-d70d-4047-92f8-fc217bbaa7f6</VirtualMachineId>
+                        <VirtualMachineId>350947aa-c16e-4eb3-98c1-fced9dac6dbc</VirtualMachineId>
                         <JoinDomainEnabled>false</JoinDomainEnabled>
                         <UseOrgSettings>false</UseOrgSettings>
                         <AdminPasswordEnabled>true</AdminPasswordEnabled>
                         <AdminPasswordAuto>true</AdminPasswordAuto>
                         <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>CentOS7-0</ComputerName>
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+                        <ComputerName>93e8f5e5-7b-001</ComputerName>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
                     </GuestCustomizationSection>
-                    <RuntimeInfoSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/runtimeInfoSection" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml">
+                    <ovf:ProductSection ovf:class="" ovf:instance="" ovf:required="true">
+                        <ovf:Info>Information about the installed software</ovf:Info>
+                        <ovf:Product>ManageIQ</ovf:Product>
+                        <ovf:Vendor>ManageIQ</ovf:Vendor>
+                        <ovf:Version>gaprindashvili</ovf:Version>
+                    </ovf:ProductSection>
+                    <RuntimeInfoSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/runtimeInfoSection">
                         <ovf:Info>Specifies Runtime info</ovf:Info>
-                        <VMWareTools version="10240"/>
+                        <VMWareTools version="10277"/>
                     </RuntimeInfoSection>
-                    <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+                    <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
                         <ovf:Info>Snapshot information section</ovf:Info>
                     </SnapshotSection>
-                    <DateCreated>2016-09-16T11:46:14.080+03:00</DateCreated>
-                    <VAppScopedLocalId>7ff5cc28-e2e0-4466-bf78-e39a3522d539</VAppScopedLocalId>
-                    <VmCapabilities href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
-                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
+                    <DateCreated>2018-02-20T12:19:59.892+01:00</DateCreated>
+                    <VAppScopedLocalId>93e8f5e5-7b61-40ed-ae94-4193eda19fec</VAppScopedLocalId>
+                    <ovfenv:Environment xmlns:ve="http://www.vmware.com/schema/ovfenv" ovfenv:id="" ve:vCenterId="vm-609">
+                        <ovfenv:PlatformSection>
+                            <ovfenv:Kind>VMware ESXi</ovfenv:Kind>
+                            <ovfenv:Version>6.5.0</ovfenv:Version>
+                            <ovfenv:Vendor>VMware, Inc.</ovfenv:Vendor>
+                            <ovfenv:Locale>en</ovfenv:Locale>
+                        </ovfenv:PlatformSection>
+                        <ve:EthernetAdapterSection xmlns="http://schemas.dmtf.org/ovf/environment/1" xmlns:oe="http://schemas.dmtf.org/ovf/environment/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                            <ve:Adapter ve:mac="00:50:56:01:00:66" ve:network="VM Network" ve:unitNumber="7"/>
+           </ve:EthernetAdapterSection>
+                    </ovfenv:Environment>
+                    <VmCapabilities href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
                         <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
                         <CpuHotAddEnabled>false</CpuHotAddEnabled>
                     </VmCapabilities>
-                    <StorageProfile href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <StorageProfile href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/b652f213-33aa-4c1f-8f30-ea2919a30843" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
                 </Vm>
             </Children>
         </VApp>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:52:37 GMT
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:31 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/disks
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.42.0
+      - fog-core/1.45.0
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Date:
-      - Fri, 16 Sep 2016 08:52:42 GMT
+      - Wed, 14 Mar 2018 10:54:31 GMT
       X-Vmware-Vcloud-Request-Id:
-      - a7d426e0-3df1-4e09-b6eb-5936ee702e36
+      - 19227904-5206-4513-bcc9-6f7f5e5a8083
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
       Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapp+xml;version=5.1
       X-Vmware-Vcloud-Request-Execution-Time:
       - '132'
-      Content-Type:
-      - application/vnd.vmware.vcloud.rasditemslist+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '2169'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <RasdItemsList xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
-            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-            <Item>
-                <rasd:Address>0</rasd:Address>
-                <rasd:Description>SCSI Controller</rasd:Description>
-                <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
-                <rasd:InstanceID>2</rasd:InstanceID>
-                <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
-                <rasd:ResourceType>6</rasd:ResourceType>
-            </Item>
-            <Item>
-                <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                <rasd:Description>Hard disk</rasd:Description>
-                <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                <rasd:HostResource xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:capacity="16384" vcloud:busSubType="lsilogic" vcloud:busType="6"></rasd:HostResource>
-                <rasd:InstanceID>2000</rasd:InstanceID>
-                <rasd:Parent>2</rasd:Parent>
-                <rasd:ResourceType>17</rasd:ResourceType>
-                <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
-                <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
-            </Item>
-            <Item>
-                <rasd:Address>0</rasd:Address>
-                <rasd:Description>IDE Controller</rasd:Description>
-                <rasd:ElementName>IDE Controller 0</rasd:ElementName>
-                <rasd:InstanceID>3</rasd:InstanceID>
-                <rasd:ResourceType>5</rasd:ResourceType>
-            </Item>
-        </RasdItemsList>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:52:42 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/disks
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:52:47 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 578a96d1-4580-4cba-9bf9-b7056c040f13
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '45'
-      Content-Type:
-      - application/vnd.vmware.vcloud.rasditemslist+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '2169'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <RasdItemsList xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
-            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-            <Item>
-                <rasd:Address>0</rasd:Address>
-                <rasd:Description>SCSI Controller</rasd:Description>
-                <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
-                <rasd:InstanceID>2</rasd:InstanceID>
-                <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
-                <rasd:ResourceType>6</rasd:ResourceType>
-            </Item>
-            <Item>
-                <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                <rasd:Description>Hard disk</rasd:Description>
-                <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                <rasd:HostResource xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:capacity="16384" vcloud:busSubType="lsilogic" vcloud:busType="6"></rasd:HostResource>
-                <rasd:InstanceID>2000</rasd:InstanceID>
-                <rasd:Parent>2</rasd:Parent>
-                <rasd:ResourceType>17</rasd:ResourceType>
-                <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
-                <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
-            </Item>
-            <Item>
-                <rasd:Address>0</rasd:Address>
-                <rasd:Description>IDE Controller</rasd:Description>
-                <rasd:ElementName>IDE Controller 0</rasd:ElementName>
-                <rasd:InstanceID>3</rasd:InstanceID>
-                <rasd:ResourceType>5</rasd:ResourceType>
-            </Item>
-        </RasdItemsList>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:52:48 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/disks
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:52:52 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 53ee9bf5-f808-49d8-afbe-a7a5f7d2485f
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '42'
-      Content-Type:
-      - application/vnd.vmware.vcloud.rasditemslist+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '2169'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <RasdItemsList xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
-            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-            <Item>
-                <rasd:Address>0</rasd:Address>
-                <rasd:Description>SCSI Controller</rasd:Description>
-                <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
-                <rasd:InstanceID>2</rasd:InstanceID>
-                <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
-                <rasd:ResourceType>6</rasd:ResourceType>
-            </Item>
-            <Item>
-                <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                <rasd:Description>Hard disk</rasd:Description>
-                <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                <rasd:HostResource xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:capacity="16384" vcloud:busSubType="lsilogic" vcloud:busType="6"></rasd:HostResource>
-                <rasd:InstanceID>2000</rasd:InstanceID>
-                <rasd:Parent>2</rasd:Parent>
-                <rasd:ResourceType>17</rasd:ResourceType>
-                <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
-                <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
-            </Item>
-            <Item>
-                <rasd:Address>0</rasd:Address>
-                <rasd:Description>IDE Controller</rasd:Description>
-                <rasd:ElementName>IDE Controller 0</rasd:ElementName>
-                <rasd:InstanceID>3</rasd:InstanceID>
-                <rasd:ResourceType>5</rasd:ResourceType>
-            </Item>
-        </RasdItemsList>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:52:53 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/org/e338a4ac-551b-4b6c-b5c0-aff31b71417f
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:52:58 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 1f376632-d0db-4d65-b5b1-308fff5bba56
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '140'
-      Content-Type:
-      - application/vnd.vmware.vcloud.org+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '2589'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPE9yZyB4
-        bWxucz0iaHR0cDovL3d3dy52bXdhcmUuY29tL3ZjbG91ZC92MS41IiBuYW1l
-        PSJNSVFEZXYiIGlkPSJ1cm46dmNsb3VkOm9yZzplMzM4YTRhYy01NTFiLTRi
-        NmMtYjVjMC1hZmYzMWI3MTQxN2YiIGhyZWY9Imh0dHBzOi8vVk1XQVJFX0NM
-        T1VEX0hPU1QvYXBpL29yZy9lMzM4YTRhYy01NTFiLTRiNmMtYjVjMC1hZmYz
-        MWI3MTQxN2YiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3Vk
-        Lm9yZyt4bWwiIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9Y
-        TUxTY2hlbWEtaW5zdGFuY2UiIHhzaTpzY2hlbWFMb2NhdGlvbj0iaHR0cDov
-        L3d3dy52bXdhcmUuY29tL3ZjbG91ZC92MS41IGh0dHA6Ly9WTVdBUkVfQ0xP
-        VURfSE9TVC9hcGkvdjEuNS9zY2hlbWEvbWFzdGVyLnhzZCI+CiAgICA8TGlu
-        ayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vVk1XQVJFX0NMT1VEX0hPU1Qv
-        YXBpL3ZkYy84OWFkZTk2OS0xZGM0LTQxNTYtYWJhZC1lMjlmNzk1MTE2NzYi
-        IG5hbWU9Ik1JUURldi1EZWZhdWx0LXZDRC1EdWFsU2l0ZVN0b3JhZ2UtUEFZ
-        RyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudmRjK3ht
-        bCIvPgogICAgPExpbmsgcmVsPSJkb3duIiBocmVmPSJodHRwczovL1ZNV0FS
-        RV9DTE9VRF9IT1NUL2FwaS90YXNrc0xpc3QvZTMzOGE0YWMtNTUxYi00YjZj
-        LWI1YzAtYWZmMzFiNzE0MTdmIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13
-        YXJlLnZjbG91ZC50YXNrc0xpc3QreG1sIi8+CiAgICA8TGluayByZWw9ImRv
-        d24iIGhyZWY9Imh0dHBzOi8vVk1XQVJFX0NMT1VEX0hPU1QvYXBpL2NhdGFs
-        b2cvMDQ5MGFkM2ItZjM0My00YjgwLThkNWItZWNiMDM5N2ZkNDEyIiBuYW1l
-        PSJTaGFyZWQgVGlldG8gQ2F0YWxvZyIgdHlwZT0iYXBwbGljYXRpb24vdm5k
-        LnZtd2FyZS52Y2xvdWQuY2F0YWxvZyt4bWwiLz4KICAgIDxMaW5rIHJlbD0i
-        ZG93biIgaHJlZj0iaHR0cHM6Ly9WTVdBUkVfQ0xPVURfSE9TVC9hcGkvY2F0
-        YWxvZy8wNDkwYWQzYi1mMzQzLTRiODAtOGQ1Yi1lY2IwMzk3ZmQ0MTIvY29u
-        dHJvbEFjY2Vzcy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNs
-        b3VkLmNvbnRyb2xBY2Nlc3MreG1sIi8+CiAgICA8TGluayByZWw9ImRvd24i
-        IGhyZWY9Imh0dHBzOi8vVk1XQVJFX0NMT1VEX0hPU1QvYXBpL2NhdGFsb2cv
-        MjYxMDM3YmMtODI5OS00MmMxLTlhYzEtYjhjNGM5NjRkOTlkIiBuYW1lPSJY
-        VGVzdENhdGFsb2ciIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNs
-        b3VkLmNhdGFsb2creG1sIi8+CiAgICA8TGluayByZWw9ImRvd24iIGhyZWY9
-        Imh0dHBzOi8vVk1XQVJFX0NMT1VEX0hPU1QvYXBpL2NhdGFsb2cvMjYxMDM3
-        YmMtODI5OS00MmMxLTlhYzEtYjhjNGM5NjRkOTlkL2NvbnRyb2xBY2Nlc3Mv
-        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5jb250cm9s
-        QWNjZXNzK3htbCIvPgogICAgPExpbmsgcmVsPSJjb250cm9sQWNjZXNzIiBo
-        cmVmPSJodHRwczovL1ZNV0FSRV9DTE9VRF9IT1NUL2FwaS9jYXRhbG9nLzI2
-        MTAzN2JjLTgyOTktNDJjMS05YWMxLWI4YzRjOTY0ZDk5ZC9hY3Rpb24vY29u
-        dHJvbEFjY2VzcyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xv
-        dWQuY29udHJvbEFjY2Vzcyt4bWwiLz4KICAgIDxMaW5rIHJlbD0iYWRkIiBo
-        cmVmPSJodHRwczovL1ZNV0FSRV9DTE9VRF9IT1NUL2FwaS9hZG1pbi9vcmcv
-        ZTMzOGE0YWMtNTUxYi00YjZjLWI1YzAtYWZmMzFiNzE0MTdmL2NhdGFsb2dz
-        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLmFkbWluLmNhdGFsb2cr
-        eG1sIi8+CiAgICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vVk1X
-        QVJFX0NMT1VEX0hPU1QvYXBpL25ldHdvcmsvNWFlODQwZGUtMTk4ZS00YTM0
-        LWEzMGEtNmMzNjM3NzQ2MGM2IiBuYW1lPSJJTlRfMTkyLjE2OC4xMC4wbTI0
-        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5vcmdOZXR3
-        b3JrK3htbCIvPgogICAgPExpbmsgcmVsPSJkb3duIiBocmVmPSJodHRwczov
-        L1ZNV0FSRV9DTE9VRF9IT1NUL2FwaS9zdXBwb3J0ZWRTeXN0ZW1zSW5mby8i
-        IHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnN1cHBvcnRl
-        ZFN5c3RlbXNJbmZvK3htbCIvPgogICAgPExpbmsgcmVsPSJkb3duIiBocmVm
-        PSJodHRwczovL1ZNV0FSRV9DTE9VRF9IT1NUL2FwaS9vcmcvZTMzOGE0YWMt
-        NTUxYi00YjZjLWI1YzAtYWZmMzFiNzE0MTdmL21ldGFkYXRhIiB0eXBlPSJh
-        cHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5tZXRhZGF0YSt4bWwiLz4K
-        ICAgIDxEZXNjcmlwdGlvbj5Pcmdhbml6YXRpb24gZm9yIFJlZEhhdCBkZXZl
-        bG9wbWVudCBvZiBNYW5hZ2VJUSB2Q2xvdWQgY29ubmVjdG9yDUNvbnRhY3Qg
-        RGF2aWQgQmFydG/FoTwvRGVzY3JpcHRpb24+CiAgICA8RnVsbE5hbWU+TWFu
-        YWdlSVEgRGV2ZWxvcG1lbnQ8L0Z1bGxOYW1lPgo8L09yZz4K
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:52:59 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:53:03 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - fd94a0ab-4175-49ae-9961-ba67eb000e13
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '91'
-      Content-Type:
-      - application/vnd.vmware.vcloud.catalog+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '2211'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <Catalog xmlns="http://www.vmware.com/vcloud/v1.5" name="Shared Tieto Catalog" id="urn:vcloud:catalog:0490ad3b-f343-4b80-8d5b-ecb0397fd412" href="https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412" type="application/vnd.vmware.vcloud.catalog+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Description>Tieto Shared Catalog</Description>
-            <CatalogItems>
-                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/23a9d1e6-a80a-4fc8-ad25-664f282d9ac0" id="23a9d1e6-a80a-4fc8-ad25-664f282d9ac0" name="Tieto Linux CentOS 7.0" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/42800327-57ed-433e-8ca4-17a33843cc0a" id="42800327-57ed-433e-8ca4-17a33843cc0a" name="CentOS 7 Everything" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/59d0aebb-aad0-4f01-9fd6-082fca414936" id="59d0aebb-aad0-4f01-9fd6-082fca414936" name="CentOS 7" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/6d250e6a-0cfe-4749-af3d-700fe490cb12" id="6d250e6a-0cfe-4749-af3d-700fe490cb12" name="Win2012R2" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/e8734bdb-af24-443e-9496-10f367424316" id="e8734bdb-af24-443e-9496-10f367424316" name="Tieto Windows Server 2012 R2" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            </CatalogItems>
-            <IsPublished>false</IsPublished>
-            <DateCreated>2016-08-02T11:09:57.957+03:00</DateCreated>
-        </Catalog>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:53:04 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:53:09 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 6b25fe17-0b30-4402-82ec-c3182765f3cc
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '63'
-      Content-Type:
-      - application/vnd.vmware.vcloud.catalog+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '2211'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <Catalog xmlns="http://www.vmware.com/vcloud/v1.5" name="Shared Tieto Catalog" id="urn:vcloud:catalog:0490ad3b-f343-4b80-8d5b-ecb0397fd412" href="https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412" type="application/vnd.vmware.vcloud.catalog+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Description>Tieto Shared Catalog</Description>
-            <CatalogItems>
-                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/23a9d1e6-a80a-4fc8-ad25-664f282d9ac0" id="23a9d1e6-a80a-4fc8-ad25-664f282d9ac0" name="Tieto Linux CentOS 7.0" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/42800327-57ed-433e-8ca4-17a33843cc0a" id="42800327-57ed-433e-8ca4-17a33843cc0a" name="CentOS 7 Everything" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/59d0aebb-aad0-4f01-9fd6-082fca414936" id="59d0aebb-aad0-4f01-9fd6-082fca414936" name="CentOS 7" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/6d250e6a-0cfe-4749-af3d-700fe490cb12" id="6d250e6a-0cfe-4749-af3d-700fe490cb12" name="Win2012R2" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/e8734bdb-af24-443e-9496-10f367424316" id="e8734bdb-af24-443e-9496-10f367424316" name="Tieto Windows Server 2012 R2" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            </CatalogItems>
-            <IsPublished>false</IsPublished>
-            <DateCreated>2016-08-02T11:09:57.957+03:00</DateCreated>
-        </Catalog>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:53:09 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/23a9d1e6-a80a-4fc8-ad25-664f282d9ac0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:53:14 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - b92fb332-f42a-4548-a6f9-8d33543c5138
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '172'
-      Content-Type:
-      - application/vnd.vmware.vcloud.catalogitem+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '1142'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" size="0" name="Tieto Linux CentOS 7.0" id="urn:vcloud:catalogitem:23a9d1e6-a80a-4fc8-ad25-664f282d9ac0" href="https://VMWARE_CLOUD_HOST/api/catalogItem/23a9d1e6-a80a-4fc8-ad25-664f282d9ac0" type="application/vnd.vmware.vcloud.catalogItem+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412" type="application/vnd.vmware.vcloud.catalog+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalogItem/23a9d1e6-a80a-4fc8-ad25-664f282d9ac0/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Description/>
-            <Entity href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57" name="Tieto Linux CentOS 7.0" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-            <DateCreated>2016-08-02T16:34:24.980+03:00</DateCreated>
-        </CatalogItem>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:53:15 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:53:20 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 52fbe006-bb92-439f-98c7-89b7f4ae90c3
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '855'
-      Content-Type:
-      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
     body:
       encoding: ASCII-8BIT
       string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="true" ovfDescriptorUploaded="true" status="8" name="Tieto Linux CentOS 7.0" id="urn:vcloud:vapptemplate:ab27a332-2cc3-4ce8-a50f-138036cf7f57" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/23a9d1e6-a80a-4fc8-ad25-664f282d9ac0" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/action/enableDownload"/>
-            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/action/disableDownload"/>
-            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/ovf" type="text/xml"/>
-            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Description/>
-            <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/2f90cae3-8ddf-48ce-b55e-45adde7a8bf6" name="system" type="application/vnd.vmware.admin.user+xml"/>
-            </Owner>
-            <Children>
-                <Vm goldMaster="true" status="8" name="CentOS7" id="urn:vcloud:vm:857551b6-380c-44d0-ab34-9d144866f0b4" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Description/>
-                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="internal">
-                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:2b</MACAddress>
-                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
-                        </NetworkConnection>
-                    </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <Enabled>false</Enabled>
-                        <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>857551b6-380c-44d0-ab34-9d144866f0b4</VirtualMachineId>
-                        <JoinDomainEnabled>false</JoinDomainEnabled>
-                        <UseOrgSettings>false</UseOrgSettings>
-                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
-                        <AdminPasswordAuto>true</AdminPasswordAuto>
-                        <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>CentOS7</ComputerName>
-                    </GuestCustomizationSection>
-                    <VAppScopedLocalId>d0733827-5a41-4816-b4a9-3cb8deb98583</VAppScopedLocalId>
-                    <DateCreated>2016-08-02T16:34:25.103+03:00</DateCreated>
-                </Vm>
-            </Children>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" ovfDescriptorUploaded="true" deployed="false" status="8" name="spec2-vapp" id="urn:vcloud:vapp:0e8b6b49-f42f-43c0-9c15-368d01c222c9" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9" type="application/vnd.vmware.vcloud.vApp+xml">
+            <Link rel="power:powerOn" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/power/action/powerOn"/>
+            <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/network/bff5aa08-9e67-45ce-a02e-a10eb64b292a" name="spec2-network" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="controlAccess" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="recompose" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/action/recomposeVApp" type="application/vnd.vmware.vcloud.recomposeVAppParams+xml"/>
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9" type="application/vnd.vmware.vcloud.vApp+xml"/>
+            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9"/>
+            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/action/enableDownload"/>
+            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/action/disableDownload"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/ovf" type="text/xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+            <Link rel="snapshot:revertToCurrent" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/action/revertToCurrentSnapshot"/>
+            <Link rel="snapshot:removeAll" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/action/removeAllSnapshots"/>
+            <Description></Description>
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+                <ovf:Info>Lease settings section</ovf:Info>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <DeploymentLeaseInSeconds>2592000</DeploymentLeaseInSeconds>
+                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
+                <StorageLeaseExpiration>2018-06-07T14:54:52.870+02:00</StorageLeaseExpiration>
+            </LeaseSettingsSection>
+            <ovf:StartupSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.startupSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/startupSection/">
+                <ovf:Info>VApp startup section</ovf:Info>
+                <ovf:Item ovf:id="spec2-vm1" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
+            </ovf:StartupSection>
+            <ovf:NetworkSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.networkSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/networkSection/">
                 <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="internal">
-                    <ovf:Description/>
+                <ovf:Network ovf:name="spec2-network">
+                    <ovf:Description></ovf:Description>
                 </ovf:Network>
             </ovf:NetworkSection>
-            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
                 <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <NetworkConfig networkName="internal">
-                    <Description/>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
+                <NetworkConfig networkName="spec2-network">
+                    <Link rel="repair" href="https://VMWARE_CLOUD_HOST/api/admin/network/bff5aa08-9e67-45ce-a02e-a10eb64b292a/action/reset"/>
+                    <Description></Description>
                     <Configuration>
                         <IpScopes>
                             <IpScope>
@@ -2529,1473 +2470,1560 @@ http_interactions:
                                 <IsEnabled>true</IsEnabled>
                                 <IpRanges>
                                     <IpRange>
-                                        <StartAddress>192.168.2.100</StartAddress>
-                                        <EndAddress>192.168.2.199</EndAddress>
+        <StartAddress>192.168.2.100</StartAddress>
+        <EndAddress>192.168.2.199</EndAddress>
                                     </IpRange>
                                 </IpRanges>
                             </IpScope>
                         </IpScopes>
                         <FenceMode>isolated</FenceMode>
                         <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
+                        <Features>
+                            <DhcpService>
+                                <IsEnabled>false</IsEnabled>
+                                <DefaultLeaseTime>3600</DefaultLeaseTime>
+                                <MaxLeaseTime>7200</MaxLeaseTime>
+                            </DhcpService>
+                        </Features>
                     </Configuration>
                     <IsDeployed>false</IsDeployed>
                 </NetworkConfig>
             </NetworkConfigSection>
-            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
-                <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
-                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
-                <StorageLeaseExpiration>2016-12-11T10:12:59.137+02:00</StorageLeaseExpiration>
-            </LeaseSettingsSection>
-            <CustomizationSection goldMaster="true" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
-                <ovf:Info>VApp template customization section</ovf:Info>
-                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
-            </CustomizationSection>
-            <DateCreated>2016-08-02T16:34:25.103+03:00</DateCreated>
-        </VAppTemplate>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:53:21 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:53:26 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 6e55e332-622e-4b78-baeb-5538532232fb
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '244'
-      Content-Type:
-      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="true" ovfDescriptorUploaded="true" status="8" name="Tieto Linux CentOS 7.0" id="urn:vcloud:vapptemplate:ab27a332-2cc3-4ce8-a50f-138036cf7f57" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/23a9d1e6-a80a-4fc8-ad25-664f282d9ac0" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/action/enableDownload"/>
-            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/action/disableDownload"/>
-            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/ovf" type="text/xml"/>
-            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Description/>
+            <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+                <ovf:Info>Snapshot information section</ovf:Info>
+                <Snapshot created="2018-03-12T15:43:30.986+01:00" poweredOn="false" size="17179869184"/>
+            </SnapshotSection>
+            <DateCreated>2018-03-09T13:39:00.260+01:00</DateCreated>
             <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/2f90cae3-8ddf-48ce-b55e-45adde7a8bf6" name="system" type="application/vnd.vmware.admin.user+xml"/>
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/f3555478-d7ea-4d9c-9b48-4bced57539e3" name="system" type="application/vnd.vmware.admin.user+xml"/>
             </Owner>
+            <InMaintenanceMode>false</InMaintenanceMode>
             <Children>
-                <Vm goldMaster="true" status="8" name="CentOS7" id="urn:vcloud:vm:857551b6-380c-44d0-ab34-9d144866f0b4" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Description/>
-                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                <Vm needsCustomization="false" nestedHypervisorEnabled="false" deployed="false" status="8" name="spec2-vm1" id="urn:vcloud:vm:aaf94123-cbf9-4de9-841c-41dd41ac310e" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="power:powerOn" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/power/action/powerOn"/>
+                    <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
+                    <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Link rel="screen:thumbnail" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/screen"/>
+                    <Link rel="media:insertMedia" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
+                    <Link rel="media:ejectMedia" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
+                    <Link rel="disk:attach" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
+                    <Link rel="disk:detach" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
+                    <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/action/enableNestedHypervisor"/>
+                    <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+                    <Link rel="snapshot:revertToCurrent" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/action/revertToCurrentSnapshot"/>
+                    <Link rel="snapshot:removeAll" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/action/removeAllSnapshots"/>
+                    <Link rel="reconfigureVm" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/action/reconfigureVm" name="spec2-vm1" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0e8b6b49-f42f-43c0-9c15-368d01c222c9" type="application/vnd.vmware.vcloud.vApp+xml"/>
+                    <Description></Description>
+                    <ovf:VirtualHardwareSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ovf:transport="" ns13:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/">
+                        <ovf:Info>Virtual hardware requirements</ovf:Info>
+                        <ovf:System>
+                            <vssd:AutomaticRecoveryAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticShutdownAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticStartupAction xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticStartupActionDelay xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:AutomaticStartupActionSequenceNumber xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:CreationTime xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:Description xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+                            <vssd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:InstanceID>0</vssd:InstanceID>
+                            <vssd:LogDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:RecoveryFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:SnapshotDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:SuspendDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:SwapFileDataRoot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <vssd:VirtualSystemIdentifier>spec2-vm1</vssd:VirtualSystemIdentifier>
+                            <vssd:VirtualSystemType>vmx-13</vssd:VirtualSystemType>
+                        </ovf:System>
+                        <ovf:Item>
+                            <rasd:Address>00:50:56:01:00:d9</rasd:Address>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Connection ns13:ipAddressingMode="POOL" ns13:ipAddress="192.168.2.100" ns13:primaryNetworkConnection="true">spec2-network</rasd:Connection>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>Vmxnet3 ethernet adapter on "spec2-network"</rasd:Description>
+                            <rasd:ElementName>Network adapter 0</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:InstanceID>1</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
+                            <rasd:ResourceType>10</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address>0</rasd:Address>
+                            <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>SCSI Controller</rasd:Description>
+                            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:InstanceID>2</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType>VirtualSCSI</rasd:ResourceSubType>
+                            <rasd:ResourceType>6</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>Hard disk</rasd:Description>
+                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:HostResource ns13:busType="6" ns13:busSubType="VirtualSCSI" ns13:capacity="16384"></rasd:HostResource>
+                            <rasd:InstanceID>2000</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent>2</rasd:Parent>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceType>17</rasd:ResourceType>
+                            <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address>0</rasd:Address>
+                            <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>IDE Controller</rasd:Description>
+                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:InstanceID>3</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceType>5</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>CD/DVD Drive</rasd:Description>
+                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:HostResource></rasd:HostResource>
+                            <rasd:InstanceID>3000</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent>3</rasd:Parent>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceType>15</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>Floppy Drive</rasd:Description>
+                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:HostResource></rasd:HostResource>
+                            <rasd:InstanceID>8000</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceType>14</rasd:ResourceType>
+                            <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                        </ovf:Item>
+                        <ovf:Item ns13:type="application/vnd.vmware.vcloud.rasdItem+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/cpu">
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>Number of Virtual CPUs</rasd:Description>
+                            <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:InstanceID>4</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceType>3</rasd:ResourceType>
+                            <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight>0</rasd:Weight>
+                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        </ovf:Item>
+                        <ovf:Item ns13:type="application/vnd.vmware.vcloud.rasdItem+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/memory">
+                            <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+                            <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Description>Memory Size</rasd:Description>
+                            <rasd:ElementName>256 MB of memory</rasd:ElementName>
+                            <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:InstanceID>5</rasd:InstanceID>
+                            <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:ResourceType>4</rasd:ResourceType>
+                            <rasd:VirtualQuantity>256</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                            <rasd:Weight>0</rasd:Weight>
+                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        </ovf:Item>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                    </ovf:VirtualHardwareSection>
+                    <ovf:OperatingSystemSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ovf:id="102" ns13:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="vmwarePhoton64Guest" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/operatingSystemSection/">
+                        <ovf:Info>Specifies the operating system installed</ovf:Info>
+                        <ovf:Description>VMware Photon OS (64-bit)</ovf:Description>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
+                    </ovf:OperatingSystemSection>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
                         <ovf:Info>Specifies the available VM network connections</ovf:Info>
                         <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="internal">
+                        <NetworkConnection needsCustomization="false" network="spec2-network">
                             <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IpAddress>192.168.2.100</IpAddress>
                             <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:2b</MACAddress>
+                            <MACAddress>00:50:56:01:00:d9</MACAddress>
                             <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
                         </NetworkConnection>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
                     </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
                         <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
                         <Enabled>false</Enabled>
                         <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>857551b6-380c-44d0-ab34-9d144866f0b4</VirtualMachineId>
+                        <VirtualMachineId>aaf94123-cbf9-4de9-841c-41dd41ac310e</VirtualMachineId>
                         <JoinDomainEnabled>false</JoinDomainEnabled>
                         <UseOrgSettings>false</UseOrgSettings>
                         <AdminPasswordEnabled>true</AdminPasswordEnabled>
                         <AdminPasswordAuto>true</AdminPasswordAuto>
                         <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>CentOS7</ComputerName>
+                        <ComputerName>spec2-vm1</ComputerName>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
                     </GuestCustomizationSection>
-                    <VAppScopedLocalId>d0733827-5a41-4816-b4a9-3cb8deb98583</VAppScopedLocalId>
-                    <DateCreated>2016-08-02T16:34:25.103+03:00</DateCreated>
+                    <RuntimeInfoSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/runtimeInfoSection">
+                        <ovf:Info>Specifies Runtime info</ovf:Info>
+                    </RuntimeInfoSection>
+                    <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+                        <ovf:Info>Snapshot information section</ovf:Info>
+                        <Snapshot created="2018-03-12T15:43:30.986+01:00" poweredOn="false" size="17179869184"/>
+                    </SnapshotSection>
+                    <DateCreated>2018-03-09T13:39:02.741+01:00</DateCreated>
+                    <VAppScopedLocalId>0166f57b-6ae3-47fe-a68b-4f7bebb61074</VAppScopedLocalId>
+                    <VmCapabilities href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
+                        <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
+                        <CpuHotAddEnabled>false</CpuHotAddEnabled>
+                    </VmCapabilities>
+                    <StorageProfile href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/b652f213-33aa-4c1f-8f30-ea2919a30843" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
                 </Vm>
             </Children>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
-                <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="internal">
-                    <ovf:Description/>
-                </ovf:Network>
-            </ovf:NetworkSection>
-            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
-                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <NetworkConfig networkName="internal">
-                    <Description/>
-                    <Configuration>
-                        <IpScopes>
-                            <IpScope>
-                                <IsInherited>false</IsInherited>
-                                <Gateway>192.168.2.1</Gateway>
-                                <Netmask>255.255.255.0</Netmask>
-                                <IsEnabled>true</IsEnabled>
-                                <IpRanges>
-                                    <IpRange>
-                                        <StartAddress>192.168.2.100</StartAddress>
-                                        <EndAddress>192.168.2.199</EndAddress>
-                                    </IpRange>
-                                </IpRanges>
-                            </IpScope>
-                        </IpScopes>
-                        <FenceMode>isolated</FenceMode>
-                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
-                    </Configuration>
-                    <IsDeployed>false</IsDeployed>
-                </NetworkConfig>
-            </NetworkConfigSection>
-            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
-                <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
-                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
-                <StorageLeaseExpiration>2016-12-11T10:12:59.137+02:00</StorageLeaseExpiration>
-            </LeaseSettingsSection>
-            <CustomizationSection goldMaster="true" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
-                <ovf:Info>VApp template customization section</ovf:Info>
-                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
-            </CustomizationSection>
-            <DateCreated>2016-08-02T16:34:25.103+03:00</DateCreated>
-        </VAppTemplate>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:53:27 GMT
+        </VApp>
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:31 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/42800327-57ed-433e-8ca4-17a33843cc0a
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/guestCustomizationSection
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.42.0
+      - fog-core/1.45.0
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Date:
-      - Fri, 16 Sep 2016 08:53:31 GMT
+      - Wed, 14 Mar 2018 10:54:31 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 3010f569-fc58-4be7-ba22-bd5ba252a35c
+      - 6eb71b73-35f4-4117-b627-dc5c9611e768
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
       Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '66'
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
       Content-Type:
-      - application/vnd.vmware.vcloud.catalogitem+xml;version=5.1
+      - application/vnd.vmware.vcloud.guestcustomizationsection+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '52'
       Vary:
       - Accept-Encoding, User-Agent
       Content-Length:
-      - '1118'
+      - '1741'
     body:
       encoding: ASCII-8BIT
       string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" size="7782531072" name="CentOS 7 Everything" id="urn:vcloud:catalogitem:42800327-57ed-433e-8ca4-17a33843cc0a" href="https://VMWARE_CLOUD_HOST/api/catalogItem/42800327-57ed-433e-8ca4-17a33843cc0a" type="application/vnd.vmware.vcloud.catalogItem+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412" type="application/vnd.vmware.vcloud.catalog+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalogItem/42800327-57ed-433e-8ca4-17a33843cc0a/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Description/>
-            <Entity href="https://VMWARE_CLOUD_HOST/api/media/485da411-6e5b-4c32-ae34-dd82c2b78f4d" name="CentOS 7 Everything" type="application/vnd.vmware.vcloud.media+xml"/>
-            <DateCreated>2016-08-02T16:01:46.560+03:00</DateCreated>
-        </CatalogItem>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:53:32 GMT
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <GuestCustomizationSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+            <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+            <Enabled>false</Enabled>
+            <ChangeSid>true</ChangeSid>
+            <VirtualMachineId>84faa107-c0b9-4a21-adc5-b17e0c5355a2</VirtualMachineId>
+            <JoinDomainEnabled>false</JoinDomainEnabled>
+            <UseOrgSettings>false</UseOrgSettings>
+            <AdminPasswordEnabled>true</AdminPasswordEnabled>
+            <AdminPasswordAuto>true</AdminPasswordAuto>
+            <ResetPasswordRequired>false</ResetPasswordRequired>
+            <ComputerName>spec1-vm1</ComputerName>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+        </GuestCustomizationSection>
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:31 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/59d0aebb-aad0-4f01-9fd6-082fca414936
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/disks
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.42.0
+      - fog-core/1.45.0
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Date:
-      - Fri, 16 Sep 2016 08:53:37 GMT
+      - Wed, 14 Mar 2018 10:54:31 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 20ac7621-c6d1-41b7-ae7b-14b8b2e45686
+      - 5211df76-040c-43a7-a0a9-bd494a212fc0
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
       Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '124'
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
       Content-Type:
-      - application/vnd.vmware.vcloud.catalogitem+xml;version=5.1
+      - application/vnd.vmware.vcloud.rasditemslist+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '37'
       Vary:
       - Accept-Encoding, User-Agent
       Content-Length:
-      - '1095'
+      - '7671'
     body:
       encoding: ASCII-8BIT
       string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" size="634388480" name="CentOS 7" id="urn:vcloud:catalogitem:59d0aebb-aad0-4f01-9fd6-082fca414936" href="https://VMWARE_CLOUD_HOST/api/catalogItem/59d0aebb-aad0-4f01-9fd6-082fca414936" type="application/vnd.vmware.vcloud.catalogItem+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412" type="application/vnd.vmware.vcloud.catalog+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalogItem/59d0aebb-aad0-4f01-9fd6-082fca414936/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Description/>
-            <Entity href="https://VMWARE_CLOUD_HOST/api/media/ff3852a3-bd3d-43b4-95c5-ec00d84b356d" name="CentOS 7" type="application/vnd.vmware.vcloud.media+xml"/>
-            <DateCreated>2016-08-02T14:44:53.647+03:00</DateCreated>
-        </CatalogItem>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:53:37 GMT
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <RasdItemsList xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml">
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+            <Item>
+                <rasd:Address>0</rasd:Address>
+                <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Description>SCSI Controller</rasd:Description>
+                <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+                <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:InstanceID>2</rasd:InstanceID>
+                <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ResourceSubType>lsilogicsas</rasd:ResourceSubType>
+                <rasd:ResourceType>6</rasd:ResourceType>
+                <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+            </Item>
+            <Item>
+                <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Description>Hard disk</rasd:Description>
+                <rasd:ElementName>Hard disk 1</rasd:ElementName>
+                <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:HostResource xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:busType="6" ns13:busSubType="lsilogicsas" ns13:capacity="10240"></rasd:HostResource>
+                <rasd:InstanceID>2000</rasd:InstanceID>
+                <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Parent>2</rasd:Parent>
+                <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ResourceType>17</rasd:ResourceType>
+                <rasd:VirtualQuantity>10737418240</rasd:VirtualQuantity>
+                <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+                <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+            </Item>
+            <Item>
+                <rasd:Address>0</rasd:Address>
+                <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Description>IDE Controller</rasd:Description>
+                <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+                <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:InstanceID>3</rasd:InstanceID>
+                <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ResourceType>5</rasd:ResourceType>
+                <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+            </Item>
+        </RasdItemsList>
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:31 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/6d250e6a-0cfe-4749-af3d-700fe490cb12
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/snapshotSection
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.42.0
+      - fog-core/1.45.0
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Date:
-      - Fri, 16 Sep 2016 08:53:42 GMT
+      - Wed, 14 Mar 2018 10:54:32 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 65712a29-9eea-4a3d-bd3b-899daa64dc47
+      - 852d4954-3eb1-469e-b69d-318d63b5083f
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
       Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '63'
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
       Content-Type:
-      - application/vnd.vmware.vcloud.catalogitem+xml;version=5.1
+      - application/vnd.vmware.vcloud.snapshotsection+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '109'
       Vary:
       - Accept-Encoding, User-Agent
       Content-Length:
-      - '1098'
+      - '1062'
     body:
       encoding: ASCII-8BIT
       string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" size="5397889024" name="Win2012R2" id="urn:vcloud:catalogitem:6d250e6a-0cfe-4749-af3d-700fe490cb12" href="https://VMWARE_CLOUD_HOST/api/catalogItem/6d250e6a-0cfe-4749-af3d-700fe490cb12" type="application/vnd.vmware.vcloud.catalogItem+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412" type="application/vnd.vmware.vcloud.catalog+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalogItem/6d250e6a-0cfe-4749-af3d-700fe490cb12/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Description/>
-            <Entity href="https://VMWARE_CLOUD_HOST/api/media/871ab1ed-816b-4708-b998-5e05dbc28bf1" name="Win2012R2" type="application/vnd.vmware.vcloud.media+xml"/>
-            <DateCreated>2016-08-02T14:44:23.147+03:00</DateCreated>
-        </CatalogItem>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:53:43 GMT
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <SnapshotSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+            <ovf:Info>Snapshot information section</ovf:Info>
+        </SnapshotSection>
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:32 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/e8734bdb-af24-443e-9496-10f367424316
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/guestCustomizationSection
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.42.0
+      - fog-core/1.45.0
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Date:
-      - Fri, 16 Sep 2016 08:53:47 GMT
+      - Wed, 14 Mar 2018 10:54:32 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 0902cfbc-8f47-4395-9fa0-5e1e5fb04bdb
+      - 2848a4be-5709-4906-aa9c-83b19824f281
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
       Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '93'
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
       Content-Type:
-      - application/vnd.vmware.vcloud.catalogitem+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '1154'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" size="0" name="Tieto Windows Server 2012 R2" id="urn:vcloud:catalogitem:e8734bdb-af24-443e-9496-10f367424316" href="https://VMWARE_CLOUD_HOST/api/catalogItem/e8734bdb-af24-443e-9496-10f367424316" type="application/vnd.vmware.vcloud.catalogItem+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412" type="application/vnd.vmware.vcloud.catalog+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalogItem/e8734bdb-af24-443e-9496-10f367424316/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Description/>
-            <Entity href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510" name="Tieto Windows Server 2012 R2" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-            <DateCreated>2016-08-02T11:11:00.127+03:00</DateCreated>
-        </CatalogItem>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:53:48 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:53:53 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 040fdfdd-3a20-4b13-b54b-98e3b68e94a7
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '138'
-      Content-Type:
-      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '8142'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="true" ovfDescriptorUploaded="true" status="8" name="Tieto Windows Server 2012 R2" id="urn:vcloud:vapptemplate:cfff2e62-3746-4007-bcfe-a054fb30c510" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/e8734bdb-af24-443e-9496-10f367424316" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/action/enableDownload"/>
-            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/action/disableDownload"/>
-            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/ovf" type="text/xml"/>
-            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Description/>
-            <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/2f90cae3-8ddf-48ce-b55e-45adde7a8bf6" name="system" type="application/vnd.vmware.admin.user+xml"/>
-            </Owner>
-            <Children>
-                <Vm goldMaster="true" status="8" name="Tieto Windows Server 2012 R2" id="urn:vcloud:vm:ac5fcf96-2b9d-4e90-9a2f-7792160da1ae" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Description/>
-                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="none">
-                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IsConnected>false</IsConnected>
-                            <MACAddress>00:50:56:84:02:de</MACAddress>
-                            <IpAddressAllocationMode>NONE</IpAddressAllocationMode>
-                        </NetworkConnection>
-                    </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <Enabled>true</Enabled>
-                        <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>ac5fcf96-2b9d-4e90-9a2f-7792160da1ae</VirtualMachineId>
-                        <JoinDomainEnabled>false</JoinDomainEnabled>
-                        <UseOrgSettings>false</UseOrgSettings>
-                        <AdminPasswordEnabled>false</AdminPasswordEnabled>
-                        <AdminPasswordAuto>true</AdminPasswordAuto>
-                        <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>TietoWindow-001</ComputerName>
-                    </GuestCustomizationSection>
-                    <VAppScopedLocalId>Tieto Windows Server 2012 R2</VAppScopedLocalId>
-                    <DateCreated>2016-08-02T11:11:07.407+03:00</DateCreated>
-                </Vm>
-            </Children>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
-                <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="none">
-                    <ovf:Description>This is a special place-holder used for disconnected network interfaces.</ovf:Description>
-                </ovf:Network>
-            </ovf:NetworkSection>
-            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
-                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <NetworkConfig networkName="none">
-                    <Description>This is a special place-holder used for disconnected network interfaces.</Description>
-                    <Configuration>
-                        <IpScopes>
-                            <IpScope>
-                                <IsInherited>false</IsInherited>
-                                <Gateway>196.254.254.254</Gateway>
-                                <Netmask>255.255.0.0</Netmask>
-                                <Dns1>196.254.254.254</Dns1>
-                            </IpScope>
-                        </IpScopes>
-                        <FenceMode>isolated</FenceMode>
-                    </Configuration>
-                    <IsDeployed>false</IsDeployed>
-                </NetworkConfig>
-            </NetworkConfigSection>
-            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
-                <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
-                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
-                <StorageLeaseExpiration>2016-12-08T09:07:24.827+02:00</StorageLeaseExpiration>
-            </LeaseSettingsSection>
-            <CustomizationSection goldMaster="true" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
-                <ovf:Info>VApp template customization section</ovf:Info>
-                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
-            </CustomizationSection>
-            <DateCreated>2016-08-02T11:11:07.407+03:00</DateCreated>
-        </VAppTemplate>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:53:54 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:53:58 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 287fca52-7906-467c-a42c-b2470fb95330
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '132'
-      Content-Type:
-      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '8142'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="true" ovfDescriptorUploaded="true" status="8" name="Tieto Windows Server 2012 R2" id="urn:vcloud:vapptemplate:cfff2e62-3746-4007-bcfe-a054fb30c510" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/e8734bdb-af24-443e-9496-10f367424316" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/action/enableDownload"/>
-            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/action/disableDownload"/>
-            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/ovf" type="text/xml"/>
-            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Description/>
-            <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/2f90cae3-8ddf-48ce-b55e-45adde7a8bf6" name="system" type="application/vnd.vmware.admin.user+xml"/>
-            </Owner>
-            <Children>
-                <Vm goldMaster="true" status="8" name="Tieto Windows Server 2012 R2" id="urn:vcloud:vm:ac5fcf96-2b9d-4e90-9a2f-7792160da1ae" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Description/>
-                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="none">
-                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IsConnected>false</IsConnected>
-                            <MACAddress>00:50:56:84:02:de</MACAddress>
-                            <IpAddressAllocationMode>NONE</IpAddressAllocationMode>
-                        </NetworkConnection>
-                    </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <Enabled>true</Enabled>
-                        <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>ac5fcf96-2b9d-4e90-9a2f-7792160da1ae</VirtualMachineId>
-                        <JoinDomainEnabled>false</JoinDomainEnabled>
-                        <UseOrgSettings>false</UseOrgSettings>
-                        <AdminPasswordEnabled>false</AdminPasswordEnabled>
-                        <AdminPasswordAuto>true</AdminPasswordAuto>
-                        <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>TietoWindow-001</ComputerName>
-                    </GuestCustomizationSection>
-                    <VAppScopedLocalId>Tieto Windows Server 2012 R2</VAppScopedLocalId>
-                    <DateCreated>2016-08-02T11:11:07.407+03:00</DateCreated>
-                </Vm>
-            </Children>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
-                <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="none">
-                    <ovf:Description>This is a special place-holder used for disconnected network interfaces.</ovf:Description>
-                </ovf:Network>
-            </ovf:NetworkSection>
-            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
-                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <NetworkConfig networkName="none">
-                    <Description>This is a special place-holder used for disconnected network interfaces.</Description>
-                    <Configuration>
-                        <IpScopes>
-                            <IpScope>
-                                <IsInherited>false</IsInherited>
-                                <Gateway>196.254.254.254</Gateway>
-                                <Netmask>255.255.0.0</Netmask>
-                                <Dns1>196.254.254.254</Dns1>
-                            </IpScope>
-                        </IpScopes>
-                        <FenceMode>isolated</FenceMode>
-                    </Configuration>
-                    <IsDeployed>false</IsDeployed>
-                </NetworkConfig>
-            </NetworkConfigSection>
-            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
-                <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
-                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
-                <StorageLeaseExpiration>2016-12-08T09:07:24.827+02:00</StorageLeaseExpiration>
-            </LeaseSettingsSection>
-            <CustomizationSection goldMaster="true" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
-                <ovf:Info>VApp template customization section</ovf:Info>
-                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
-            </CustomizationSection>
-            <DateCreated>2016-08-02T11:11:07.407+03:00</DateCreated>
-        </VAppTemplate>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:53:59 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:54:04 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - c39d975b-632a-420b-86e8-38274ffee112
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '36'
-      Content-Type:
-      - application/vnd.vmware.vcloud.catalog+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '2221'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <Catalog xmlns="http://www.vmware.com/vcloud/v1.5" name="XTestCatalog" id="urn:vcloud:catalog:261037bc-8299-42c1-9ac1-b8c4c964d99d" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d" type="application/vnd.vmware.vcloud.catalog+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/org/e338a4ac-551b-4b6c-b5c0-aff31b71417f" type="application/vnd.vmware.vcloud.org+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d/catalogItems" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="controlAccess" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Description/>
-            <CatalogItems>
-                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/77519250-ce5a-45d5-939d-fbe79704e18d" id="77519250-ce5a-45d5-939d-fbe79704e18d" name="vApp_cankamat_remote_1" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d" id="8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d" name="vApp_CentOS_and_msWin" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/fd9c3a97-14bd-499b-bd52-054a1602ae89" id="fd9c3a97-14bd-499b-bd52-054a1602ae89" name="CentOS 7" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            </CatalogItems>
-            <IsPublished>false</IsPublished>
-            <DateCreated>2016-08-11T15:14:05.377+03:00</DateCreated>
-        </Catalog>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:54:04 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:54:09 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 6876d973-576a-4674-9c52-1548d26ff07c
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
+      - application/vnd.vmware.vcloud.guestcustomizationsection+xml;version=5.1
       X-Vmware-Vcloud-Request-Execution-Time:
       - '30'
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1748'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <GuestCustomizationSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+            <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+            <Enabled>false</Enabled>
+            <ChangeSid>false</ChangeSid>
+            <VirtualMachineId>350947aa-c16e-4eb3-98c1-fced9dac6dbc</VirtualMachineId>
+            <JoinDomainEnabled>false</JoinDomainEnabled>
+            <UseOrgSettings>false</UseOrgSettings>
+            <AdminPasswordEnabled>true</AdminPasswordEnabled>
+            <AdminPasswordAuto>true</AdminPasswordAuto>
+            <ResetPasswordRequired>false</ResetPasswordRequired>
+            <ComputerName>93e8f5e5-7b-001</ComputerName>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+        </GuestCustomizationSection>
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:32 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/disks
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - ee9f52dbb4d245048614dba57e182fd3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 Mar 2018 10:54:32 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - feb06c9b-68e3-48fc-a571-1133bbbf1896
+      X-Vcloud-Authorization:
+      - ee9f52dbb4d245048614dba57e182fd3
+      Set-Cookie:
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
+      Content-Type:
+      - application/vnd.vmware.vcloud.rasditemslist+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '30'
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '5501'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <RasdItemsList xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml">
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+            <Item>
+                <rasd:Address>0</rasd:Address>
+                <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Description>SCSI Controller</rasd:Description>
+                <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+                <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:InstanceID>2</rasd:InstanceID>
+                <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
+                <rasd:ResourceType>6</rasd:ResourceType>
+                <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+            </Item>
+            <Item>
+                <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Description>Hard disk</rasd:Description>
+                <rasd:ElementName>Hard disk 1</rasd:ElementName>
+                <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:HostResource xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:busType="6" ns13:busSubType="lsilogic" ns13:capacity="67584"></rasd:HostResource>
+                <rasd:InstanceID>2000</rasd:InstanceID>
+                <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Parent>2</rasd:Parent>
+                <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ResourceType>17</rasd:ResourceType>
+                <rasd:VirtualQuantity>70866960384</rasd:VirtualQuantity>
+                <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+                <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+            </Item>
+        </RasdItemsList>
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:32 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/snapshotSection
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - ee9f52dbb4d245048614dba57e182fd3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 Mar 2018 10:54:32 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 0e916a86-0cc0-4ea6-ab64-3bc13c90af79
+      X-Vcloud-Authorization:
+      - ee9f52dbb4d245048614dba57e182fd3
+      Set-Cookie:
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
+      Content-Type:
+      - application/vnd.vmware.vcloud.snapshotsection+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '101'
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1062'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <SnapshotSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-350947aa-c16e-4eb3-98c1-fced9dac6dbc/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+            <ovf:Info>Snapshot information section</ovf:Info>
+        </SnapshotSection>
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:32 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/guestCustomizationSection
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - ee9f52dbb4d245048614dba57e182fd3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 Mar 2018 10:54:32 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - ee27171f-b6dd-4809-9c40-c48002097b7c
+      X-Vcloud-Authorization:
+      - ee9f52dbb4d245048614dba57e182fd3
+      Set-Cookie:
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
+      Content-Type:
+      - application/vnd.vmware.vcloud.guestcustomizationsection+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '100'
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1742'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <GuestCustomizationSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+            <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+            <Enabled>false</Enabled>
+            <ChangeSid>false</ChangeSid>
+            <VirtualMachineId>aaf94123-cbf9-4de9-841c-41dd41ac310e</VirtualMachineId>
+            <JoinDomainEnabled>false</JoinDomainEnabled>
+            <UseOrgSettings>false</UseOrgSettings>
+            <AdminPasswordEnabled>true</AdminPasswordEnabled>
+            <AdminPasswordAuto>true</AdminPasswordAuto>
+            <ResetPasswordRequired>false</ResetPasswordRequired>
+            <ComputerName>spec2-vm1</ComputerName>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+        </GuestCustomizationSection>
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:32 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/disks
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - ee9f52dbb4d245048614dba57e182fd3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 Mar 2018 10:54:32 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 1edce235-260e-4f33-85bf-c4265ccc0e2f
+      X-Vcloud-Authorization:
+      - ee9f52dbb4d245048614dba57e182fd3
+      Set-Cookie:
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
+      Content-Type:
+      - application/vnd.vmware.vcloud.rasditemslist+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '34'
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '7671'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <RasdItemsList xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml">
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+            <Item>
+                <rasd:Address>0</rasd:Address>
+                <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Description>SCSI Controller</rasd:Description>
+                <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+                <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:InstanceID>2</rasd:InstanceID>
+                <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ResourceSubType>VirtualSCSI</rasd:ResourceSubType>
+                <rasd:ResourceType>6</rasd:ResourceType>
+                <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+            </Item>
+            <Item>
+                <rasd:Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Description>Hard disk</rasd:Description>
+                <rasd:ElementName>Hard disk 1</rasd:ElementName>
+                <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:HostResource xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:busType="6" ns13:busSubType="VirtualSCSI" ns13:capacity="16384"></rasd:HostResource>
+                <rasd:InstanceID>2000</rasd:InstanceID>
+                <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Parent>2</rasd:Parent>
+                <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ResourceType>17</rasd:ResourceType>
+                <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
+                <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+                <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+            </Item>
+            <Item>
+                <rasd:Address>0</rasd:Address>
+                <rasd:AddressOnParent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AllocationUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AutomaticAllocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:AutomaticDeallocation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Caption xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ChangeableType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Description>IDE Controller</rasd:Description>
+                <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+                <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:InstanceID>3</rasd:InstanceID>
+                <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:MappingBehavior xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:OtherResourceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Parent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:PoolID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Reservation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:ResourceType>5</rasd:ResourceType>
+                <rasd:VirtualQuantity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <rasd:Weight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+            </Item>
+        </RasdItemsList>
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:32 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/snapshotSection
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - ee9f52dbb4d245048614dba57e182fd3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 Mar 2018 10:54:32 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 0c25a5d1-1107-4456-ba5d-b05cd4a3c3dc
+      X-Vcloud-Authorization:
+      - ee9f52dbb4d245048614dba57e182fd3
+      Set-Cookie:
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
+      Content-Type:
+      - application/vnd.vmware.vcloud.snapshotsection+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '95'
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1155'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <SnapshotSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+            <ovf:Info>Snapshot information section</ovf:Info>
+            <Snapshot created="2018-03-12T15:43:30.986+01:00" poweredOn="false" size="17179869184"/>
+        </SnapshotSection>
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:32 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/org/6d6733f6-536a-454f-bbc3-efee7f6de081
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - ee9f52dbb4d245048614dba57e182fd3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 Mar 2018 10:54:32 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - e2a94d14-5177-40e6-9445-523d6d4b96d2
+      X-Vcloud-Authorization:
+      - ee9f52dbb4d245048614dba57e182fd3
+      Set-Cookie:
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
+      Content-Type:
+      - application/vnd.vmware.vcloud.org+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '73'
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '3075'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <Org xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" name="miq-dev" id="urn:vcloud:org:6d6733f6-536a-454f-bbc3-efee7f6de081" href="https://VMWARE_CLOUD_HOST/api/org/6d6733f6-536a-454f-bbc3-efee7f6de081" type="application/vnd.vmware.vcloud.org+xml">
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6" name="MIQ Devel VDC" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/tasksList/6d6733f6-536a-454f-bbc3-efee7f6de081" type="application/vnd.vmware.vcloud.tasksList+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/d3e213db-d4fa-49e4-a940-5810ab811648" name="RedHat Catalog2" type="application/vnd.vmware.vcloud.catalog+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/d3e213db-d4fa-49e4-a940-5810ab811648/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/8fac6233-474c-44b4-a45b-87e488102170" name="My First Catalog" type="application/vnd.vmware.vcloud.catalog+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/8fac6233-474c-44b4-a45b-87e488102170/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="controlAccess" href="https://VMWARE_CLOUD_HOST/api/catalog/8fac6233-474c-44b4-a45b-87e488102170/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/admin/org/6d6733f6-536a-454f-bbc3-efee7f6de081/catalogs" type="application/vnd.vmware.admin.catalog+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/network/9e381434-a787-49b5-949e-5d67eff76a18" name="ManageIQ Development network" type="application/vnd.vmware.vcloud.orgNetwork+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/network/5038b60d-fbb8-42e8-8bf3-e711f703507c" name="ManageIQ Dev external network" type="application/vnd.vmware.vcloud.orgNetwork+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/supportedSystemsInfo/" type="application/vnd.vmware.vcloud.supportedSystemsInfo+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/org/6d6733f6-536a-454f-bbc3-efee7f6de081/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Description></Description>
+            <FullName>ManageIQ Development Org</FullName>
+        </Org>
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:32 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/catalog/d3e213db-d4fa-49e4-a940-5810ab811648
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - ee9f52dbb4d245048614dba57e182fd3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 Mar 2018 10:54:32 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 4100b1e1-494e-4245-b401-214f0c6162b4
+      X-Vcloud-Authorization:
+      - ee9f52dbb4d245048614dba57e182fd3
+      Set-Cookie:
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
       Content-Type:
       - application/vnd.vmware.vcloud.catalog+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '23'
       Vary:
       - Accept-Encoding, User-Agent
       Content-Length:
-      - '2221'
+      - '1984'
     body:
       encoding: ASCII-8BIT
       string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <Catalog xmlns="http://www.vmware.com/vcloud/v1.5" name="XTestCatalog" id="urn:vcloud:catalog:261037bc-8299-42c1-9ac1-b8c4c964d99d" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d" type="application/vnd.vmware.vcloud.catalog+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/org/e338a4ac-551b-4b6c-b5c0-aff31b71417f" type="application/vnd.vmware.vcloud.org+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d/catalogItems" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="controlAccess" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Description/>
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <Catalog xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" name="RedHat Catalog2" id="urn:vcloud:catalog:d3e213db-d4fa-49e4-a940-5810ab811648" href="https://VMWARE_CLOUD_HOST/api/catalog/d3e213db-d4fa-49e4-a940-5810ab811648" type="application/vnd.vmware.vcloud.catalog+xml">
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/d3e213db-d4fa-49e4-a940-5810ab811648/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/d3e213db-d4fa-49e4-a940-5810ab811648/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Description></Description>
             <CatalogItems>
-                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/77519250-ce5a-45d5-939d-fbe79704e18d" id="77519250-ce5a-45d5-939d-fbe79704e18d" name="vApp_cankamat_remote_1" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d" id="8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d" name="vApp_CentOS_and_msWin" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/fd9c3a97-14bd-499b-bd52-054a1602ae89" id="fd9c3a97-14bd-499b-bd52-054a1602ae89" name="CentOS 7" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/56d7510b-c955-4afa-82cb-483eb1826589" id="56d7510b-c955-4afa-82cb-483eb1826589" name="Win-dev-201802-vapp" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/a7da7c15-7644-4a50-9ade-605f97dce291" id="a7da7c15-7644-4a50-9ade-605f97dce291" name="Windows and Linux VAPP TEMPLATE" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            </CatalogItems>
+            <IsPublished>true</IsPublished>
+            <DateCreated>2018-03-02T13:21:51.753+01:00</DateCreated>
+        </Catalog>
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:32 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/catalog/8fac6233-474c-44b4-a45b-87e488102170
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - ee9f52dbb4d245048614dba57e182fd3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 Mar 2018 10:54:32 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 4a5d76ff-41f7-4137-8b07-f298deb4b166
+      X-Vcloud-Authorization:
+      - ee9f52dbb4d245048614dba57e182fd3
+      Set-Cookie:
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
+      Content-Type:
+      - application/vnd.vmware.vcloud.catalog+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '17'
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '2228'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <Catalog xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" name="My First Catalog" id="urn:vcloud:catalog:8fac6233-474c-44b4-a45b-87e488102170" href="https://VMWARE_CLOUD_HOST/api/catalog/8fac6233-474c-44b4-a45b-87e488102170" type="application/vnd.vmware.vcloud.catalog+xml">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/org/6d6733f6-536a-454f-bbc3-efee7f6de081" type="application/vnd.vmware.vcloud.org+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/8fac6233-474c-44b4-a45b-87e488102170/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/catalog/8fac6233-474c-44b4-a45b-87e488102170/catalogItems" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/8fac6233-474c-44b4-a45b-87e488102170/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="controlAccess" href="https://VMWARE_CLOUD_HOST/api/catalog/8fac6233-474c-44b4-a45b-87e488102170/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Description></Description>
+            <CatalogItems>
+                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/f098a296-1633-4e68-a904-3cf7f577ad56" id="f098a296-1633-4e68-a904-3cf7f577ad56" name="spec2-vapp-win" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
             </CatalogItems>
             <IsPublished>false</IsPublished>
-            <DateCreated>2016-08-11T15:14:05.377+03:00</DateCreated>
+            <DateCreated>2018-02-19T14:05:38.657+01:00</DateCreated>
         </Catalog>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:54:10 GMT
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:32 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/77519250-ce5a-45d5-939d-fbe79704e18d
+    uri: https://VMWARE_CLOUD_HOST/api/catalog/8fac6233-474c-44b4-a45b-87e488102170
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.42.0
+      - fog-core/1.45.0
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Date:
-      - Fri, 16 Sep 2016 08:54:14 GMT
+      - Wed, 14 Mar 2018 10:54:32 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 89494e8c-3023-41b7-831b-61f42610094e
+      - 59473160-b94d-4c4b-8856-e9b46ef9fa15
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
       Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '132'
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
       Content-Type:
-      - application/vnd.vmware.vcloud.catalogitem+xml;version=5.1
+      - application/vnd.vmware.vcloud.catalog+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '13'
       Vary:
       - Accept-Encoding, User-Agent
       Content-Length:
-      - '1427'
+      - '2228'
     body:
       encoding: ASCII-8BIT
       string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" size="0" name="vApp_cankamat_remote_1" id="urn:vcloud:catalogitem:77519250-ce5a-45d5-939d-fbe79704e18d" href="https://VMWARE_CLOUD_HOST/api/catalogItem/77519250-ce5a-45d5-939d-fbe79704e18d" type="application/vnd.vmware.vcloud.catalogItem+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d" type="application/vnd.vmware.vcloud.catalog+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalogItem/77519250-ce5a-45d5-939d-fbe79704e18d/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/catalogItem/77519250-ce5a-45d5-939d-fbe79704e18d" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/catalogItem/77519250-ce5a-45d5-939d-fbe79704e18d"/>
-            <Description/>
-            <Entity href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" name="vApp_cankamat_remote_1" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-            <DateCreated>2016-08-11T15:15:51.703+03:00</DateCreated>
-        </CatalogItem>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:54:15 GMT
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <Catalog xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" name="My First Catalog" id="urn:vcloud:catalog:8fac6233-474c-44b4-a45b-87e488102170" href="https://VMWARE_CLOUD_HOST/api/catalog/8fac6233-474c-44b4-a45b-87e488102170" type="application/vnd.vmware.vcloud.catalog+xml">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/org/6d6733f6-536a-454f-bbc3-efee7f6de081" type="application/vnd.vmware.vcloud.org+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/8fac6233-474c-44b4-a45b-87e488102170/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/catalog/8fac6233-474c-44b4-a45b-87e488102170/catalogItems" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/8fac6233-474c-44b4-a45b-87e488102170/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="controlAccess" href="https://VMWARE_CLOUD_HOST/api/catalog/8fac6233-474c-44b4-a45b-87e488102170/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Description></Description>
+            <CatalogItems>
+                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/f098a296-1633-4e68-a904-3cf7f577ad56" id="f098a296-1633-4e68-a904-3cf7f577ad56" name="spec2-vapp-win" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            </CatalogItems>
+            <IsPublished>false</IsPublished>
+            <DateCreated>2018-02-19T14:05:38.657+01:00</DateCreated>
+        </Catalog>
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:32 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31
+    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/f098a296-1633-4e68-a904-3cf7f577ad56
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.42.0
+      - fog-core/1.45.0
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Date:
-      - Fri, 16 Sep 2016 08:54:21 GMT
+      - Wed, 14 Mar 2018 10:54:33 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 0634bbd5-2b90-4dd5-ac1d-18e4833a9ea9
+      - 60c4c121-dbd6-41f4-9721-abd4c0b77b13
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
       Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
+      Content-Type:
+      - application/vnd.vmware.vcloud.catalogitem+xml;version=5.1
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '1516'
+      - '175'
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1900'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" size="0" name="spec2-vapp-win" id="urn:vcloud:catalogitem:f098a296-1633-4e68-a904-3cf7f577ad56" href="https://VMWARE_CLOUD_HOST/api/catalogItem/f098a296-1633-4e68-a904-3cf7f577ad56" type="application/vnd.vmware.vcloud.catalogItem+xml">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/catalog/8fac6233-474c-44b4-a45b-87e488102170" type="application/vnd.vmware.vcloud.catalog+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalogItem/f098a296-1633-4e68-a904-3cf7f577ad56/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/catalogItem/f098a296-1633-4e68-a904-3cf7f577ad56" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/catalogItem/f098a296-1633-4e68-a904-3cf7f577ad56"/>
+            <Description></Description>
+            <Entity href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910" name="spec2-vapp-win" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <DateCreated>2018-03-09T16:18:29.989+01:00</DateCreated>
+        </CatalogItem>
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:33 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - ee9f52dbb4d245048614dba57e182fd3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 Mar 2018 10:54:33 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 34071dc6-4589-4281-9fa9-f726de18aebf
+      X-Vcloud-Authorization:
+      - ee9f52dbb4d245048614dba57e182fd3
+      Set-Cookie:
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
       Content-Type:
       - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '146'
       Vary:
       - Accept-Encoding, User-Agent
     body:
       encoding: ASCII-8BIT
       string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="vApp_cankamat_remote_1" id="urn:vcloud:vapptemplate:5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/77519250-ce5a-45d5-939d-fbe79704e18d" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31"/>
-            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/action/enableDownload"/>
-            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/action/disableDownload"/>
-            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/ovf" type="text/xml"/>
-            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Description/>
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="spec2-vapp-win" id="urn:vcloud:vapptemplate:7d70b225-56a6-4868-8eba-f64a3509c910" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910" type="application/vnd.vmware.vcloud.vAppTemplate+xml">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/f098a296-1633-4e68-a904-3cf7f577ad56" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/action/enableDownload"/>
+            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/action/disableDownload"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/ovf" type="text/xml"/>
+            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/b652f213-33aa-4c1f-8f30-ea2919a30843" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Description></Description>
             <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/ab07ee17-4acb-4d7c-b15f-ccdc4aefd77d" name="cankamat_remote" type="application/vnd.vmware.admin.user+xml"/>
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/a4a18dd6-d9aa-4d4e-a024-653b924e7091" name="administrator" type="application/vnd.vmware.admin.user+xml"/>
             </Owner>
             <Children>
-                <Vm goldMaster="false" status="8" name="CentOS7" id="urn:vcloud:vm:3c6fd87c-d8f1-4add-827f-c35982f3e5b1" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Description/>
-                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                <Vm goldMaster="false" status="8" name="spec2-vm1" id="urn:vcloud:vm:ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/b652f213-33aa-4c1f-8f30-ea2919a30843" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description></Description>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
                         <ovf:Info>Specifies the available VM network connections</ovf:Info>
                         <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="INT_192.168.10.0m24">
+                        <NetworkConnection needsCustomization="true" network="spec2-network">
                             <NetworkConnectionIndex>0</NetworkConnectionIndex>
                             <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:2d</MACAddress>
+                            <MACAddress>00:50:56:01:00:d9</MACAddress>
                             <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
                         </NetworkConnection>
                     </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
                         <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
                         <Enabled>false</Enabled>
                         <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>3c6fd87c-d8f1-4add-827f-c35982f3e5b1</VirtualMachineId>
+                        <VirtualMachineId>ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6</VirtualMachineId>
                         <JoinDomainEnabled>false</JoinDomainEnabled>
                         <UseOrgSettings>false</UseOrgSettings>
                         <AdminPasswordEnabled>true</AdminPasswordEnabled>
                         <AdminPasswordAuto>true</AdminPasswordAuto>
                         <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>CentOS7-0</ComputerName>
+                        <ComputerName>spec2-vm1</ComputerName>
                     </GuestCustomizationSection>
-                    <VAppScopedLocalId>7ff5cc28-e2e0-4466-bf78-e39a3522d539</VAppScopedLocalId>
-                    <DateCreated>2016-08-11T15:15:51.933+03:00</DateCreated>
+                    <VAppScopedLocalId>0166f57b-6ae3-47fe-a68b-4f7bebb61074</VAppScopedLocalId>
+                    <DateCreated>2018-03-09T16:18:30.150+01:00</DateCreated>
                 </Vm>
             </Children>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
+            <ovf:NetworkSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.networkSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/networkSection/">
                 <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="INT_192.168.10.0m24">
-                    <ovf:Description/>
+                <ovf:Network ovf:name="spec2-network">
+                    <ovf:Description></ovf:Description>
                 </ovf:Network>
             </ovf:NetworkSection>
-            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
                 <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <NetworkConfig networkName="INT_192.168.10.0m24">
-                    <Description/>
+                <NetworkConfig networkName="spec2-network">
+                    <Description></Description>
                     <Configuration>
                         <IpScopes>
                             <IpScope>
-                                <IsInherited>true</IsInherited>
-                                <Gateway>192.168.10.1</Gateway>
+                                <IsInherited>false</IsInherited>
+                                <Gateway>192.168.2.1</Gateway>
                                 <Netmask>255.255.255.0</Netmask>
-                                <Dns1>192.168.10.1</Dns1>
-                                <DnsSuffix>test.local</DnsSuffix>
                                 <IsEnabled>true</IsEnabled>
                                 <IpRanges>
                                     <IpRange>
-                                        <StartAddress>192.168.10.100</StartAddress>
-                                        <EndAddress>192.168.10.199</EndAddress>
+        <StartAddress>192.168.2.100</StartAddress>
+        <EndAddress>192.168.2.199</EndAddress>
                                     </IpRange>
                                 </IpRanges>
                             </IpScope>
                         </IpScopes>
-                        <ParentNetwork href="" name="INT_192.168.10.0m24"/>
-                        <FenceMode>bridged</FenceMode>
+                        <FenceMode>isolated</FenceMode>
                         <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
                     </Configuration>
                     <IsDeployed>false</IsDeployed>
                 </NetworkConfig>
             </NetworkConfigSection>
-            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
                 <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
                 <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
-                <StorageLeaseExpiration>2016-12-15T10:46:33.057+02:00</StorageLeaseExpiration>
+                <StorageLeaseExpiration>2018-06-07T17:18:30.150+02:00</StorageLeaseExpiration>
             </LeaseSettingsSection>
-            <CustomizationSection goldMaster="false" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
+            <CustomizationSection goldMaster="false" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
                 <ovf:Info>VApp template customization section</ovf:Info>
                 <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
             </CustomizationSection>
-            <DateCreated>2016-08-11T15:15:51.933+03:00</DateCreated>
+            <DateCreated>2018-03-09T16:18:30.150+01:00</DateCreated>
         </VAppTemplate>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:54:22 GMT
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:33 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.42.0
+      - fog-core/1.45.0
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Date:
-      - Fri, 16 Sep 2016 08:54:27 GMT
+      - Wed, 14 Mar 2018 10:54:33 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 7d2aaaf8-2ad6-4ed7-845c-4035d1b191bf
+      - beed756d-32c4-41ab-8e67-55cd0698a72f
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
       Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '215'
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
       Content-Type:
       - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '121'
       Vary:
       - Accept-Encoding, User-Agent
     body:
       encoding: ASCII-8BIT
       string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="vApp_cankamat_remote_1" id="urn:vcloud:vapptemplate:5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/77519250-ce5a-45d5-939d-fbe79704e18d" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31"/>
-            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/action/enableDownload"/>
-            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/action/disableDownload"/>
-            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/ovf" type="text/xml"/>
-            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Description/>
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="spec2-vapp-win" id="urn:vcloud:vapptemplate:7d70b225-56a6-4868-8eba-f64a3509c910" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910" type="application/vnd.vmware.vcloud.vAppTemplate+xml">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/f098a296-1633-4e68-a904-3cf7f577ad56" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/action/enableDownload"/>
+            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/action/disableDownload"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/ovf" type="text/xml"/>
+            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/b652f213-33aa-4c1f-8f30-ea2919a30843" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Description></Description>
             <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/ab07ee17-4acb-4d7c-b15f-ccdc4aefd77d" name="cankamat_remote" type="application/vnd.vmware.admin.user+xml"/>
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/a4a18dd6-d9aa-4d4e-a024-653b924e7091" name="administrator" type="application/vnd.vmware.admin.user+xml"/>
             </Owner>
             <Children>
-                <Vm goldMaster="false" status="8" name="CentOS7" id="urn:vcloud:vm:3c6fd87c-d8f1-4add-827f-c35982f3e5b1" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Description/>
-                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                <Vm goldMaster="false" status="8" name="spec2-vm1" id="urn:vcloud:vm:ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/b652f213-33aa-4c1f-8f30-ea2919a30843" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description></Description>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
                         <ovf:Info>Specifies the available VM network connections</ovf:Info>
                         <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="INT_192.168.10.0m24">
+                        <NetworkConnection needsCustomization="true" network="spec2-network">
                             <NetworkConnectionIndex>0</NetworkConnectionIndex>
                             <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:2d</MACAddress>
+                            <MACAddress>00:50:56:01:00:d9</MACAddress>
                             <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
                         </NetworkConnection>
                     </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
                         <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
                         <Enabled>false</Enabled>
                         <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>3c6fd87c-d8f1-4add-827f-c35982f3e5b1</VirtualMachineId>
+                        <VirtualMachineId>ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6</VirtualMachineId>
                         <JoinDomainEnabled>false</JoinDomainEnabled>
                         <UseOrgSettings>false</UseOrgSettings>
                         <AdminPasswordEnabled>true</AdminPasswordEnabled>
                         <AdminPasswordAuto>true</AdminPasswordAuto>
                         <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>CentOS7-0</ComputerName>
+                        <ComputerName>spec2-vm1</ComputerName>
                     </GuestCustomizationSection>
-                    <VAppScopedLocalId>7ff5cc28-e2e0-4466-bf78-e39a3522d539</VAppScopedLocalId>
-                    <DateCreated>2016-08-11T15:15:51.933+03:00</DateCreated>
+                    <VAppScopedLocalId>0166f57b-6ae3-47fe-a68b-4f7bebb61074</VAppScopedLocalId>
+                    <DateCreated>2018-03-09T16:18:30.150+01:00</DateCreated>
                 </Vm>
             </Children>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
+            <ovf:NetworkSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.networkSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/networkSection/">
                 <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="INT_192.168.10.0m24">
-                    <ovf:Description/>
+                <ovf:Network ovf:name="spec2-network">
+                    <ovf:Description></ovf:Description>
                 </ovf:Network>
             </ovf:NetworkSection>
-            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
                 <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <NetworkConfig networkName="INT_192.168.10.0m24">
-                    <Description/>
+                <NetworkConfig networkName="spec2-network">
+                    <Description></Description>
                     <Configuration>
                         <IpScopes>
                             <IpScope>
-                                <IsInherited>true</IsInherited>
-                                <Gateway>192.168.10.1</Gateway>
+                                <IsInherited>false</IsInherited>
+                                <Gateway>192.168.2.1</Gateway>
                                 <Netmask>255.255.255.0</Netmask>
-                                <Dns1>192.168.10.1</Dns1>
-                                <DnsSuffix>test.local</DnsSuffix>
                                 <IsEnabled>true</IsEnabled>
                                 <IpRanges>
                                     <IpRange>
-                                        <StartAddress>192.168.10.100</StartAddress>
-                                        <EndAddress>192.168.10.199</EndAddress>
+        <StartAddress>192.168.2.100</StartAddress>
+        <EndAddress>192.168.2.199</EndAddress>
                                     </IpRange>
                                 </IpRanges>
                             </IpScope>
                         </IpScopes>
-                        <ParentNetwork href="" name="INT_192.168.10.0m24"/>
-                        <FenceMode>bridged</FenceMode>
+                        <FenceMode>isolated</FenceMode>
                         <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
                     </Configuration>
                     <IsDeployed>false</IsDeployed>
                 </NetworkConfig>
             </NetworkConfigSection>
-            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
                 <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
                 <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
-                <StorageLeaseExpiration>2016-12-15T10:46:33.057+02:00</StorageLeaseExpiration>
+                <StorageLeaseExpiration>2018-06-07T17:18:30.150+02:00</StorageLeaseExpiration>
             </LeaseSettingsSection>
-            <CustomizationSection goldMaster="false" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
+            <CustomizationSection goldMaster="false" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
                 <ovf:Info>VApp template customization section</ovf:Info>
                 <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
             </CustomizationSection>
-            <DateCreated>2016-08-11T15:15:51.933+03:00</DateCreated>
+            <DateCreated>2018-03-09T16:18:30.150+01:00</DateCreated>
         </VAppTemplate>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:54:28 GMT
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:33 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/ovf
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.42.0
+      - fog-core/1.45.0
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Date:
-      - Fri, 16 Sep 2016 08:54:32 GMT
+      - Wed, 14 Mar 2018 10:54:33 GMT
       X-Vmware-Vcloud-Request-Id:
-      - a9977575-f0a7-4f85-8259-339636807f73
+      - 8abb276c-daf8-430d-8004-1ff58f178337
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
       Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '228'
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
       Content-Type:
-      - application/vnd.vmware.vcloud.catalogitem+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '1425'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" size="0" name="vApp_CentOS_and_msWin" id="urn:vcloud:catalogitem:8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d" href="https://VMWARE_CLOUD_HOST/api/catalogItem/8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d" type="application/vnd.vmware.vcloud.catalogItem+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d" type="application/vnd.vmware.vcloud.catalog+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalogItem/8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/catalogItem/8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/catalogItem/8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d"/>
-            <Description/>
-            <Entity href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" name="vApp_CentOS_and_msWin" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-            <DateCreated>2016-09-09T10:08:37.550+03:00</DateCreated>
-        </CatalogItem>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:54:33 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
       - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:54:38 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 49c3fdb5-0920-4ad3-9896-2c87fb8167e4
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '317'
-      Content-Type:
-      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
+      - '237'
       Vary:
       - Accept-Encoding, User-Agent
     body:
       encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
-        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="vApp_CentOS_and_msWin" id="urn:vcloud:vapptemplate:a19bdc8f-88fa-4dd6-8436-486590353ed5" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5"/>
-            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/action/enableDownload"/>
-            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/action/disableDownload"/>
-            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/ovf" type="text/xml"/>
-            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Description/>
-            <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/ab07ee17-4acb-4d7c-b15f-ccdc4aefd77d" name="cankamat_remote" type="application/vnd.vmware.admin.user+xml"/>
-            </Owner>
-            <Children>
-                <Vm goldMaster="false" status="8" name="CentOS7" id="urn:vcloud:vm:e9b55b85-640b-462c-9e7a-d18c47a7a5f3" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Description/>
-                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="none">
-                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IsConnected>false</IsConnected>
-                            <MACAddress>00:50:56:01:00:4d</MACAddress>
-                            <IpAddressAllocationMode>NONE</IpAddressAllocationMode>
-                        </NetworkConnection>
-                    </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <Enabled>false</Enabled>
-                        <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>e9b55b85-640b-462c-9e7a-d18c47a7a5f3</VirtualMachineId>
-                        <JoinDomainEnabled>false</JoinDomainEnabled>
-                        <UseOrgSettings>false</UseOrgSettings>
-                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
-                        <AdminPasswordAuto>true</AdminPasswordAuto>
-                        <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>CentOS7-0-0</ComputerName>
-                    </GuestCustomizationSection>
-                    <VAppScopedLocalId>926f501b-c7ea-4b9d-a155-6695c3345150</VAppScopedLocalId>
-                    <DateCreated>2016-09-09T10:08:38.767+03:00</DateCreated>
-                </Vm>
-                <Vm goldMaster="false" status="8" name="Tieto Windows Server 2012 R2" id="urn:vcloud:vm:04f85cca-3f8d-43b4-8473-7aa099f95c1b" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Description/>
-                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="none">
-                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IsConnected>false</IsConnected>
-                            <MACAddress>00:50:56:01:00:4c</MACAddress>
-                            <IpAddressAllocationMode>NONE</IpAddressAllocationMode>
-                        </NetworkConnection>
-                    </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <Enabled>true</Enabled>
-                        <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>04f85cca-3f8d-43b4-8473-7aa099f95c1b</VirtualMachineId>
-                        <JoinDomainEnabled>false</JoinDomainEnabled>
-                        <UseOrgSettings>false</UseOrgSettings>
-                        <AdminPasswordEnabled>false</AdminPasswordEnabled>
-                        <AdminPasswordAuto>true</AdminPasswordAuto>
-                        <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>TietoWindow-0</ComputerName>
-                    </GuestCustomizationSection>
-                    <VAppScopedLocalId>2e9ee64a-2368-40fc-94ee-0473373f0f4c</VAppScopedLocalId>
-                    <DateCreated>2016-09-09T10:08:38.767+03:00</DateCreated>
-                </Vm>
-            </Children>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
-                <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="none">
-                    <ovf:Description>This is a special place-holder used for disconnected network interfaces.</ovf:Description>
-                </ovf:Network>
-            </ovf:NetworkSection>
-            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
-                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <NetworkConfig networkName="none">
-                    <Description>This is a special place-holder used for disconnected network interfaces.</Description>
-                    <Configuration>
-                        <IpScopes>
-                            <IpScope>
-                                <IsInherited>false</IsInherited>
-                                <Gateway>196.254.254.254</Gateway>
-                                <Netmask>255.255.0.0</Netmask>
-                                <Dns1>196.254.254.254</Dns1>
-                            </IpScope>
-                        </IpScopes>
-                        <FenceMode>isolated</FenceMode>
-                    </Configuration>
-                    <IsDeployed>false</IsDeployed>
-                </NetworkConfig>
-            </NetworkConfigSection>
-            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
-                <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
-                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
-                <StorageLeaseExpiration>2016-12-11T14:22:25.960+02:00</StorageLeaseExpiration>
-            </LeaseSettingsSection>
-            <CustomizationSection goldMaster="false" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
-                <ovf:Info>VApp template customization section</ovf:Info>
-                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
-            </CustomizationSection>
-            <DateCreated>2016-09-09T10:08:38.767+03:00</DateCreated>
-        </VAppTemplate>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:54:39 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:54:44 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 7abe8560-d20c-46e0-818d-dd8fba08989b
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '308'
-      Content-Type:
-      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="vApp_CentOS_and_msWin" id="urn:vcloud:vapptemplate:a19bdc8f-88fa-4dd6-8436-486590353ed5" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5"/>
-            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/action/enableDownload"/>
-            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/action/disableDownload"/>
-            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/ovf" type="text/xml"/>
-            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Description/>
-            <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/ab07ee17-4acb-4d7c-b15f-ccdc4aefd77d" name="cankamat_remote" type="application/vnd.vmware.admin.user+xml"/>
-            </Owner>
-            <Children>
-                <Vm goldMaster="false" status="8" name="CentOS7" id="urn:vcloud:vm:e9b55b85-640b-462c-9e7a-d18c47a7a5f3" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Description/>
-                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="none">
-                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IsConnected>false</IsConnected>
-                            <MACAddress>00:50:56:01:00:4d</MACAddress>
-                            <IpAddressAllocationMode>NONE</IpAddressAllocationMode>
-                        </NetworkConnection>
-                    </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <Enabled>false</Enabled>
-                        <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>e9b55b85-640b-462c-9e7a-d18c47a7a5f3</VirtualMachineId>
-                        <JoinDomainEnabled>false</JoinDomainEnabled>
-                        <UseOrgSettings>false</UseOrgSettings>
-                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
-                        <AdminPasswordAuto>true</AdminPasswordAuto>
-                        <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>CentOS7-0-0</ComputerName>
-                    </GuestCustomizationSection>
-                    <VAppScopedLocalId>926f501b-c7ea-4b9d-a155-6695c3345150</VAppScopedLocalId>
-                    <DateCreated>2016-09-09T10:08:38.767+03:00</DateCreated>
-                </Vm>
-                <Vm goldMaster="false" status="8" name="Tieto Windows Server 2012 R2" id="urn:vcloud:vm:04f85cca-3f8d-43b4-8473-7aa099f95c1b" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Description/>
-                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="none">
-                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IsConnected>false</IsConnected>
-                            <MACAddress>00:50:56:01:00:4c</MACAddress>
-                            <IpAddressAllocationMode>NONE</IpAddressAllocationMode>
-                        </NetworkConnection>
-                    </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <Enabled>true</Enabled>
-                        <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>04f85cca-3f8d-43b4-8473-7aa099f95c1b</VirtualMachineId>
-                        <JoinDomainEnabled>false</JoinDomainEnabled>
-                        <UseOrgSettings>false</UseOrgSettings>
-                        <AdminPasswordEnabled>false</AdminPasswordEnabled>
-                        <AdminPasswordAuto>true</AdminPasswordAuto>
-                        <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>TietoWindow-0</ComputerName>
-                    </GuestCustomizationSection>
-                    <VAppScopedLocalId>2e9ee64a-2368-40fc-94ee-0473373f0f4c</VAppScopedLocalId>
-                    <DateCreated>2016-09-09T10:08:38.767+03:00</DateCreated>
-                </Vm>
-            </Children>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
-                <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="none">
-                    <ovf:Description>This is a special place-holder used for disconnected network interfaces.</ovf:Description>
-                </ovf:Network>
-            </ovf:NetworkSection>
-            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
-                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <NetworkConfig networkName="none">
-                    <Description>This is a special place-holder used for disconnected network interfaces.</Description>
-                    <Configuration>
-                        <IpScopes>
-                            <IpScope>
-                                <IsInherited>false</IsInherited>
-                                <Gateway>196.254.254.254</Gateway>
-                                <Netmask>255.255.0.0</Netmask>
-                                <Dns1>196.254.254.254</Dns1>
-                            </IpScope>
-                        </IpScopes>
-                        <FenceMode>isolated</FenceMode>
-                    </Configuration>
-                    <IsDeployed>false</IsDeployed>
-                </NetworkConfig>
-            </NetworkConfigSection>
-            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
-                <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
-                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
-                <StorageLeaseExpiration>2016-12-11T14:22:25.960+02:00</StorageLeaseExpiration>
-            </LeaseSettingsSection>
-            <CustomizationSection goldMaster="false" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
-                <ovf:Info>VApp template customization section</ovf:Info>
-                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
-            </CustomizationSection>
-            <DateCreated>2016-09-09T10:08:38.767+03:00</DateCreated>
-        </VAppTemplate>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:54:45 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/fd9c3a97-14bd-499b-bd52-054a1602ae89
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:54:49 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 53e3db9b-cbd0-4660-a5b6-cbb11125e2b8
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '55'
-      Content-Type:
-      - application/vnd.vmware.vcloud.catalogitem+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '1380'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" size="634388480" name="CentOS 7" id="urn:vcloud:catalogitem:fd9c3a97-14bd-499b-bd52-054a1602ae89" href="https://VMWARE_CLOUD_HOST/api/catalogItem/fd9c3a97-14bd-499b-bd52-054a1602ae89" type="application/vnd.vmware.vcloud.catalogItem+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d" type="application/vnd.vmware.vcloud.catalog+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalogItem/fd9c3a97-14bd-499b-bd52-054a1602ae89/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/catalogItem/fd9c3a97-14bd-499b-bd52-054a1602ae89" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/catalogItem/fd9c3a97-14bd-499b-bd52-054a1602ae89"/>
-            <Description/>
-            <Entity href="https://VMWARE_CLOUD_HOST/api/media/48ce1b6a-2c31-485d-a6ce-8f914c044459" name="CentOS 7" type="application/vnd.vmware.vcloud.media+xml"/>
-            <DateCreated>2016-08-11T15:56:57.053+03:00</DateCreated>
-        </CatalogItem>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:54:50 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/ovf
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:54:55 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - e11ebd6b-8b8e-48b4-b9aa-4985519e11f1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '519'
-      Content-Type:
-      - application/*+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <ovf:Envelope xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
+        <ovf:Envelope xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd">
             <ovf:References/>
             <ovf:NetworkSection>
                 <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="internal">
+                <ovf:Network ovf:name="spec2-network">
                     <ovf:Description/>
                 </ovf:Network>
             </ovf:NetworkSection>
-            <vcloud:CustomizationSection goldMaster="true" ovf:required="false">
+            <vcloud:CustomizationSection goldMaster="false" ovf:required="false">
                 <ovf:Info>VApp template customization section</ovf:Info>
                 <vcloud:CustomizeOnInstantiate>true</vcloud:CustomizeOnInstantiate>
             </vcloud:CustomizationSection>
             <vcloud:NetworkConfigSection ovf:required="false">
                 <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <vcloud:NetworkConfig networkName="internal">
+                <vcloud:NetworkConfig networkName="spec2-network">
                     <vcloud:Description/>
                     <vcloud:Configuration>
                         <vcloud:IpScopes>
@@ -4021,36 +4049,36 @@ http_interactions:
             <vcloud:LeaseSettingsSection ovf:required="false">
                 <ovf:Info>Lease settings section</ovf:Info>
                 <vcloud:StorageLeaseInSeconds>7776000</vcloud:StorageLeaseInSeconds>
-                <vcloud:StorageLeaseExpiration>2016-12-11T10:12:59.137+02:00</vcloud:StorageLeaseExpiration>
+                <vcloud:StorageLeaseExpiration>2018-06-07T17:18:30.150+02:00</vcloud:StorageLeaseExpiration>
             </vcloud:LeaseSettingsSection>
-            <ovf:VirtualSystemCollection ovf:id="Tieto Linux CentOS 7.0">
+            <ovf:VirtualSystemCollection ovf:id="spec2-vapp-win">
                 <ovf:Info>A collection of virtual machines</ovf:Info>
-                <ovf:Name>Tieto Linux CentOS 7.0</ovf:Name>
+                <ovf:Name>spec2-vapp-win</ovf:Name>
                 <ovf:StartupSection>
                     <ovf:Info>VApp startup section</ovf:Info>
-                    <ovf:Item ovf:id="CentOS7" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
+                    <ovf:Item ovf:id="spec2-vm1" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
                 </ovf:StartupSection>
-                <ovf:VirtualSystem ovf:id="CentOS7">
+                <ovf:VirtualSystem ovf:id="spec2-vm1">
                     <ovf:Info>A virtual machine</ovf:Info>
-                    <ovf:Name>CentOS7</ovf:Name>
-                    <ovf:OperatingSystemSection ovf:id="101" vmw:osType="centos64Guest">
+                    <ovf:Name>spec2-vm1</ovf:Name>
+                    <ovf:OperatingSystemSection ovf:id="36" vmw:osType="vmwarePhoton64Guest">
                         <ovf:Info>Specifies the operating system installed</ovf:Info>
-                        <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>
+                        <ovf:Description>VMware Photon OS (64-bit)</ovf:Description>
                     </ovf:OperatingSystemSection>
                     <ovf:VirtualHardwareSection ovf:transport="">
                         <ovf:Info>Virtual hardware requirements</ovf:Info>
                         <ovf:System>
                             <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
                             <vssd:InstanceID>0</vssd:InstanceID>
-                            <vssd:VirtualSystemIdentifier>CentOS7</vssd:VirtualSystemIdentifier>
-                            <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
+                            <vssd:VirtualSystemIdentifier>spec2-vm1</vssd:VirtualSystemIdentifier>
+                            <vssd:VirtualSystemType>vmx-13</vssd:VirtualSystemType>
                         </ovf:System>
                         <ovf:Item>
-                            <rasd:Address>00:50:56:01:00:2b</rasd:Address>
+                            <rasd:Address>00:50:56:01:00:d9</rasd:Address>
                             <rasd:AddressOnParent>0</rasd:AddressOnParent>
                             <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
-                            <rasd:Connection vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="POOL">internal</rasd:Connection>
-                            <rasd:Description>Vmxnet3 ethernet adapter on "internal"</rasd:Description>
+                            <rasd:Connection vcloud:ipAddressingMode="POOL" vcloud:primaryNetworkConnection="true">spec2-network</rasd:Connection>
+                            <rasd:Description>Vmxnet3 ethernet adapter on "spec2-network"</rasd:Description>
                             <rasd:ElementName>Network adapter 0</rasd:ElementName>
                             <rasd:InstanceID>1</rasd:InstanceID>
                             <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
@@ -4062,14 +4090,14 @@ http_interactions:
                             <rasd:Description>SCSI Controller</rasd:Description>
                             <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
                             <rasd:InstanceID>2</rasd:InstanceID>
-                            <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
+                            <rasd:ResourceSubType>VirtualSCSI</rasd:ResourceSubType>
                             <rasd:ResourceType>6</rasd:ResourceType>
                         </ovf:Item>
                         <ovf:Item>
                             <rasd:AddressOnParent>0</rasd:AddressOnParent>
                             <rasd:Description>Hard disk</rasd:Description>
                             <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                            <rasd:HostResource vcloud:capacity="16384" vcloud:busSubType="lsilogic" vcloud:busType="6"/>
+                            <rasd:HostResource vcloud:busType="6" vcloud:busSubType="VirtualSCSI" vcloud:capacity="16384"/>
                             <rasd:InstanceID>2000</rasd:InstanceID>
                             <rasd:Parent>2</rasd:Parent>
                             <rasd:ResourceType>17</rasd:ResourceType>
@@ -4096,21 +4124,21 @@ http_interactions:
                         <ovf:Item>
                             <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
                             <rasd:Description>Number of Virtual CPUs</rasd:Description>
-                            <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
+                            <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
                             <rasd:InstanceID>4</rasd:InstanceID>
                             <rasd:Reservation>0</rasd:Reservation>
                             <rasd:ResourceType>3</rasd:ResourceType>
-                            <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
                             <rasd:Weight>0</rasd:Weight>
                         </ovf:Item>
                         <ovf:Item>
                             <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
                             <rasd:Description>Memory Size</rasd:Description>
-                            <rasd:ElementName>2048 MB of memory</rasd:ElementName>
+                            <rasd:ElementName>256 MB of memory</rasd:ElementName>
                             <rasd:InstanceID>5</rasd:InstanceID>
                             <rasd:Reservation>0</rasd:Reservation>
                             <rasd:ResourceType>4</rasd:ResourceType>
-                            <rasd:VirtualQuantity>2048</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>256</rasd:VirtualQuantity>
                             <rasd:Weight>0</rasd:Weight>
                         </ovf:Item>
                         <ovf:Item>
@@ -4122,6 +4150,7 @@ http_interactions:
                             <rasd:InstanceID>3000</rasd:InstanceID>
                             <rasd:Parent>3</rasd:Parent>
                             <rasd:ResourceType>15</rasd:ResourceType>
+                            <vmw:Config ovf:required="false" vmw:key="backing.exclusive" vmw:value="false"/>
                         </ovf:Item>
                         <vmw:Config ovf:required="false" vmw:key="cpuHotAddEnabled" vmw:value="false"/>
                         <vmw:Config ovf:required="false" vmw:key="cpuHotRemoveEnabled" vmw:value="false"/>
@@ -4140,931 +4169,130 @@ http_interactions:
                         <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestStandby" vmw:value="true"/>
                         <vmw:Config ovf:required="false" vmw:key="tools.syncTimeWithHost" vmw:value="false"/>
                         <vmw:Config ovf:required="false" vmw:key="tools.toolsUpgradePolicy" vmw:value="manual"/>
-                        <vmw:Config ovf:required="false" vmw:key="uuid" vmw:value="4204522e-c748-6c34-d2b3-35d6020f5d9a"/>
+                        <vmw:Config ovf:required="false" vmw:key="uuid" vmw:value="42202fd3-b53c-09e3-983f-1a77d9681fa3"/>
                     </ovf:VirtualHardwareSection>
                     <vcloud:GuestCustomizationSection ovf:required="false">
                         <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
                         <vcloud:Enabled>false</vcloud:Enabled>
                         <vcloud:ChangeSid>false</vcloud:ChangeSid>
-                        <vcloud:VirtualMachineId>857551b6-380c-44d0-ab34-9d144866f0b4</vcloud:VirtualMachineId>
+                        <vcloud:VirtualMachineId>ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6</vcloud:VirtualMachineId>
                         <vcloud:JoinDomainEnabled>false</vcloud:JoinDomainEnabled>
                         <vcloud:UseOrgSettings>false</vcloud:UseOrgSettings>
                         <vcloud:AdminPasswordEnabled>true</vcloud:AdminPasswordEnabled>
                         <vcloud:AdminPasswordAuto>true</vcloud:AdminPasswordAuto>
                         <vcloud:ResetPasswordRequired>false</vcloud:ResetPasswordRequired>
-                        <vcloud:ComputerName>CentOS7</vcloud:ComputerName>
+                        <vcloud:ComputerName>spec2-vm1</vcloud:ComputerName>
                     </vcloud:GuestCustomizationSection>
                     <vcloud:NetworkConnectionSection ovf:required="false">
                         <ovf:Info>Specifies the available VM network connections</ovf:Info>
                         <vcloud:PrimaryNetworkConnectionIndex>0</vcloud:PrimaryNetworkConnectionIndex>
-                        <vcloud:NetworkConnection needsCustomization="true" network="internal">
+                        <vcloud:NetworkConnection needsCustomization="true" network="spec2-network">
                             <vcloud:NetworkConnectionIndex>0</vcloud:NetworkConnectionIndex>
                             <vcloud:IsConnected>true</vcloud:IsConnected>
-                            <vcloud:MACAddress>00:50:56:01:00:2b</vcloud:MACAddress>
+                            <vcloud:MACAddress>00:50:56:01:00:d9</vcloud:MACAddress>
                             <vcloud:IpAddressAllocationMode>POOL</vcloud:IpAddressAllocationMode>
                         </vcloud:NetworkConnection>
                     </vcloud:NetworkConnectionSection>
                 </ovf:VirtualSystem>
             </ovf:VirtualSystemCollection>
         </ovf:Envelope>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:54:56 GMT
+    http_version:
+  recorded_at: Wed, 14 Mar 2018 10:54:33 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/ovf
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog-core/1.42.0
+      - fog-core/1.45.0
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Date:
-      - Fri, 16 Sep 2016 08:55:01 GMT
+      - Wed, 14 Mar 2018 10:54:33 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 42f16231-6625-4ec3-963b-a3858b88d570
+      - d115e6da-b8e7-4d0e-bf82-e8f117b4237e
       X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
+      - ee9f52dbb4d245048614dba57e182fd3
       Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '385'
-      Content-Type:
-      - application/*+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <ovf:Envelope xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
-            <ovf:References/>
-            <ovf:NetworkSection>
-                <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="none">
-                    <ovf:Description>This is a special place-holder used for disconnected network interfaces.</ovf:Description>
-                </ovf:Network>
-            </ovf:NetworkSection>
-            <vcloud:CustomizationSection goldMaster="true" ovf:required="false">
-                <ovf:Info>VApp template customization section</ovf:Info>
-                <vcloud:CustomizeOnInstantiate>true</vcloud:CustomizeOnInstantiate>
-            </vcloud:CustomizationSection>
-            <vcloud:NetworkConfigSection ovf:required="false">
-                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <vcloud:NetworkConfig networkName="none">
-                    <vcloud:Description>This is a special place-holder used for disconnected network interfaces.</vcloud:Description>
-                    <vcloud:Configuration>
-                        <vcloud:IpScopes>
-                            <vcloud:IpScope>
-                                <vcloud:IsInherited>false</vcloud:IsInherited>
-                                <vcloud:Gateway>196.254.254.254</vcloud:Gateway>
-                                <vcloud:Netmask>255.255.0.0</vcloud:Netmask>
-                                <vcloud:Dns1>196.254.254.254</vcloud:Dns1>
-                            </vcloud:IpScope>
-                        </vcloud:IpScopes>
-                        <vcloud:FenceMode>isolated</vcloud:FenceMode>
-                    </vcloud:Configuration>
-                    <vcloud:IsDeployed>false</vcloud:IsDeployed>
-                </vcloud:NetworkConfig>
-            </vcloud:NetworkConfigSection>
-            <vcloud:LeaseSettingsSection ovf:required="false">
-                <ovf:Info>Lease settings section</ovf:Info>
-                <vcloud:StorageLeaseInSeconds>7776000</vcloud:StorageLeaseInSeconds>
-                <vcloud:StorageLeaseExpiration>2016-12-08T09:07:24.827+02:00</vcloud:StorageLeaseExpiration>
-            </vcloud:LeaseSettingsSection>
-            <ovf:VirtualSystemCollection ovf:id="Tieto Windows Server 2012 R2">
-                <ovf:Info>A collection of virtual machines</ovf:Info>
-                <ovf:Name>Tieto Windows Server 2012 R2</ovf:Name>
-                <ovf:StartupSection>
-                    <ovf:Info>VApp startup section</ovf:Info>
-                    <ovf:Item ovf:id="Tieto Windows Server 2012 R2" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
-                </ovf:StartupSection>
-                <ovf:VirtualSystem ovf:id="Tieto Windows Server 2012 R2">
-                    <ovf:Info>A virtual machine</ovf:Info>
-                    <ovf:Name>Tieto Windows Server 2012 R2</ovf:Name>
-                    <ovf:OperatingSystemSection ovf:id="112" vmw:osType="windows8Server64Guest">
-                        <ovf:Info>Specifies the operating system installed</ovf:Info>
-                        <ovf:Description>Microsoft Windows Server 2012 (64-bit)</ovf:Description>
-                    </ovf:OperatingSystemSection>
-                    <ovf:VirtualHardwareSection ovf:transport="">
-                        <ovf:Info>Virtual hardware requirements</ovf:Info>
-                        <ovf:System>
-                            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
-                            <vssd:InstanceID>0</vssd:InstanceID>
-                            <vssd:VirtualSystemIdentifier>Tieto Windows Server 2012 R2</vssd:VirtualSystemIdentifier>
-                            <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
-                        </ovf:System>
-                        <ovf:Item>
-                            <rasd:Address>00:50:56:84:02:de</rasd:Address>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Connection vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="NONE">none</rasd:Connection>
-                            <rasd:Description>Vmxnet3 ethernet adapter on "none"</rasd:Description>
-                            <rasd:ElementName>Network adapter 0</rasd:ElementName>
-                            <rasd:InstanceID>1</rasd:InstanceID>
-                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
-                            <rasd:ResourceType>10</rasd:ResourceType>
-                            <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="true"/>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>SCSI Controller</rasd:Description>
-                            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>2</rasd:InstanceID>
-                            <rasd:ResourceSubType>lsilogicsas</rasd:ResourceSubType>
-                            <rasd:ResourceType>6</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:Description>Hard disk</rasd:Description>
-                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                            <rasd:HostResource vcloud:capacity="40960" vcloud:busSubType="lsilogicsas" vcloud:busType="6"/>
-                            <rasd:InstanceID>2000</rasd:InstanceID>
-                            <rasd:Parent>2</rasd:Parent>
-                            <rasd:ResourceType>17</rasd:ResourceType>
-                            <rasd:VirtualQuantity>42949672960</rasd:VirtualQuantity>
-                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
-                            <vmw:Config ovf:required="false" vmw:key="backing.writeThrough" vmw:value="false"/>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>SATA Controller</rasd:Description>
-                            <rasd:ElementName>SATA Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>3</rasd:InstanceID>
-                            <rasd:ResourceSubType>vmware.sata.ahci</rasd:ResourceSubType>
-                            <rasd:ResourceType>20</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>CD/DVD Drive</rasd:Description>
-                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>16000</rasd:InstanceID>
-                            <rasd:Parent>3</rasd:Parent>
-                            <rasd:ResourceType>15</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>Floppy Drive</rasd:Description>
-                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>8000</rasd:InstanceID>
-                            <rasd:ResourceType>14</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
-                            <rasd:Description>Number of Virtual CPUs</rasd:Description>
-                            <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
-                            <rasd:InstanceID>4</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>3</rasd:ResourceType>
-                            <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
-                            <rasd:Description>Memory Size</rasd:Description>
-                            <rasd:ElementName>4096 MB of memory</rasd:ElementName>
-                            <rasd:InstanceID>5</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>4</rasd:ResourceType>
-                            <rasd:VirtualQuantity>4096</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                        </ovf:Item>
-                        <vmw:Config ovf:required="false" vmw:key="cpuHotAddEnabled" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="cpuHotRemoveEnabled" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="bios"/>
-                        <vmw:Config ovf:required="false" vmw:key="virtualICH7MPresent" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="virtualSMCPresent" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="memoryHotAddEnabled" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="nestedHVEnabled" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.powerOffType" vmw:value="soft"/>
-                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.resetType" vmw:value="soft"/>
-                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.standbyAction" vmw:value="checkpoint"/>
-                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.suspendType" vmw:value="hard"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.afterPowerOn" vmw:value="true"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.afterResume" vmw:value="true"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestShutdown" vmw:value="true"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestStandby" vmw:value="true"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.syncTimeWithHost" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.toolsUpgradePolicy" vmw:value="manual"/>
-                        <vmw:Config ovf:required="false" vmw:key="uuid" vmw:value="4204a04c-cb69-b862-2a14-5d573643bf78"/>
-                    </ovf:VirtualHardwareSection>
-                    <vcloud:GuestCustomizationSection ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <vcloud:Enabled>true</vcloud:Enabled>
-                        <vcloud:ChangeSid>false</vcloud:ChangeSid>
-                        <vcloud:VirtualMachineId>ac5fcf96-2b9d-4e90-9a2f-7792160da1ae</vcloud:VirtualMachineId>
-                        <vcloud:JoinDomainEnabled>false</vcloud:JoinDomainEnabled>
-                        <vcloud:UseOrgSettings>false</vcloud:UseOrgSettings>
-                        <vcloud:AdminPasswordEnabled>false</vcloud:AdminPasswordEnabled>
-                        <vcloud:AdminPasswordAuto>true</vcloud:AdminPasswordAuto>
-                        <vcloud:ResetPasswordRequired>false</vcloud:ResetPasswordRequired>
-                        <vcloud:ComputerName>TietoWindow-001</vcloud:ComputerName>
-                    </vcloud:GuestCustomizationSection>
-                    <vcloud:NetworkConnectionSection ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <vcloud:PrimaryNetworkConnectionIndex>0</vcloud:PrimaryNetworkConnectionIndex>
-                        <vcloud:NetworkConnection needsCustomization="true" network="none">
-                            <vcloud:NetworkConnectionIndex>0</vcloud:NetworkConnectionIndex>
-                            <vcloud:IsConnected>false</vcloud:IsConnected>
-                            <vcloud:MACAddress>00:50:56:84:02:de</vcloud:MACAddress>
-                            <vcloud:IpAddressAllocationMode>NONE</vcloud:IpAddressAllocationMode>
-                        </vcloud:NetworkConnection>
-                    </vcloud:NetworkConnectionSection>
-                </ovf:VirtualSystem>
-            </ovf:VirtualSystemCollection>
-        </ovf:Envelope>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:55:02 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/ovf
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:55:07 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 408b91ef-c857-43dd-9dce-2dd720c26725
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '437'
-      Content-Type:
-      - application/*+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <ovf:Envelope xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
-            <ovf:References/>
-            <ovf:NetworkSection>
-                <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="INT_192.168.10.0m24">
-                    <ovf:Description/>
-                </ovf:Network>
-            </ovf:NetworkSection>
-            <vcloud:CustomizationSection goldMaster="false" ovf:required="false">
-                <ovf:Info>VApp template customization section</ovf:Info>
-                <vcloud:CustomizeOnInstantiate>true</vcloud:CustomizeOnInstantiate>
-            </vcloud:CustomizationSection>
-            <vcloud:NetworkConfigSection ovf:required="false">
-                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <vcloud:NetworkConfig networkName="INT_192.168.10.0m24">
-                    <vcloud:Description/>
-                    <vcloud:Configuration>
-                        <vcloud:IpScopes>
-                            <vcloud:IpScope>
-                                <vcloud:IsInherited>true</vcloud:IsInherited>
-                                <vcloud:Gateway>192.168.10.1</vcloud:Gateway>
-                                <vcloud:Netmask>255.255.255.0</vcloud:Netmask>
-                                <vcloud:Dns1>192.168.10.1</vcloud:Dns1>
-                                <vcloud:DnsSuffix>test.local</vcloud:DnsSuffix>
-                                <vcloud:IsEnabled>true</vcloud:IsEnabled>
-                                <vcloud:IpRanges>
-                                    <vcloud:IpRange>
-                                        <vcloud:StartAddress>192.168.10.100</vcloud:StartAddress>
-                                        <vcloud:EndAddress>192.168.10.199</vcloud:EndAddress>
-                                    </vcloud:IpRange>
-                                </vcloud:IpRanges>
-                            </vcloud:IpScope>
-                        </vcloud:IpScopes>
-                        <vcloud:ParentNetwork href="" name="INT_192.168.10.0m24"/>
-                        <vcloud:FenceMode>bridged</vcloud:FenceMode>
-                        <vcloud:RetainNetInfoAcrossDeployments>false</vcloud:RetainNetInfoAcrossDeployments>
-                    </vcloud:Configuration>
-                    <vcloud:IsDeployed>false</vcloud:IsDeployed>
-                </vcloud:NetworkConfig>
-            </vcloud:NetworkConfigSection>
-            <vcloud:LeaseSettingsSection ovf:required="false">
-                <ovf:Info>Lease settings section</ovf:Info>
-                <vcloud:StorageLeaseInSeconds>7776000</vcloud:StorageLeaseInSeconds>
-                <vcloud:StorageLeaseExpiration>2016-12-15T10:46:33.057+02:00</vcloud:StorageLeaseExpiration>
-            </vcloud:LeaseSettingsSection>
-            <ovf:VirtualSystemCollection ovf:id="vApp_cankamat_remote_1">
-                <ovf:Info>A collection of virtual machines</ovf:Info>
-                <ovf:Name>vApp_cankamat_remote_1</ovf:Name>
-                <ovf:StartupSection>
-                    <ovf:Info>VApp startup section</ovf:Info>
-                    <ovf:Item ovf:id="CentOS7" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
-                </ovf:StartupSection>
-                <ovf:VirtualSystem ovf:id="CentOS7">
-                    <ovf:Info>A virtual machine</ovf:Info>
-                    <ovf:Name>CentOS7</ovf:Name>
-                    <ovf:OperatingSystemSection ovf:id="101" vmw:osType="centos64Guest">
-                        <ovf:Info>Specifies the operating system installed</ovf:Info>
-                        <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>
-                    </ovf:OperatingSystemSection>
-                    <ovf:VirtualHardwareSection ovf:transport="">
-                        <ovf:Info>Virtual hardware requirements</ovf:Info>
-                        <ovf:System>
-                            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
-                            <vssd:InstanceID>0</vssd:InstanceID>
-                            <vssd:VirtualSystemIdentifier>CentOS7</vssd:VirtualSystemIdentifier>
-                            <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
-                        </ovf:System>
-                        <ovf:Item>
-                            <rasd:Address>00:50:56:01:00:2d</rasd:Address>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
-                            <rasd:Connection vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="POOL">INT_192.168.10.0m24</rasd:Connection>
-                            <rasd:Description>Vmxnet3 ethernet adapter on "INT_192.168.10.0m24"</rasd:Description>
-                            <rasd:ElementName>Network adapter 0</rasd:ElementName>
-                            <rasd:InstanceID>1</rasd:InstanceID>
-                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
-                            <rasd:ResourceType>10</rasd:ResourceType>
-                            <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="true"/>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>SCSI Controller</rasd:Description>
-                            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>2</rasd:InstanceID>
-                            <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
-                            <rasd:ResourceType>6</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:Description>Hard disk</rasd:Description>
-                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                            <rasd:HostResource vcloud:capacity="16384" vcloud:busSubType="lsilogic" vcloud:busType="6"/>
-                            <rasd:InstanceID>2000</rasd:InstanceID>
-                            <rasd:Parent>2</rasd:Parent>
-                            <rasd:ResourceType>17</rasd:ResourceType>
-                            <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
-                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
-                            <vmw:Config ovf:required="false" vmw:key="backing.writeThrough" vmw:value="false"/>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>IDE Controller</rasd:Description>
-                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>3</rasd:InstanceID>
-                            <rasd:ResourceType>5</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>Floppy Drive</rasd:Description>
-                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>8000</rasd:InstanceID>
-                            <rasd:ResourceType>14</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
-                            <rasd:Description>Number of Virtual CPUs</rasd:Description>
-                            <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
-                            <rasd:InstanceID>4</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>3</rasd:ResourceType>
-                            <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
-                            <rasd:Description>Memory Size</rasd:Description>
-                            <rasd:ElementName>2048 MB of memory</rasd:ElementName>
-                            <rasd:InstanceID>5</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>4</rasd:ResourceType>
-                            <rasd:VirtualQuantity>2048</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>CD/DVD Drive</rasd:Description>
-                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>3000</rasd:InstanceID>
-                            <rasd:Parent>3</rasd:Parent>
-                            <rasd:ResourceType>15</rasd:ResourceType>
-                        </ovf:Item>
-                        <vmw:Config ovf:required="false" vmw:key="cpuHotAddEnabled" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="cpuHotRemoveEnabled" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="bios"/>
-                        <vmw:Config ovf:required="false" vmw:key="virtualICH7MPresent" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="virtualSMCPresent" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="memoryHotAddEnabled" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="nestedHVEnabled" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.powerOffType" vmw:value="soft"/>
-                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.resetType" vmw:value="soft"/>
-                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.standbyAction" vmw:value="checkpoint"/>
-                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.suspendType" vmw:value="hard"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.afterPowerOn" vmw:value="true"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.afterResume" vmw:value="true"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestShutdown" vmw:value="true"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestStandby" vmw:value="true"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.syncTimeWithHost" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.toolsUpgradePolicy" vmw:value="manual"/>
-                        <vmw:Config ovf:required="false" vmw:key="uuid" vmw:value="4204522e-c748-6c34-d2b3-35d6020f5d9a"/>
-                    </ovf:VirtualHardwareSection>
-                    <vcloud:GuestCustomizationSection ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <vcloud:Enabled>false</vcloud:Enabled>
-                        <vcloud:ChangeSid>false</vcloud:ChangeSid>
-                        <vcloud:VirtualMachineId>3c6fd87c-d8f1-4add-827f-c35982f3e5b1</vcloud:VirtualMachineId>
-                        <vcloud:JoinDomainEnabled>false</vcloud:JoinDomainEnabled>
-                        <vcloud:UseOrgSettings>false</vcloud:UseOrgSettings>
-                        <vcloud:AdminPasswordEnabled>true</vcloud:AdminPasswordEnabled>
-                        <vcloud:AdminPasswordAuto>true</vcloud:AdminPasswordAuto>
-                        <vcloud:ResetPasswordRequired>false</vcloud:ResetPasswordRequired>
-                        <vcloud:ComputerName>CentOS7-0</vcloud:ComputerName>
-                    </vcloud:GuestCustomizationSection>
-                    <vcloud:NetworkConnectionSection ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <vcloud:PrimaryNetworkConnectionIndex>0</vcloud:PrimaryNetworkConnectionIndex>
-                        <vcloud:NetworkConnection needsCustomization="true" network="INT_192.168.10.0m24">
-                            <vcloud:NetworkConnectionIndex>0</vcloud:NetworkConnectionIndex>
-                            <vcloud:IsConnected>true</vcloud:IsConnected>
-                            <vcloud:MACAddress>00:50:56:01:00:2d</vcloud:MACAddress>
-                            <vcloud:IpAddressAllocationMode>POOL</vcloud:IpAddressAllocationMode>
-                        </vcloud:NetworkConnection>
-                    </vcloud:NetworkConnectionSection>
-                </ovf:VirtualSystem>
-            </ovf:VirtualSystemCollection>
-        </ovf:Envelope>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:55:08 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/ovf
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:55:13 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 2b6e6fcf-e19e-4851-be1d-382e39b8472b
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '799'
-      Content-Type:
-      - application/*+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <ovf:Envelope xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
-            <ovf:References/>
-            <ovf:NetworkSection>
-                <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="none">
-                    <ovf:Description>This is a special place-holder used for disconnected network interfaces.</ovf:Description>
-                </ovf:Network>
-            </ovf:NetworkSection>
-            <vcloud:CustomizationSection goldMaster="false" ovf:required="false">
-                <ovf:Info>VApp template customization section</ovf:Info>
-                <vcloud:CustomizeOnInstantiate>true</vcloud:CustomizeOnInstantiate>
-            </vcloud:CustomizationSection>
-            <vcloud:NetworkConfigSection ovf:required="false">
-                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <vcloud:NetworkConfig networkName="none">
-                    <vcloud:Description>This is a special place-holder used for disconnected network interfaces.</vcloud:Description>
-                    <vcloud:Configuration>
-                        <vcloud:IpScopes>
-                            <vcloud:IpScope>
-                                <vcloud:IsInherited>false</vcloud:IsInherited>
-                                <vcloud:Gateway>196.254.254.254</vcloud:Gateway>
-                                <vcloud:Netmask>255.255.0.0</vcloud:Netmask>
-                                <vcloud:Dns1>196.254.254.254</vcloud:Dns1>
-                            </vcloud:IpScope>
-                        </vcloud:IpScopes>
-                        <vcloud:FenceMode>isolated</vcloud:FenceMode>
-                    </vcloud:Configuration>
-                    <vcloud:IsDeployed>false</vcloud:IsDeployed>
-                </vcloud:NetworkConfig>
-            </vcloud:NetworkConfigSection>
-            <vcloud:LeaseSettingsSection ovf:required="false">
-                <ovf:Info>Lease settings section</ovf:Info>
-                <vcloud:StorageLeaseInSeconds>7776000</vcloud:StorageLeaseInSeconds>
-                <vcloud:StorageLeaseExpiration>2016-12-11T14:22:25.960+02:00</vcloud:StorageLeaseExpiration>
-            </vcloud:LeaseSettingsSection>
-            <ovf:VirtualSystemCollection ovf:id="vApp_CentOS_and_msWin">
-                <ovf:Info>A collection of virtual machines</ovf:Info>
-                <ovf:Name>vApp_CentOS_and_msWin</ovf:Name>
-                <ovf:StartupSection>
-                    <ovf:Info>VApp startup section</ovf:Info>
-                    <ovf:Item ovf:id="CentOS7" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
-                    <ovf:Item ovf:id="Tieto Windows Server 2012 R2" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
-                </ovf:StartupSection>
-                <ovf:VirtualSystem ovf:id="Tieto Windows Server 2012 R2">
-                    <ovf:Info>A virtual machine</ovf:Info>
-                    <ovf:Name>Tieto Windows Server 2012 R2</ovf:Name>
-                    <ovf:OperatingSystemSection ovf:id="112" vmw:osType="windows8Server64Guest">
-                        <ovf:Info>Specifies the operating system installed</ovf:Info>
-                        <ovf:Description>Microsoft Windows Server 2012 (64-bit)</ovf:Description>
-                    </ovf:OperatingSystemSection>
-                    <ovf:VirtualHardwareSection ovf:transport="">
-                        <ovf:Info>Virtual hardware requirements</ovf:Info>
-                        <ovf:System>
-                            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
-                            <vssd:InstanceID>0</vssd:InstanceID>
-                            <vssd:VirtualSystemIdentifier>Tieto Windows Server 2012 R2</vssd:VirtualSystemIdentifier>
-                            <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
-                        </ovf:System>
-                        <ovf:Item>
-                            <rasd:Address>00:50:56:01:00:4c</rasd:Address>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Connection vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="NONE">none</rasd:Connection>
-                            <rasd:Description>Vmxnet3 ethernet adapter on "none"</rasd:Description>
-                            <rasd:ElementName>Network adapter 0</rasd:ElementName>
-                            <rasd:InstanceID>1</rasd:InstanceID>
-                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
-                            <rasd:ResourceType>10</rasd:ResourceType>
-                            <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="192"/>
-                            <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="true"/>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>SCSI Controller</rasd:Description>
-                            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>2</rasd:InstanceID>
-                            <rasd:ResourceSubType>lsilogicsas</rasd:ResourceSubType>
-                            <rasd:ResourceType>6</rasd:ResourceType>
-                            <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="160"/>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:Description>Hard disk</rasd:Description>
-                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                            <rasd:HostResource vcloud:capacity="40960" vcloud:busSubType="lsilogicsas" vcloud:busType="6"/>
-                            <rasd:InstanceID>2000</rasd:InstanceID>
-                            <rasd:Parent>2</rasd:Parent>
-                            <rasd:ResourceType>17</rasd:ResourceType>
-                            <rasd:VirtualQuantity>42949672960</rasd:VirtualQuantity>
-                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
-                            <vmw:Config ovf:required="false" vmw:key="backing.writeThrough" vmw:value="false"/>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>SATA Controller</rasd:Description>
-                            <rasd:ElementName>SATA Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>3</rasd:InstanceID>
-                            <rasd:ResourceSubType>vmware.sata.ahci</rasd:ResourceSubType>
-                            <rasd:ResourceType>20</rasd:ResourceType>
-                            <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="33"/>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>CD/DVD Drive</rasd:Description>
-                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>16000</rasd:InstanceID>
-                            <rasd:Parent>3</rasd:Parent>
-                            <rasd:ResourceType>15</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>Floppy Drive</rasd:Description>
-                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>8000</rasd:InstanceID>
-                            <rasd:ResourceType>14</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
-                            <rasd:Description>Number of Virtual CPUs</rasd:Description>
-                            <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
-                            <rasd:InstanceID>4</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>3</rasd:ResourceType>
-                            <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
-                            <rasd:Description>Memory Size</rasd:Description>
-                            <rasd:ElementName>4096 MB of memory</rasd:ElementName>
-                            <rasd:InstanceID>5</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>4</rasd:ResourceType>
-                            <rasd:VirtualQuantity>4096</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                        </ovf:Item>
-                        <vmw:Config ovf:required="false" vmw:key="cpuHotAddEnabled" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="cpuHotRemoveEnabled" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="bios"/>
-                        <vmw:Config ovf:required="false" vmw:key="virtualICH7MPresent" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="virtualSMCPresent" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="memoryHotAddEnabled" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="nestedHVEnabled" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.powerOffType" vmw:value="soft"/>
-                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.resetType" vmw:value="soft"/>
-                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.standbyAction" vmw:value="checkpoint"/>
-                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.suspendType" vmw:value="hard"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.afterPowerOn" vmw:value="true"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.afterResume" vmw:value="true"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestShutdown" vmw:value="true"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestStandby" vmw:value="true"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.syncTimeWithHost" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.toolsUpgradePolicy" vmw:value="manual"/>
-                        <vmw:Config ovf:required="false" vmw:key="uuid" vmw:value="4204a04c-cb69-b862-2a14-5d573643bf78"/>
-                    </ovf:VirtualHardwareSection>
-                    <vcloud:GuestCustomizationSection ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <vcloud:Enabled>true</vcloud:Enabled>
-                        <vcloud:ChangeSid>false</vcloud:ChangeSid>
-                        <vcloud:VirtualMachineId>04f85cca-3f8d-43b4-8473-7aa099f95c1b</vcloud:VirtualMachineId>
-                        <vcloud:JoinDomainEnabled>false</vcloud:JoinDomainEnabled>
-                        <vcloud:UseOrgSettings>false</vcloud:UseOrgSettings>
-                        <vcloud:AdminPasswordEnabled>false</vcloud:AdminPasswordEnabled>
-                        <vcloud:AdminPasswordAuto>true</vcloud:AdminPasswordAuto>
-                        <vcloud:ResetPasswordRequired>false</vcloud:ResetPasswordRequired>
-                        <vcloud:ComputerName>TietoWindow-0</vcloud:ComputerName>
-                    </vcloud:GuestCustomizationSection>
-                    <vcloud:NetworkConnectionSection ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <vcloud:PrimaryNetworkConnectionIndex>0</vcloud:PrimaryNetworkConnectionIndex>
-                        <vcloud:NetworkConnection needsCustomization="true" network="none">
-                            <vcloud:NetworkConnectionIndex>0</vcloud:NetworkConnectionIndex>
-                            <vcloud:IsConnected>false</vcloud:IsConnected>
-                            <vcloud:MACAddress>00:50:56:01:00:4c</vcloud:MACAddress>
-                            <vcloud:IpAddressAllocationMode>NONE</vcloud:IpAddressAllocationMode>
-                        </vcloud:NetworkConnection>
-                    </vcloud:NetworkConnectionSection>
-                </ovf:VirtualSystem>
-                <ovf:VirtualSystem ovf:id="CentOS7">
-                    <ovf:Info>A virtual machine</ovf:Info>
-                    <ovf:Name>CentOS7</ovf:Name>
-                    <ovf:OperatingSystemSection ovf:id="101" vmw:osType="centos64Guest">
-                        <ovf:Info>Specifies the operating system installed</ovf:Info>
-                        <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>
-                    </ovf:OperatingSystemSection>
-                    <ovf:VirtualHardwareSection ovf:transport="">
-                        <ovf:Info>Virtual hardware requirements</ovf:Info>
-                        <ovf:System>
-                            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
-                            <vssd:InstanceID>0</vssd:InstanceID>
-                            <vssd:VirtualSystemIdentifier>CentOS7</vssd:VirtualSystemIdentifier>
-                            <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
-                        </ovf:System>
-                        <ovf:Item>
-                            <rasd:Address>00:50:56:01:00:4d</rasd:Address>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Connection vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="NONE">none</rasd:Connection>
-                            <rasd:Description>Vmxnet3 ethernet adapter on "none"</rasd:Description>
-                            <rasd:ElementName>Network adapter 0</rasd:ElementName>
-                            <rasd:InstanceID>1</rasd:InstanceID>
-                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
-                            <rasd:ResourceType>10</rasd:ResourceType>
-                            <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="160"/>
-                            <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="true"/>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>SCSI Controller</rasd:Description>
-                            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>2</rasd:InstanceID>
-                            <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
-                            <rasd:ResourceType>6</rasd:ResourceType>
-                            <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="16"/>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:Description>Hard disk</rasd:Description>
-                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                            <rasd:HostResource vcloud:capacity="16384" vcloud:busSubType="lsilogic" vcloud:busType="6"/>
-                            <rasd:InstanceID>2000</rasd:InstanceID>
-                            <rasd:Parent>2</rasd:Parent>
-                            <rasd:ResourceType>17</rasd:ResourceType>
-                            <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
-                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
-                            <vmw:Config ovf:required="false" vmw:key="backing.writeThrough" vmw:value="false"/>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>IDE Controller</rasd:Description>
-                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>3</rasd:InstanceID>
-                            <rasd:ResourceType>5</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>Floppy Drive</rasd:Description>
-                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>8000</rasd:InstanceID>
-                            <rasd:ResourceType>14</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
-                            <rasd:Description>Number of Virtual CPUs</rasd:Description>
-                            <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
-                            <rasd:InstanceID>4</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>3</rasd:ResourceType>
-                            <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
-                            <rasd:Description>Memory Size</rasd:Description>
-                            <rasd:ElementName>2048 MB of memory</rasd:ElementName>
-                            <rasd:InstanceID>5</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>4</rasd:ResourceType>
-                            <rasd:VirtualQuantity>2048</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>CD/DVD Drive</rasd:Description>
-                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>3000</rasd:InstanceID>
-                            <rasd:Parent>3</rasd:Parent>
-                            <rasd:ResourceType>15</rasd:ResourceType>
-                        </ovf:Item>
-                        <vmw:Config ovf:required="false" vmw:key="cpuHotAddEnabled" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="cpuHotRemoveEnabled" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="bios"/>
-                        <vmw:Config ovf:required="false" vmw:key="virtualICH7MPresent" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="virtualSMCPresent" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="memoryHotAddEnabled" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="nestedHVEnabled" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.powerOffType" vmw:value="soft"/>
-                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.resetType" vmw:value="soft"/>
-                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.standbyAction" vmw:value="checkpoint"/>
-                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.suspendType" vmw:value="hard"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.afterPowerOn" vmw:value="true"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.afterResume" vmw:value="true"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestShutdown" vmw:value="true"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestStandby" vmw:value="true"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.syncTimeWithHost" vmw:value="false"/>
-                        <vmw:Config ovf:required="false" vmw:key="tools.toolsUpgradePolicy" vmw:value="manual"/>
-                        <vmw:Config ovf:required="false" vmw:key="uuid" vmw:value="4204522e-c748-6c34-d2b3-35d6020f5d9a"/>
-                    </ovf:VirtualHardwareSection>
-                    <vcloud:GuestCustomizationSection ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <vcloud:Enabled>false</vcloud:Enabled>
-                        <vcloud:ChangeSid>false</vcloud:ChangeSid>
-                        <vcloud:VirtualMachineId>e9b55b85-640b-462c-9e7a-d18c47a7a5f3</vcloud:VirtualMachineId>
-                        <vcloud:JoinDomainEnabled>false</vcloud:JoinDomainEnabled>
-                        <vcloud:UseOrgSettings>false</vcloud:UseOrgSettings>
-                        <vcloud:AdminPasswordEnabled>true</vcloud:AdminPasswordEnabled>
-                        <vcloud:AdminPasswordAuto>true</vcloud:AdminPasswordAuto>
-                        <vcloud:ResetPasswordRequired>false</vcloud:ResetPasswordRequired>
-                        <vcloud:ComputerName>CentOS7-0-0</vcloud:ComputerName>
-                    </vcloud:GuestCustomizationSection>
-                    <vcloud:NetworkConnectionSection ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <vcloud:PrimaryNetworkConnectionIndex>0</vcloud:PrimaryNetworkConnectionIndex>
-                        <vcloud:NetworkConnection needsCustomization="true" network="none">
-                            <vcloud:NetworkConnectionIndex>0</vcloud:NetworkConnectionIndex>
-                            <vcloud:IsConnected>false</vcloud:IsConnected>
-                            <vcloud:MACAddress>00:50:56:01:00:4d</vcloud:MACAddress>
-                            <vcloud:IpAddressAllocationMode>NONE</vcloud:IpAddressAllocationMode>
-                        </vcloud:NetworkConnection>
-                    </vcloud:NetworkConnectionSection>
-                </ovf:VirtualSystem>
-            </ovf:VirtualSystemCollection>
-        </ovf:Envelope>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:55:14 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:55:19 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 491d6303-09cb-418a-9ad0-68882938436c
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '258'
+      - vcloud-token=ee9f52dbb4d245048614dba57e182fd3; Secure; Path=/
       Content-Type:
       - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '123'
       Vary:
       - Accept-Encoding, User-Agent
     body:
       encoding: ASCII-8BIT
       string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="true" ovfDescriptorUploaded="true" status="8" name="Tieto Linux CentOS 7.0" id="urn:vcloud:vapptemplate:ab27a332-2cc3-4ce8-a50f-138036cf7f57" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/23a9d1e6-a80a-4fc8-ad25-664f282d9ac0" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/action/enableDownload"/>
-            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/action/disableDownload"/>
-            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/ovf" type="text/xml"/>
-            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Description/>
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="spec2-vapp-win" id="urn:vcloud:vapptemplate:7d70b225-56a6-4868-8eba-f64a3509c910" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910" type="application/vnd.vmware.vcloud.vAppTemplate+xml">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/0946827a-1a9e-4b9f-8ea3-732b3afe47c6" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/f098a296-1633-4e68-a904-3cf7f577ad56" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/action/enableDownload"/>
+            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/action/disableDownload"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/ovf" type="text/xml"/>
+            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/b652f213-33aa-4c1f-8f30-ea2919a30843" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Description></Description>
             <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/2f90cae3-8ddf-48ce-b55e-45adde7a8bf6" name="system" type="application/vnd.vmware.admin.user+xml"/>
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/a4a18dd6-d9aa-4d4e-a024-653b924e7091" name="administrator" type="application/vnd.vmware.admin.user+xml"/>
             </Owner>
             <Children>
-                <Vm goldMaster="true" status="8" name="CentOS7" id="urn:vcloud:vm:857551b6-380c-44d0-ab34-9d144866f0b4" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Description/>
-                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                <Vm goldMaster="false" status="8" name="spec2-vm1" id="urn:vcloud:vm:ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/b652f213-33aa-4c1f-8f30-ea2919a30843" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description></Description>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
                         <ovf:Info>Specifies the available VM network connections</ovf:Info>
                         <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="internal">
+                        <NetworkConnection needsCustomization="true" network="spec2-network">
                             <NetworkConnectionIndex>0</NetworkConnectionIndex>
                             <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:2b</MACAddress>
+                            <MACAddress>00:50:56:01:00:d9</MACAddress>
                             <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
                         </NetworkConnection>
                     </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
                         <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
                         <Enabled>false</Enabled>
                         <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>857551b6-380c-44d0-ab34-9d144866f0b4</VirtualMachineId>
+                        <VirtualMachineId>ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6</VirtualMachineId>
                         <JoinDomainEnabled>false</JoinDomainEnabled>
                         <UseOrgSettings>false</UseOrgSettings>
                         <AdminPasswordEnabled>true</AdminPasswordEnabled>
                         <AdminPasswordAuto>true</AdminPasswordAuto>
                         <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>CentOS7</ComputerName>
+                        <ComputerName>spec2-vm1</ComputerName>
                     </GuestCustomizationSection>
-                    <VAppScopedLocalId>d0733827-5a41-4816-b4a9-3cb8deb98583</VAppScopedLocalId>
-                    <DateCreated>2016-08-02T16:34:25.103+03:00</DateCreated>
+                    <VAppScopedLocalId>0166f57b-6ae3-47fe-a68b-4f7bebb61074</VAppScopedLocalId>
+                    <DateCreated>2018-03-09T16:18:30.150+01:00</DateCreated>
                 </Vm>
             </Children>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
+            <ovf:NetworkSection xmlns:ns13="http://www.vmware.com/vcloud/v1.5" ns13:type="application/vnd.vmware.vcloud.networkSection+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/networkSection/">
                 <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="internal">
-                    <ovf:Description/>
+                <ovf:Network ovf:name="spec2-network">
+                    <ovf:Description></ovf:Description>
                 </ovf:Network>
             </ovf:NetworkSection>
-            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
                 <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <NetworkConfig networkName="internal">
-                    <Description/>
+                <NetworkConfig networkName="spec2-network">
+                    <Description></Description>
                     <Configuration>
                         <IpScopes>
                             <IpScope>
@@ -5074,8 +4302,8 @@ http_interactions:
                                 <IsEnabled>true</IsEnabled>
                                 <IpRanges>
                                     <IpRange>
-                                        <StartAddress>192.168.2.100</StartAddress>
-                                        <EndAddress>192.168.2.199</EndAddress>
+        <StartAddress>192.168.2.100</StartAddress>
+        <EndAddress>192.168.2.199</EndAddress>
                                     </IpRange>
                                 </IpRanges>
                             </IpScope>
@@ -5086,717 +4314,18 @@ http_interactions:
                     <IsDeployed>false</IsDeployed>
                 </NetworkConfig>
             </NetworkConfigSection>
-            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
                 <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
                 <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
-                <StorageLeaseExpiration>2016-12-11T10:12:59.137+02:00</StorageLeaseExpiration>
+                <StorageLeaseExpiration>2018-06-07T17:18:30.150+02:00</StorageLeaseExpiration>
             </LeaseSettingsSection>
-            <CustomizationSection goldMaster="true" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
+            <CustomizationSection goldMaster="false" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7d70b225-56a6-4868-8eba-f64a3509c910/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
                 <ovf:Info>VApp template customization section</ovf:Info>
                 <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
             </CustomizationSection>
-            <DateCreated>2016-08-02T16:34:25.103+03:00</DateCreated>
+            <DateCreated>2018-03-09T16:18:30.150+01:00</DateCreated>
         </VAppTemplate>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:55:19 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:55:24 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - d0bf0543-3426-4eff-807c-a8ba3399165a
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '130'
-      Content-Type:
-      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '8142'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="true" ovfDescriptorUploaded="true" status="8" name="Tieto Windows Server 2012 R2" id="urn:vcloud:vapptemplate:cfff2e62-3746-4007-bcfe-a054fb30c510" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/e8734bdb-af24-443e-9496-10f367424316" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/action/enableDownload"/>
-            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/action/disableDownload"/>
-            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/ovf" type="text/xml"/>
-            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Description/>
-            <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/2f90cae3-8ddf-48ce-b55e-45adde7a8bf6" name="system" type="application/vnd.vmware.admin.user+xml"/>
-            </Owner>
-            <Children>
-                <Vm goldMaster="true" status="8" name="Tieto Windows Server 2012 R2" id="urn:vcloud:vm:ac5fcf96-2b9d-4e90-9a2f-7792160da1ae" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Description/>
-                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="none">
-                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IsConnected>false</IsConnected>
-                            <MACAddress>00:50:56:84:02:de</MACAddress>
-                            <IpAddressAllocationMode>NONE</IpAddressAllocationMode>
-                        </NetworkConnection>
-                    </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <Enabled>true</Enabled>
-                        <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>ac5fcf96-2b9d-4e90-9a2f-7792160da1ae</VirtualMachineId>
-                        <JoinDomainEnabled>false</JoinDomainEnabled>
-                        <UseOrgSettings>false</UseOrgSettings>
-                        <AdminPasswordEnabled>false</AdminPasswordEnabled>
-                        <AdminPasswordAuto>true</AdminPasswordAuto>
-                        <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>TietoWindow-001</ComputerName>
-                    </GuestCustomizationSection>
-                    <VAppScopedLocalId>Tieto Windows Server 2012 R2</VAppScopedLocalId>
-                    <DateCreated>2016-08-02T11:11:07.407+03:00</DateCreated>
-                </Vm>
-            </Children>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
-                <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="none">
-                    <ovf:Description>This is a special place-holder used for disconnected network interfaces.</ovf:Description>
-                </ovf:Network>
-            </ovf:NetworkSection>
-            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
-                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <NetworkConfig networkName="none">
-                    <Description>This is a special place-holder used for disconnected network interfaces.</Description>
-                    <Configuration>
-                        <IpScopes>
-                            <IpScope>
-                                <IsInherited>false</IsInherited>
-                                <Gateway>196.254.254.254</Gateway>
-                                <Netmask>255.255.0.0</Netmask>
-                                <Dns1>196.254.254.254</Dns1>
-                            </IpScope>
-                        </IpScopes>
-                        <FenceMode>isolated</FenceMode>
-                    </Configuration>
-                    <IsDeployed>false</IsDeployed>
-                </NetworkConfig>
-            </NetworkConfigSection>
-            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
-                <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
-                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
-                <StorageLeaseExpiration>2016-12-08T09:07:24.827+02:00</StorageLeaseExpiration>
-            </LeaseSettingsSection>
-            <CustomizationSection goldMaster="true" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
-                <ovf:Info>VApp template customization section</ovf:Info>
-                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
-            </CustomizationSection>
-            <DateCreated>2016-08-02T11:11:07.407+03:00</DateCreated>
-        </VAppTemplate>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:55:25 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:55:30 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 2a6150f9-4a9d-4853-bbee-6bdddd4cb018
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '202'
-      Content-Type:
-      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="vApp_cankamat_remote_1" id="urn:vcloud:vapptemplate:5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/77519250-ce5a-45d5-939d-fbe79704e18d" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31"/>
-            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/action/enableDownload"/>
-            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/action/disableDownload"/>
-            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/ovf" type="text/xml"/>
-            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Description/>
-            <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/ab07ee17-4acb-4d7c-b15f-ccdc4aefd77d" name="cankamat_remote" type="application/vnd.vmware.admin.user+xml"/>
-            </Owner>
-            <Children>
-                <Vm goldMaster="false" status="8" name="CentOS7" id="urn:vcloud:vm:3c6fd87c-d8f1-4add-827f-c35982f3e5b1" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Description/>
-                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="INT_192.168.10.0m24">
-                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:2d</MACAddress>
-                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
-                        </NetworkConnection>
-                    </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <Enabled>false</Enabled>
-                        <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>3c6fd87c-d8f1-4add-827f-c35982f3e5b1</VirtualMachineId>
-                        <JoinDomainEnabled>false</JoinDomainEnabled>
-                        <UseOrgSettings>false</UseOrgSettings>
-                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
-                        <AdminPasswordAuto>true</AdminPasswordAuto>
-                        <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>CentOS7-0</ComputerName>
-                    </GuestCustomizationSection>
-                    <VAppScopedLocalId>7ff5cc28-e2e0-4466-bf78-e39a3522d539</VAppScopedLocalId>
-                    <DateCreated>2016-08-11T15:15:51.933+03:00</DateCreated>
-                </Vm>
-            </Children>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
-                <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="INT_192.168.10.0m24">
-                    <ovf:Description/>
-                </ovf:Network>
-            </ovf:NetworkSection>
-            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
-                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <NetworkConfig networkName="INT_192.168.10.0m24">
-                    <Description/>
-                    <Configuration>
-                        <IpScopes>
-                            <IpScope>
-                                <IsInherited>true</IsInherited>
-                                <Gateway>192.168.10.1</Gateway>
-                                <Netmask>255.255.255.0</Netmask>
-                                <Dns1>192.168.10.1</Dns1>
-                                <DnsSuffix>test.local</DnsSuffix>
-                                <IsEnabled>true</IsEnabled>
-                                <IpRanges>
-                                    <IpRange>
-                                        <StartAddress>192.168.10.100</StartAddress>
-                                        <EndAddress>192.168.10.199</EndAddress>
-                                    </IpRange>
-                                </IpRanges>
-                            </IpScope>
-                        </IpScopes>
-                        <ParentNetwork href="" name="INT_192.168.10.0m24"/>
-                        <FenceMode>bridged</FenceMode>
-                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
-                    </Configuration>
-                    <IsDeployed>false</IsDeployed>
-                </NetworkConfig>
-            </NetworkConfigSection>
-            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
-                <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
-                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
-                <StorageLeaseExpiration>2016-12-15T10:46:33.057+02:00</StorageLeaseExpiration>
-            </LeaseSettingsSection>
-            <CustomizationSection goldMaster="false" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
-                <ovf:Info>VApp template customization section</ovf:Info>
-                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
-            </CustomizationSection>
-            <DateCreated>2016-08-11T15:15:51.933+03:00</DateCreated>
-        </VAppTemplate>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:55:30 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 16 Sep 2016 08:55:35 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 79aa1829-0574-4a9c-b806-4afe0b1a521e
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-      Set-Cookie:
-      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '326'
-      Content-Type:
-      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="vApp_CentOS_and_msWin" id="urn:vcloud:vapptemplate:a19bdc8f-88fa-4dd6-8436-486590353ed5" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5"/>
-            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/action/enableDownload"/>
-            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/action/disableDownload"/>
-            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/ovf" type="text/xml"/>
-            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Description/>
-            <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/ab07ee17-4acb-4d7c-b15f-ccdc4aefd77d" name="cankamat_remote" type="application/vnd.vmware.admin.user+xml"/>
-            </Owner>
-            <Children>
-                <Vm goldMaster="false" status="8" name="Tieto Windows Server 2012 R2" id="urn:vcloud:vm:04f85cca-3f8d-43b4-8473-7aa099f95c1b" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Description/>
-                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="none">
-                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IsConnected>false</IsConnected>
-                            <MACAddress>00:50:56:01:00:4c</MACAddress>
-                            <IpAddressAllocationMode>NONE</IpAddressAllocationMode>
-                        </NetworkConnection>
-                    </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <Enabled>true</Enabled>
-                        <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>04f85cca-3f8d-43b4-8473-7aa099f95c1b</VirtualMachineId>
-                        <JoinDomainEnabled>false</JoinDomainEnabled>
-                        <UseOrgSettings>false</UseOrgSettings>
-                        <AdminPasswordEnabled>false</AdminPasswordEnabled>
-                        <AdminPasswordAuto>true</AdminPasswordAuto>
-                        <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>TietoWindow-0</ComputerName>
-                    </GuestCustomizationSection>
-                    <VAppScopedLocalId>2e9ee64a-2368-40fc-94ee-0473373f0f4c</VAppScopedLocalId>
-                    <DateCreated>2016-09-09T10:08:38.767+03:00</DateCreated>
-                </Vm>
-                <Vm goldMaster="false" status="8" name="CentOS7" id="urn:vcloud:vm:e9b55b85-640b-462c-9e7a-d18c47a7a5f3" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Description/>
-                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="none">
-                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IsConnected>false</IsConnected>
-                            <MACAddress>00:50:56:01:00:4d</MACAddress>
-                            <IpAddressAllocationMode>NONE</IpAddressAllocationMode>
-                        </NetworkConnection>
-                    </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <Enabled>false</Enabled>
-                        <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>e9b55b85-640b-462c-9e7a-d18c47a7a5f3</VirtualMachineId>
-                        <JoinDomainEnabled>false</JoinDomainEnabled>
-                        <UseOrgSettings>false</UseOrgSettings>
-                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
-                        <AdminPasswordAuto>true</AdminPasswordAuto>
-                        <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>CentOS7-0-0</ComputerName>
-                    </GuestCustomizationSection>
-                    <VAppScopedLocalId>926f501b-c7ea-4b9d-a155-6695c3345150</VAppScopedLocalId>
-                    <DateCreated>2016-09-09T10:08:38.767+03:00</DateCreated>
-                </Vm>
-            </Children>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
-                <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="none">
-                    <ovf:Description>This is a special place-holder used for disconnected network interfaces.</ovf:Description>
-                </ovf:Network>
-            </ovf:NetworkSection>
-            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
-                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <NetworkConfig networkName="none">
-                    <Description>This is a special place-holder used for disconnected network interfaces.</Description>
-                    <Configuration>
-                        <IpScopes>
-                            <IpScope>
-                                <IsInherited>false</IsInherited>
-                                <Gateway>196.254.254.254</Gateway>
-                                <Netmask>255.255.0.0</Netmask>
-                                <Dns1>196.254.254.254</Dns1>
-                            </IpScope>
-                        </IpScopes>
-                        <FenceMode>isolated</FenceMode>
-                    </Configuration>
-                    <IsDeployed>false</IsDeployed>
-                </NetworkConfig>
-            </NetworkConfigSection>
-            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
-                <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
-                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
-                <StorageLeaseExpiration>2016-12-11T14:22:25.960+02:00</StorageLeaseExpiration>
-            </LeaseSettingsSection>
-            <CustomizationSection goldMaster="false" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
-                <ovf:Info>VApp template customization section</ovf:Info>
-                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
-            </CustomizationSection>
-            <DateCreated>2016-09-09T10:08:38.767+03:00</DateCreated>
-        </VAppTemplate>
-    http_version: 
-  recorded_at: Fri, 16 Sep 2016 08:55:36 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/snapshotSection
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - c52a60a15bd3434096cb4d4cc1ccea15
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 23 Feb 2018 12:50:19 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 5c9eda34-c719-4e5f-b2ad-3639a9d9be6e
-      X-Vcloud-Authorization:
-      - c52a60a15bd3434096cb4d4cc1ccea15
-      Set-Cookie:
-      - vcloud-token=c52a60a15bd3434096cb4d4cc1ccea15; Secure; Path=/
-      Content-Type:
-      - application/vnd.vmware.vcloud.snapshotsection+xml;version=5.1
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '62'
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '1062'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <SnapshotSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-6850d9ee-ce30-42e0-aaad-3909e1861c48/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
-            <ovf:Info>Snapshot information section</ovf:Info>
-        </SnapshotSection>
     http_version:
-  recorded_at: Fri, 23 Feb 2018 12:50:19 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/snapshotSection
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - c52a60a15bd3434096cb4d4cc1ccea15
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 23 Feb 2018 12:50:20 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 26083f04-68e1-4347-85b6-920148fbc41e
-      X-Vcloud-Authorization:
-      - c52a60a15bd3434096cb4d4cc1ccea15
-      Set-Cookie:
-      - vcloud-token=c52a60a15bd3434096cb4d4cc1ccea15; Secure; Path=/
-      Content-Type:
-      - application/vnd.vmware.vcloud.snapshotsection+xml;version=5.1
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '109'
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '1154'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <SnapshotSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-9e951807-f9a6-4d95-a1b9-c83fa9a061a7/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
-            <ovf:Info>Snapshot information section</ovf:Info>
-            <Snapshot created="2018-02-22T12:22:20.784+01:00" poweredOn="false" size="4294967296"/>
-        </SnapshotSection>
-    http_version:
-  recorded_at: Fri, 23 Feb 2018 12:50:20 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/snapshotSection
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - c52a60a15bd3434096cb4d4cc1ccea15
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 23 Feb 2018 12:50:20 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 26083f04-68e1-4347-85b6-920148fbc41e
-      X-Vcloud-Authorization:
-      - c52a60a15bd3434096cb4d4cc1ccea15
-      Set-Cookie:
-      - vcloud-token=c52a60a15bd3434096cb4d4cc1ccea15; Secure; Path=/
-      Content-Type:
-      - application/vnd.vmware.vcloud.snapshotsection+xml;version=5.1
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '109'
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '1154'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <SnapshotSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-9e951807-f9a6-4d95-a1b9-c83fa9a061a7/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
-            <ovf:Info>Snapshot information section</ovf:Info>
-            <Snapshot created="2018-02-22T12:22:20.784+01:00" poweredOn="false" size="4294967296"/>
-        </SnapshotSection>
-    http_version:
-  recorded_at: Fri, 23 Feb 2018 12:50:20 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/guestCustomizationSection
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 27 Feb 2018 13:47:04 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 847868c4-6cce-4d35-9b90-bfdeea747cfd
-      X-Vcloud-Authorization:
-      - eb22e4808d8a463ab6d72dd293d4cc0a
-      Set-Cookie:
-      - vcloud-token=eb22e4808d8a463ab6d72dd293d4cc0a; Secure; Path=/
-      Content-Type:
-      - application/vnd.vmware.vcloud.guestcustomizationsection+xml;version=5.1
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '26'
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '1743'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <GuestCustomizationSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-352c29cb-43a9-42e3-8726-c2d38b99f78f/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-            <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-            <Enabled>false</Enabled>
-            <ChangeSid>true</ChangeSid>
-            <VirtualMachineId>352c29cb-43a9-42e3-8726-c2d38b99f78f</VirtualMachineId>
-            <JoinDomainEnabled>false</JoinDomainEnabled>
-            <UseOrgSettings>false</UseOrgSettings>
-            <AdminPasswordEnabled>true</AdminPasswordEnabled>
-            <AdminPasswordAuto>true</AdminPasswordAuto>
-            <ResetPasswordRequired>false</ResetPasswordRequired>
-            <ComputerName>WebServerVM</ComputerName>
-            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-352c29cb-43a9-42e3-8726-c2d38b99f78f/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
-        </GuestCustomizationSection>
-    http_version:
-  recorded_at: Tue, 27 Feb 2018 13:47:04 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/guestCustomizationSection
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 27 Feb 2018 13:47:04 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 847868c4-6cce-4d35-9b90-bfdeea747cfd
-      X-Vcloud-Authorization:
-      - eb22e4808d8a463ab6d72dd293d4cc0a
-      Set-Cookie:
-      - vcloud-token=eb22e4808d8a463ab6d72dd293d4cc0a; Secure; Path=/
-      Content-Type:
-      - application/vnd.vmware.vcloud.guestcustomizationsection+xml;version=5.1
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '26'
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '1743'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <GuestCustomizationSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-352c29cb-43a9-42e3-8726-c2d38b99f78f/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-            <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-            <Enabled>false</Enabled>
-            <ChangeSid>true</ChangeSid>
-            <VirtualMachineId>352c29cb-43a9-42e3-8726-c2d38b99f78f</VirtualMachineId>
-            <JoinDomainEnabled>false</JoinDomainEnabled>
-            <UseOrgSettings>false</UseOrgSettings>
-            <AdminPasswordEnabled>true</AdminPasswordEnabled>
-            <AdminPasswordAuto>true</AdminPasswordAuto>
-            <ResetPasswordRequired>false</ResetPasswordRequired>
-            <ComputerName>WebServerVM2</ComputerName>
-            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-352c29cb-43a9-42e3-8726-c2d38b99f78f/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
-        </GuestCustomizationSection>
-    http_version:
-  recorded_at: Tue, 27 Feb 2018 13:47:04 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/guestCustomizationSection
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 5654e38c198f4265bc768fea28d3b1bf
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 27 Feb 2018 13:47:04 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 847868c4-6cce-4d35-9b90-bfdeea747cfd
-      X-Vcloud-Authorization:
-      - eb22e4808d8a463ab6d72dd293d4cc0a
-      Set-Cookie:
-      - vcloud-token=eb22e4808d8a463ab6d72dd293d4cc0a; Secure; Path=/
-      Content-Type:
-      - application/vnd.vmware.vcloud.guestcustomizationsection+xml;version=5.1
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '26'
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '1743'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <GuestCustomizationSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:ovfenv="http://schemas.dmtf.org/ovf/environment/1" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ns9="http://www.vmware.com/vcloud/networkservice/1.0" xmlns:ns10="http://www.vmware.com/vcloud/networkservice/common/1.0" xmlns:ns11="http://www.vmware.com/vcloud/networkservice/ipam/1.0" xmlns:ns12="http://www.vmware.com/vcloud/versions" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-352c29cb-43a9-42e3-8726-c2d38b99f78f/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-            <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-            <Enabled>false</Enabled>
-            <ChangeSid>true</ChangeSid>
-            <VirtualMachineId>352c29cb-43a9-42e3-8726-c2d38b99f78f</VirtualMachineId>
-            <JoinDomainEnabled>false</JoinDomainEnabled>
-            <UseOrgSettings>false</UseOrgSettings>
-            <AdminPasswordEnabled>true</AdminPasswordEnabled>
-            <AdminPasswordAuto>true</AdminPasswordAuto>
-            <ResetPasswordRequired>false</ResetPasswordRequired>
-            <ComputerName>WebServerVM3</ComputerName>
-            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-352c29cb-43a9-42e3-8726-c2d38b99f78f/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
-        </GuestCustomizationSection>
-    http_version:
-  recorded_at: Tue, 27 Feb 2018 13:47:04 GMT
+  recorded_at: Wed, 14 Mar 2018 10:54:33 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
With this commit we implement graph inventory refresh for cloud manager. Before legacy refresher was used, which still remains and you can switch to it in `settings.yml`. Both refreshers use and pass the same unit tests.