### PR TITLE
Actually apply CloudManager's api_version

### DIFF
--- a/app/models/manageiq/providers/vmware/manager_auth_mixin.rb
+++ b/app/models/manageiq/providers/vmware/manager_auth_mixin.rb
@@ -28,21 +28,23 @@ module ManageIQ::Providers::Vmware::ManagerAuthMixin
   def connect(options = {})
     raise "no credentials defined" if missing_credentials?(options[:auth_type])
 
-    server   = options[:ip] || address
-    port     = options[:port] || self.port
-    username = options[:user] || authentication_userid(options[:auth_type])
-    password = options[:pass] || authentication_password(options[:auth_type])
+    server      = options[:ip] || address
+    port        = options[:port] || self.port
+    api_version = options[:api_version] || self.api_version
+    username    = options[:user] || authentication_userid(options[:auth_type])
+    password    = options[:pass] || authentication_password(options[:auth_type])
 
-    self.class.raw_connect(server, port, username, password)
+    self.class.raw_connect(server, port, username, password, api_version)
   end
 
   module ClassMethods
-    def raw_connect(server, port, username, password, validate = false)
+    def raw_connect(server, port, username, password, api_version = '5.5', validate = false)
       params = {
         :vcloud_director_username      => username,
         :vcloud_director_password      => MiqPassword.try_decrypt(password),
         :vcloud_director_host          => server,
         :vcloud_director_show_progress => false,
+        :vcloud_director_api_version   => api_version,
         :port                          => port,
         :connection_options            => {
           :ssl_verify_peer => false # for development

--- a/spec/models/manageiq/providers/vmware/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/refresher_spec.rb
@@ -9,9 +9,10 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
     @ems = FactoryGirl.create(
       :ems_vmware_cloud,
-      :zone     => zone,
-      :hostname => @hostname,
-      :port     => @port
+      :zone        => zone,
+      :hostname    => @hostname,
+      :port        => @port,
+      :api_version => '5.5'
     )
 
     @userid = Rails.application.secrets.vmware_cloud.try(:[], 'userid') || 'VMWARE_CLOUD_USERID'
@@ -92,7 +93,7 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
 
   def assert_ems
     expect(@ems).to have_attributes(
-      :api_version => "5.1",
+      :api_version => "5.5",
       :uid_ems     => nil
     )
 

--- a/spec/models/manageiq/providers/vmware/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager_spec.rb
@@ -38,6 +38,7 @@ describe ManageIQ::Providers::Vmware::CloudManager do
         :vcloud_director_password      => "encrypted",
         :vcloud_director_host          => "server",
         :vcloud_director_show_progress => false,
+        :vcloud_director_api_version   => "api_version",
         :port                          => "port",
         :connection_options            => {
           :ssl_verify_peer => false # for development
@@ -53,7 +54,7 @@ describe ManageIQ::Providers::Vmware::CloudManager do
       encrypted = MiqPassword.encrypt("encrypted")
       expect(::Fog::Compute::VcloudDirector).to receive(:new).with(params)
 
-      described_class.raw_connect("server", "port", "username", encrypted)
+      described_class.raw_connect("server", "port", "username", encrypted, "api_version")
     end
 
     it "validates the password if validate is true if specified" do
@@ -61,7 +62,7 @@ describe ManageIQ::Providers::Vmware::CloudManager do
       expect(::Fog::Compute::VcloudDirector).to receive(:new).with(params)
 
       expect do
-        described_class.raw_connect("server", "port", "username", "encrypted", true)
+        described_class.raw_connect("server", "port", "username", "encrypted", "api_version", true)
       end.to raise_error(MiqException::MiqInvalidCredentialsError, "Login failed due to a bad username or password.")
     end
 
@@ -69,7 +70,7 @@ describe ManageIQ::Providers::Vmware::CloudManager do
       expect(described_class).to_not receive(:validate_connection)
       expect(::Fog::Compute::VcloudDirector).to receive(:new).with(params)
 
-      described_class.raw_connect("server", "port", "username", "encrypted")
+      described_class.raw_connect("server", "port", "username", "encrypted", "api_version")
     end
   end
 


### PR DESCRIPTION
We're only storing API version in VMDB, but we never actually apply it when performing API calls (so it always defaults to 5.1)! It didn't really matter until now, because most of the API was implemented in v1.5. Acquiring WebMKS ticket, however, requires >= 5.5.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1560517

Merge in one take with: https://github.com/ManageIQ/manageiq-ui-classic/pull/3701

@miq-bot add_label enhancement,gaprindashvili/yes
@miq-bot assign @agrare 