### PR TITLE
Add supports revert to snapshot

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm.rb
@@ -6,6 +6,7 @@ class ManageIQ::Providers::Vmware::CloudManager::Vm < ManageIQ::Providers::Cloud
   supports :remove_all_snapshots
   supports_not :remove_snapshot
   supports :snapshot_create
+  supports :revert_to_snapshot
 
   def provider_object(connection = nil)
     connection ||= ext_management_system.connect

--- a/spec/models/manageiq/providers/vmware/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager_spec.rb
@@ -139,6 +139,10 @@ describe ManageIQ::Providers::Vmware::CloudManager do
 
         @ems.vm_revert_to_snapshot(vm)
       end
+
+      it 'supports revert to snapshot' do
+        expect(vm.supports_revert_to_snapshot?).to be_truthy
+      end
     end
 
     context ".vm_remove_snapshot" do


### PR DESCRIPTION
With this commit revert snapshot is enabled.

Revert to snapshot is [supported](https://github.com/ManageIQ/manageiq/blob/master/app/models/vm_or_template/operations/snapshot.rb#L43-L47) only if delete snapshot is supported. At first delete snapshot was enabled, but after revert to snapshot was merged I implemented https://github.com/ManageIQ/manageiq-providers-vmware/pull/191#pullrequestreview-99801664. Since I did not know revert relied on delete snapshot and there was no test to check, if revert to snapshot is supported, mistake went through unnoticed.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1567760