### PR TITLE
Save ems cluster for a vm

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/cache.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/cache.rb
@@ -19,6 +19,10 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Cache
     props
   end
 
+  def find(obj)
+    data[obj.class.wsdl_name][obj._ref] unless obj.nil?
+  end
+
   delegate :[], :keys, :to => :data
 
   private

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -30,7 +30,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
 
     until exit_requested
       persister = targeted_persister_klass.new(ems)
-      parser    = parser_klass.new(persister)
+      parser    = parser_klass.new(inventory_cache, persister)
 
       version = monitor_updates(vim, property_filter, version, persister, parser)
     end
@@ -49,7 +49,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
 
   def initial_refresh(vim, property_filter)
     persister = full_persister_klass.new(ems)
-    parser    = parser_klass.new(persister)
+    parser    = parser_klass.new(inventory_cache, persister)
 
     monitor_updates(vim, property_filter, "", persister, parser)
   end

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -6,10 +6,11 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
   include_concern :ResourcePool
   include_concern :VirtualMachine
 
-  attr_reader :persister
-  private     :persister
+  attr_reader :cache, :persister
+  private     :cache, :persister
 
-  def initialize(persister)
+  def initialize(cache, persister)
+    @cache     = cache
     @persister = persister
   end
 

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -65,7 +65,8 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
       return if runtime.nil?
 
       vm_hash[:connection_state] = runtime[:connectionState]
-      vm_hash[:host] = persister.hosts.lazy_find(runtime[:host]._ref) if runtime[:host]
+      vm_hash[:host] = lazy_find_managed_object(runtime[:host])
+      vm_hash[:ems_cluster] = lazy_find_managed_object(cache.find(runtime[:host])&.dig(:parent))
       vm_hash[:boot_time] = runtime[:bootTime]
       vm_hash[:raw_power_state] = if props.fetch_path(:summary, :config, :template)
                                       "never"

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -40,7 +40,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
       let(:vim)             { RbVmomi::VIM.new(:ns => "urn2", :rev => "6.5") }
       let(:property_filter) { RbVmomi::VIM.PropertyFilter(vim, "session[6f2dcefd-41de-6dfb-0160-1ee1cc024553]") }
       let(:persister)       { ems.class::Inventory::Persister::Targeted.new(ems) }
-      let(:parser)          { ems.class::Inventory::Parser.new(persister) }
+      let(:parser)          { ems.class::Inventory::Parser.new(collector.send(:inventory_cache), persister) }
 
       before do
         # Use the VCR to prime the cache and do the initial save_inventory

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -69,7 +69,10 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
       end
 
       def run_targeted_refresh(update_set)
-        collector.send(:process_update_set, property_filter, update_set, parser)
+        collector.send(:process_update_set, property_filter, update_set).each do |obj, props|
+          parser.parse(obj, props)
+        end
+
         collector.send(:save_inventory, persister)
       end
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -341,7 +341,8 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         :start_connected => true,
       )
 
-      # TODO: expect(vm.ems_cluster).not_to be_nil
+      expect(vm.ems_cluster).not_to be_nil
+      expect(vm.ems_cluster.ems_ref).to eq("domain-c12")
 
       expect(vm.host).not_to be_nil
       expect(vm.host.ems_ref).to eq("host-17")
@@ -349,8 +350,11 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
       expect(vm.parent_blue_folder).not_to be_nil
       expect(vm.parent_blue_folder.ems_ref).to eq("group-v3")
 
-      # TODO: expect(vm.parent_yellow_folder).not_to be_nil
+      expect(vm.parent_yellow_folder).not_to be_nil
+      expect(vm.parent_yellow_folder.ems_ref).to eq("group-d1")
+
       expect(vm.parent_resource_pool).not_to be_nil
+      expect(vm.parent_resource_pool.ems_ref).to eq("resgroup-19")
     end
   end
 end


### PR DESCRIPTION
We need to save the ems_cluster for a VM which comes from the host, for this we need access to the inventory cache from the parser to get access to the host's parent.