### PR TITLE
Set api_version and uid_ems in streaming refresh

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -51,6 +51,10 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
     persister = full_persister_klass.new(ems)
     parser    = parser_klass.new(inventory_cache, persister)
 
+    # Set the ems.api_version and ems.uid_ems manually until there is a way to
+    # set it with an inventory_collection
+    set_ems_attributes(vim)
+
     monitor_updates(vim, property_filter, "", persister, parser)
   end
 
@@ -106,6 +110,13 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
     return if vim.nil?
 
     vim.close
+  end
+
+  def set_ems_attributes(vim)
+    api_version   = vim.serviceContent.about.apiVersion
+    instance_uuid = vim.serviceContent.about.instanceUuid
+
+    ems.update_attributes(:api_version => api_version, :uid_ems => instance_uuid)
   end
 
   def wait_for_updates(vim, version)

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -23,7 +23,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
           run_full_refresh
           ems.reload
 
-          assert_table_counts
+          assert_ems
           assert_specific_datacenter
           assert_specific_folder
           assert_specific_host
@@ -50,7 +50,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
 
       it "doesn't impact unassociated inventory" do
         run_targeted_refresh(targeted_update_set([vm_power_on_object_update]))
-        assert_table_counts
+        assert_ems
       end
 
       it "power on a virtual machine" do
@@ -164,7 +164,9 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
       end
     end
 
-    def assert_table_counts
+    def assert_ems
+      expect(ems.api_version).to eq("5.5")
+      expect(ems.uid_ems).to eq("D6EB1D64-05B2-4937-BFF6-6F77C6E647B7")
       expect(ems.ems_clusters.count).to eq(8)
       expect(ems.ems_folders.count).to eq(21)
       expect(ems.ems_folders.where(:type => "Datacenter").count).to eq(4)


### PR DESCRIPTION
The api_version and uid_ems weren't being set by streaming refresh since
there is no inventory collection/parser for the ems.