### PR TITLE
Sort unitNumber as an integer not a string

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/network.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/network.rb
@@ -140,7 +140,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration::Netw
     end
 
     devs = inventory_hash.fetch_path("config", "hardware", "device") || []
-    devs.select { |d| d.key?('macAddress') }.sort_by { |d| d['unitNumber'] }
+    devs.select { |d| d.key?('macAddress') }.sort_by { |d| d['unitNumber'].to_i }
   end
 
   def get_network_device(vimVm, _vmcs, _vim = nil, vlan = nil)


### PR DESCRIPTION
The get_network_adapters method was sorting NICs by their unitNumber as
an integer.  This was causing '10' to be sorted before '7', '8', and
'9'.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1562089