### PR TITLE
Bump version of vmware_web_service

### DIFF
--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("fog-vcloud-director", ["~> 0.1.10"])
   s.add_dependency "fog-core",                "~>1.40"
-  s.add_dependency "vmware_web_service",      "~>0.2.6"
+  s.add_dependency "vmware_web_service",      "~>0.2.9"
   s.add_dependency "rbvmomi",                 "~>1.11.3"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
Require vmware_web_service 0.2.9 to pull in fix for large DRb message
payloads.

https://bugzilla.redhat.com/show_bug.cgi?id=1573588