### PR TITLE
Split vApp provisioning customization into three tabs

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/orchestration_template.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/orchestration_template.rb
@@ -1,36 +1,53 @@
 class ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate < OrchestrationTemplate
   def parameter_groups
-    # Define vApp's general purpose parameters.
-    groups = [OrchestrationTemplate::OrchestrationParameterGroup.new(
-      :label      => 'vApp Parameters',
-      :parameters => vapp_parameters,
-    )]
-
     template = ManageIQ::Providers::Vmware::CloudManager::OvfTemplate.new(content)
-    groups + vapp_net_param_groups(template) + vm_param_groups(template)
+    vapp_parameter_group + vapp_net_param_groups(template) + vm_param_groups(template)
   end
 
-  def vapp_parameters
+  def tabs
+    template = ManageIQ::Providers::Vmware::CloudManager::OvfTemplate.new(content)
+
     [
-      OrchestrationTemplate::OrchestrationParameter.new(
-        :name          => 'deploy',
-        :label         => 'Deploy vApp',
-        :data_type     => 'boolean',
-        :default_value => true,
-        :constraints   => [
-          OrchestrationTemplate::OrchestrationParameterBoolean.new
-        ]
-      ),
-      OrchestrationTemplate::OrchestrationParameter.new(
-        :name          => 'powerOn',
-        :label         => 'Power On vApp',
-        :data_type     => 'boolean',
-        :default_value => false,
-        :constraints   => [
-          OrchestrationTemplate::OrchestrationParameterBoolean.new
-        ]
-      )
+      {
+        :title        => "Basic Information",
+        :stack_group  => deployment_options,
+        :param_groups => vapp_parameter_group
+      },
+      {
+        :title        => "vApp Networks",
+        :param_groups => vapp_net_param_groups(template)
+      },
+      {
+        :title        => "Instances",
+        :param_groups => vm_param_groups(template)
+      }
     ]
+  end
+
+  def vapp_parameter_group
+    [OrchestrationTemplate::OrchestrationParameterGroup.new(
+      :label      => 'vApp Parameters',
+      :parameters => [
+        OrchestrationTemplate::OrchestrationParameter.new(
+          :name          => 'deploy',
+          :label         => 'Deploy vApp',
+          :data_type     => 'boolean',
+          :default_value => true,
+          :constraints   => [
+            OrchestrationTemplate::OrchestrationParameterBoolean.new
+          ]
+        ),
+        OrchestrationTemplate::OrchestrationParameter.new(
+          :name          => 'powerOn',
+          :label         => 'Power On vApp',
+          :data_type     => 'boolean',
+          :default_value => false,
+          :constraints   => [
+            OrchestrationTemplate::OrchestrationParameterBoolean.new
+          ]
+        )
+      ],
+    )]
   end
 
   def vm_param_groups(template)
@@ -182,7 +199,7 @@ class ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate < Orchest
       end
 
       OrchestrationTemplate::OrchestrationParameterGroup.new(
-        :label      => "VM Instance Parameters for '#{vm.name}'",
+        :label      => vm.name.to_s,
         :parameters => vm_parameters
       )
     end
@@ -251,7 +268,7 @@ class ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate < Orchest
       end
 
       OrchestrationTemplate::OrchestrationParameterGroup.new(
-        :label      => "vApp Network Parameters for '#{vapp_net.name}'",
+        :label      => vapp_net.name.to_s,
         :parameters => vapp_net_parameters
       )
     end
@@ -310,7 +327,7 @@ class ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate < Orchest
 
   def ip_constraint
     OrchestrationTemplate::OrchestrationParameterPattern.new(
-      :pattern     => '^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?).){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$',
+      :pattern     => '(^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?).){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)?',
       :description => 'IP address'
     )
   end


### PR DESCRIPTION
With this commit we split rather large provisioning dialog into three tabs:

- Basic information
- vApp Networks
- Instances

Only 'Basic Information' tab is required to be filled with some data, like VDC to deploy into and vApp name, while other two tabs can be skipped.

Also, with this commit we update IP address regex validator. Until now it was matching "must be IP address" and now it's matching "must be empty or IP address", because UI doesn't seem to respect `:required => false` setting.

![capture](https://user-images.githubusercontent.com/8102426/39244920-74a1ed64-4892-11e8-9d2b-bb7e8e0990eb.PNG)


Original PR: https://github.com/ManageIQ/manageiq-providers-vmware/pull/229 (@gasper-vrhovsek left company)
Depends on: https://github.com/ManageIQ/manageiq/pull/17342
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1571758

@miq-bot assign @agrare 
@miq-bot add_label enhancement,gaprindashvili/yes

/cc @bzwei 