### PR TITLE
VMware provider IP discovery fix

### DIFF
--- a/app/models/manageiq/providers/vmware/discovery.rb
+++ b/app/models/manageiq/providers/vmware/discovery.rb
@@ -4,70 +4,61 @@ module ManageIQ
   module Providers
     module Vmware
       class Discovery
-        SERVER_CONSOLE_PORTS = [902, 912].freeze
-
-        ESX_PORTS = [902, 903].freeze
-
-        VC_PORTS = [
-          [
-            135, # VC < 5.1 or
-            7444 # VC >= 5.1
-          ],
-          [
-            139,  # VC < 5.1 or
-            2012, # VC >= 5.1
-            2013,
-            2014
-          ]
-        ].freeze
-
         def self.probe(ost)
-          # Check if VMware Server
-          ost.hypervisor << :vmwareserver if ManageIQ::NetworkDiscovery::Port.scan_open(ost, SERVER_CONSOLE_PORTS).length == 2
-
-          # First check if we can access the VMware webservice before even trying the port scans.
-          begin
-            require 'VMwareWebService/MiqVimClientBase'
-            MiqVimClientBase.new(ost.ipaddr, "test", "test")
-          rescue => err
-            $log&.debug("Vmware::Discovery: Failed to connect to VMware webservice: #{err}. ip = #{ost.ipaddr}")
-            return
-          end
-
-          $log&.debug("Vmware::Discovery: ip = #{ost.ipaddr}, Connected to VMware webservice. Machine is either ESX or VirtualCenter.")
-
-          # Next check for ESX or VC. Since VC shares some port numbers with ESX, we check VC before ESX
-
-          # TODO: See if there is a way we can check ESX first, and without having to
-          #   also check VC, since it is more likely there will be more ESX servers on
-          #   a network than VC servers.
-
-          checked_vc = false
-          found_vc = false
-
-          # Check if we have VC ports
-          if ost.discover_types.include?(:virtualcenter)
-            checked_vc = true
-
-            if ManageIQ::NetworkDiscovery::Port.all_open?(ost, VC_PORTS)
-              ost.os << :mswin
-              ost.hypervisor << :virtualcenter
-              found_vc = true
-              $log&.debug("Vmware::Discovery: ip = #{ost.ipaddr}, Machine is VirtualCenter.")
+          # Get Info from VMware (vSphere) Web Service API
+          access_webservice(ost) do |info|
+            if add_hypervisor(ost, info)
+              add_os(ost, info)
             end
           end
+        rescue StandardError => err
+          _log&.warn("Vmware::Discovery: Failed to connect to VMware webservice: #{err}. ip = #{ost.ipaddr}")
+          return
+        end
 
-          # Check if we have ESX ports open
-          if !found_vc && ost.discover_types.include?(:esx) && ManageIQ::NetworkDiscovery::Port.any_open?(ost, ESX_PORTS)
+        # Obtains info about IP address from vSphere Web Service API
+        # @param ost [OpenStruct]
+        def self.access_webservice(ost)
+          require 'VMwareWebService/MiqVimClientBase'
+          vim = MiqVimClientBase.new(ost.ipaddr, "test", "test")
+          info = vim&.sic&.about
 
-            # Since VC may share ports with ESX, but it may have not already been
-            # checked due to filtering, check that this is not a VC server
-            if checked_vc || !ManageIQ::NetworkDiscovery::Port.all_open?(ost, VC_PORTS)
-              ost.os << :linux
-              ost.hypervisor << :esx
-              $log&.debug("Vmware::Discovery: ip = #{ost.ipaddr}, Machine is an ESX server.")
-            end
-          end
+          _log&.debug("Vmware::Discovery: ip = #{ost.ipaddr}, Connected to VMware webservice.")
+
+          yield info
+        end
+
+        # Adds product type (as hypervisor value) from vmware api info
+        def self.add_hypervisor(ost, info)
+          hypervisor = case info&.productLineId
+                       when 'vpx'
+                         _log&.debug("Vmware::Discovery: ip = #{ost.ipaddr}, Machine is VirtualCenter.")
+                         :virtualcenter
+                       when 'esx'
+                         _log&.debug("Vmware::Discovery: ip = #{ost.ipaddr}, Machine is an ESX server.")
+                         :esx
+                       when 'embeddedEsx'
+                         _log&.debug("Vmware::Discovery: ip = #{ost.ipaddr}, Machine is an ESXi server.")
+                         :esx
+                       when 'gsx'
+                         _log&.debug("Vmware::Discovery: ip = #{ost.ipaddr}, Machine is an VMWare Server product.")
+                         :vmwareserver
+                       else
+                         _log&.error("Vmware::Discovery: ip: #{ost.ipaddr}, Unknown product: #{info&.productLineId}")
+                         nil
+                       end
+
+          ost.hypervisor << hypervisor if hypervisor
+          hypervisor
+        end
+
+        # Adds operating system from vmware api info
+        def self.add_os(ost, info)
+          ost.os << if info&.osType.to_s.include?('win32')
+                      :mswin
+                    else
+                      :linux
+                    end
         end
       end
     end


### PR DESCRIPTION
Recognition of vSphere product based on API info instead ports scanning
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1559347

Steps to reproduce:
Have a VMWare Virtual Center (vSphere) on known IP
1. Navigate to Compute -> Infrastructure -> Providers
2. Configuration -> Discover Infrastructure Providers
3. Input valid IP range and choose valid provider, click Start

Cc @agrare, @Ladas 
@miq-bot add_label bug