### PR TITLE
Try to get VM UUID from summary.config or config

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,7 @@
 ignore: |
   /vendor/**
   /spec/manageiq/**
+  /spec/tools/vim_data/**
   /spec/vcr_cassettes/**
 
 extends: relaxed

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -825,7 +825,7 @@ module ManageIQ::Providers
           invalid, err = if summary_config.nil? || config.nil?
                            type = ['summary_config', 'config'].find_all { |t| eval(t).nil? }.join(", ")
                            [true, "Missing configuration for VM [#{mor}]: #{type}."]
-                         elsif summary_config["uuid"].blank?
+                         elsif summary_config["uuid"].blank? && config["uuid"].blank?
                            [true, "Missing UUID for VM [#{mor}]."]
                          elsif pathname.blank?
                            _log.debug "vmPathname class: [#{pathname.class}] inspect: [#{pathname.inspect}]"
@@ -997,7 +997,8 @@ module ManageIQ::Providers
           :guest_os_full_name => inv["guestFullName"].blank? ? "Other" : inv["guestFullName"]
         }
 
-        bios = MiqUUID.clean_guid(inv["uuid"]) || inv["uuid"]
+        uuid = inv["uuid"] || config["uuid"]
+        bios = MiqUUID.clean_guid(uuid) || uuid
         result[:bios] = bios unless bios.blank?
 
         if inv["numCpu"].present?

--- a/app/models/manageiq/providers/vmware/infra_manager/selector_spec.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/selector_spec.rb
@@ -101,6 +101,7 @@ module ManageIQ::Providers::Vmware::InfraManager::SelectorSpec
       "config.hotPlugMemoryIncrementSize",
       "config.hotPlugMemoryLimit",
       "config.memoryHotAddEnabled",
+      "config.uuid",
       "config.version",
       "datastore",
       "datastore.ManagedObjectReference",

--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("fog-vcloud-director", ["~> 0.1.10"])
   s.add_dependency "fog-core",                "~>1.40"
-  s.add_dependency "vmware_web_service",      "~>0.2.9"
+  s.add_dependency "vmware_web_service",      "~>0.2.10"
   s.add_dependency "rbvmomi",                 "~>1.11.3"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresh_parser_spec.rb
@@ -1,7 +1,7 @@
 describe ManageIQ::Providers::Vmware::InfraManager::RefreshParser do
   context ".vm_inv_to_hardware_hash" do
     context "properly calculates cores and sockets" do
-      let(:inv) { {"summary" => {"config" => {"name" => "a"}}} }
+      let(:inv) { {"config" => {}, "summary" => {"config" => {"name" => "a"}}} }
 
       it("without total") { assert_cores_and_sockets_values(nil, nil, nil) }
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -37,6 +37,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     assert_specific_dvportgroup
     assert_specific_host
     assert_specific_vm
+    assert_specific_vm_missing_uuid
     assert_cpu_layout
     assert_relationship_tree
   end
@@ -799,6 +800,11 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :cpu_cores_per_socket => 2,
       :cpu_sockets          => 2,
     )
+  end
+
+  def assert_specific_vm_missing_uuid
+    v = ManageIQ::Providers::Vmware::InfraManager::Vm.find_by(:ems_ref => 'vm-12201')
+    expect(v.uid_ems).to eq('422f5d0e-8bd4-2767-d278-eec66f00a1a1')
   end
 
   def assert_relationship_tree


### PR DESCRIPTION
In some instances a VM will have a nil summary.config.uuid but a valid
config.uuid.  Attempt to get the UUID from config.uuid as a fallback in
the event that summary.config.uuid is nil.

Depends on: ~~https://github.com/ManageIQ/vmware_web_service/pull/39~~

https://bugzilla.redhat.com/show_bug.cgi?id=1569090