### PR TITLE
Fix storage parsing to use datastore url

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -58,7 +58,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
   end
 
   def parse_datastore(object, kind, props)
-    persister.storages.targeted_scope << object._ref
+    persister.storages.targeted_scope << parse_datastore_location(props)
     return if kind == "leave"
 
     storage_hash = {
@@ -226,6 +226,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
     parse_virtual_machine_config(vm_hash, props)
     parse_virtual_machine_resource_config(vm_hash, props)
     parse_virtual_machine_summary(vm_hash, props)
+    parse_virtual_machine_storage(vm_hash, props)
 
     vm = persister.vms_and_templates.build(vm_hash)
 

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/datastore.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/datastore.rb
@@ -5,12 +5,17 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
       return if summary.nil?
 
       storage_hash[:name] = summary[:name]
-      storage_hash[:location] = normalize_storage_uid(summary[:url])
+      storage_hash[:location] = parse_datastore_location(props)
       storage_hash[:store_type] = summary[:type].to_s.upcase
       storage_hash[:total_space] = summary[:capacity]
       storage_hash[:free_space] = summary[:freeSpace]
       storage_hash[:uncommitted] = summary[:uncommitted]
       storage_hash[:multiplehostaccess] = summary[:multipleHostAccess].to_s.downcase == "true"
+    end
+
+    def parse_datastore_location(props)
+      url = props.fetch_path(:summary, :url)
+      normalize_storage_uid(url) if url
     end
 
     def parse_datastore_capability(storage_hash, props)

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -25,6 +25,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
 
           assert_table_counts
           assert_specific_datacenter
+          assert_specific_datastore
           assert_specific_folder
           assert_specific_host
           assert_specific_cluster
@@ -72,9 +73,9 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
       it "deleting a virtual machine" do
         vm = ems.vms.find_by(:ems_ref => 'vm-107')
 
-        expect(vm.archived?).to be_falsy
+        expect(vm.orphaned?).to be_falsy
         run_targeted_refresh(targeted_update_set(vm_delete_object_updates))
-        expect(vm.reload.archived?).to be_truthy
+        expect(vm.reload.orphaned?).to be_truthy
       end
 
       def run_targeted_refresh(update_set)
@@ -196,6 +197,26 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
 
       expect(datacenter.children.count).to eq(4)
       expect(datacenter.children.map(&:name)).to match_array(%w(host network datastore vm))
+    end
+
+    def assert_specific_datastore
+      storage = ems.storages.find_by(:location => "ds:///vmfs/volumes/5280a4c3-b5e2-7dc7-5c31-7a344d35466c/")
+
+      expect(storage).to have_attributes(
+        :location                      => "ds:///vmfs/volumes/5280a4c3-b5e2-7dc7-5c31-7a344d35466c/",
+        :name                          => "GlobalDS_0",
+        :store_type                    => "VMFS",
+        :total_space                   => 1_099_511_627_776,
+        :free_space                    => 824_633_720_832,
+        :multiplehostaccess            => 1,
+        :directory_hierarchy_supported => true,
+        :thin_provisioning_supported   => true,
+        :raw_disk_mappings_supported   => true,
+      )
+
+      expect(storage.hosts.count).to eq(32)
+      expect(storage.disks.count).to eq(512)
+      expect(storage.vms.count).to   eq(512)
     end
 
     def assert_specific_folder
@@ -385,6 +406,9 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
 
       expect(vm.host).not_to be_nil
       expect(vm.host.ems_ref).to eq("host-17")
+
+      expect(vm.storage).not_to be_nil
+      expect(vm.storage.name).to eq("GlobalDS_0")
 
       expect(vm.parent_blue_folder).not_to be_nil
       expect(vm.parent_blue_folder.ems_ref).to eq("group-v3")


### PR DESCRIPTION
Fix the storage parser to use the datastore location as the manager_ref
not the managed object reference.

Depends on: ~~https://github.com/ManageIQ/manageiq-providers-vmware/pull/255~~, https://github.com/ManageIQ/manageiq-providers-vmware/pull/258