### PR TITLE
[FINE] Lock fog-vcloud-director gem to 0.1.8

### DIFF
--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config.lib}/**/*"]
 
-  s.add_dependency("fog-vcloud-director", ["~> 0.1.8"])
+  s.add_dependency("fog-vcloud-director", ["0.1.8"])
   s.add_dependency "fog-core",                "~>1.40"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
With this commit we prevent `fine` branch from silently following fog-vcloud-director gem development as not all chages are compatible. So we lock the version to 0.1.8.

@miq-bot assign @agrare 
@miq-bot add_label dependencies,fine/yes
