### PR TITLE
Shift fog-vcloud-director version to 0.1.10

### DIFF
--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency("fog-vcloud-director", ["~> 0.1.9"])
+  s.add_dependency("fog-vcloud-director", ["~> 0.1.10"])
   s.add_dependency "fog-core",                "~>1.40"
   s.add_dependency "vmware_web_service",      "~>0.2.6"
   s.add_dependency "rbvmomi",                 "~>1.11.3"


### PR DESCRIPTION
With this commit we shift gem version because WebMKS console depends on some API calls that were only implemented in this version of the gem. Also, since the new gem shifts default version from 5.1 -> 5.5 and due to a bug that CloudProvider always uses default version no matter what version is stored in VMDB - we update the spec to match the new default.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1560517

@miq-bot add_label enhancement,gaprindashvili/yes
@miq-bot assign @agrare 