### PR TITLE
Load Lans efficiently in ProvisionWorkflow

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
@@ -133,10 +133,14 @@ class ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow < ManageIQ::P
 
     # dvportgroups key-value transformed
     if options[:dvs]
-      dvlans = Hash.new { |h, k| h[k] = [] }
-      hosts.to_miq_a.each do |h|
-        h.lans.each { |l| dvlans[l.name] << l.switch.name if l.switch.shared? }
-      end
+      dvlans      = Hash.new { |h, k| h[k] = [] }
+      shared_lans = Lan.distinct.select(:id, :switch_id, :name)
+                       .includes(:switch)
+                       .joins(:switch => :host_switches)
+                       .where(:host_switches => {:host_id => hosts.map(&:id)})
+                       .merge(Switch.shareable)
+
+      shared_lans.each { |l| dvlans[l.name] << l.switch.name }
       dvlans.each do |l, v|
         vlans["dvs_#{l}"] = "#{l} (#{v.sort.uniq.join('/')})"
       end


### PR DESCRIPTION
Instead of preloading Lan records, splitting them up based on if they are shareable and instantiating entire `ActiveRecord` instances to only use the name column in a hash, use a specific query to gather and filter those values and generate a hash from that.

**IMPORTANT NOTE:** There will be a PR on `ManageIQ/manageiq` that will remove the preloading in `app/models/miq_provision_virt_workflow.rb` that this relied on to avoid an N+1.  The idea is that we would merge any provider PRs first, and then the fix in the main repo so the performance impact during this is minimal.

Benchmarks
----------

Since this is part of a multi-PR fix, benchmarks will be displayed in the main PR in the `ManageIQ/manageiq` repo.  Links to the related PRs will be posted down below when available.


Links
-----

* Partially addresses https://bugzilla.redhat.com/show_bug.cgi?id=1569626
* Full collection of proposed changes: [git compare](https://github.com/ManageIQ/manageiq/compare/master...NickLaMuro:multiple_miq_provision_workflow_query_optimizations)
* Document keeping track of overall improvements for this effort: [gist](https://gist.github.com/NickLaMuro/36f9f394a5b3cecc4aaf33d3e84dfb27)
* Main Repo PR:  https://github.com/ManageIQ/manageiq/pull/17381