### PR TITLE
Bump version of rbvmomi gem to 1.12.0

### DIFF
--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency("fog-vcloud-director", ["~> 0.2.2"])
   s.add_dependency "fog-core",                "~>1.40"
   s.add_dependency "vmware_web_service",      "~>0.2.10"
-  s.add_dependency "rbvmomi",                 "~>1.11.3"
+  s.add_dependency "rbvmomi",                 "~>1.12.0"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
RbVmomi released a new version of the gem to support vSphere 6.7

Depends on:

- [x] https://github.com/ManageIQ/vmware_web_service/pull/36