### PR TITLE
Enhance disk and CPU inventoring

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/refresh_parser.rb
@@ -108,45 +108,51 @@ class ManageIQ::Providers::Vmware::CloudManager::RefreshParser < ManageIQ::Provi
   end
 
   def parse_vm(vm)
-    status        = vm.status
-    uid           = vm.id
-    name          = vm.name
-    hostname      = vm.customization.try(:computer_name)
-    guest_os      = vm.operating_system
-    bitness       = vm.operating_system =~ /64-bit/ ? 64 : 32
-    cpus          = vm.cpu
-    memory_mb     = vm.memory
-    vapp_uid      = vm.vapp_id
-    stack         = @data_index.fetch_path(:orchestration_stacks, vapp_uid)
-    disk_capacity = vm.hard_disks.inject(0) { |sum, x| sum + x.values[0] } * 1.megabyte
+    status           = vm.status
+    uid              = vm.id
+    name             = vm.name
+    hostname         = vm.customization.try(:computer_name)
+    guest_os         = vm.operating_system
+    bitness          = vm.operating_system =~ /64-bit/ ? 64 : 32
+    cpus             = vm.cpu
+    cores_per_socket = vm.cores_per_socket
+    memory_mb        = vm.memory
+    vapp_uid         = vm.vapp_id
+    stack            = @data_index.fetch_path(:orchestration_stacks, vapp_uid)
+    disk_capacity    = vm.hard_disks.inject(0) { |sum, x| sum + x.values[0] } * 1.megabyte
+    cpu_hot_add      = vm.cpu_hot_add
+    mem_hot_add      = vm.memory_hot_add
 
-    disks = vm.disks.all.select { |d| hdd? d.bus_type }.map do |disk|
+    disks = vm.disks.all.select { |d| hdd? d.bus_type }.each_with_index.map do |disk, i|
       {
-        :device_name     => disk.name,
+        :device_name     => "Disk #{i}",
         :device_type     => "disk",
+        :disk_type       => controller_description(disk.bus_sub_type).sub(' controller', ''),
         :controller_type => controller_description(disk.bus_sub_type),
         :size            => disk.capacity * 1.megabyte,
-        :location        => "#{vm.id}-#{disk.id}",
-        :filename        => "#{vm.id}-#{disk.id}",
+        :location        => "#{vm.id}/#{disk.address}/#{disk.address_on_parent}/#{disk.id}",
+        :filename        => "Disk #{i}"
       }
     end
 
     new_result = {
-      :type                => ManageIQ::Providers::Vmware::CloudManager::Vm.name,
-      :uid_ems             => uid,
-      :ems_ref             => uid,
-      :name                => name,
-      :hostname            => hostname,
-      :vendor              => "vmware",
-      :raw_power_state     => status,
-      :snapshots           => [parse_snapshot(vm)].compact,
+      :type                   => ManageIQ::Providers::Vmware::CloudManager::Vm.name,
+      :uid_ems                => uid,
+      :ems_ref                => uid,
+      :name                   => name,
+      :hostname               => hostname,
+      :vendor                 => "vmware",
+      :raw_power_state        => status,
+      :snapshots              => [parse_snapshot(vm)].compact,
+      :cpu_hot_add_enabled    => cpu_hot_add,
+      :memory_hot_add_enabled => mem_hot_add,
 
       :hardware            => {
         :guest_os             => guest_os,
         :guest_os_full_name   => guest_os,
         :bitness              => bitness,
-        :cpu_sockets          => cpus,
-        :cpu_cores_per_socket => 1,
+        :cpu_sockets          => cpus / cores_per_socket,
+        :cpu_cores_per_socket => cores_per_socket,
         :cpu_total_cores      => cpus,
         :memory_mb            => memory_mb,
         :disk_capacity        => disk_capacity,

--- a/app/models/manageiq/providers/vmware/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/inventory/parser/cloud_manager.rb
@@ -30,13 +30,15 @@ class ManageIQ::Providers::Vmware::Inventory::Parser::CloudManager < ManageIQ::P
   def vms
     collector.vms.each do |vm|
       parsed_vm = persister.vms.find_or_build(vm[:vm].id).assign_attributes(
-        :uid_ems             => vm[:vm].id,
-        :name                => vm[:vm].name,
-        :hostname            => vm[:hostname],
-        :vendor              => 'vmware',
-        :raw_power_state     => vm[:vm].status,
-        :orchestration_stack => persister.orchestration_stacks.lazy_find(vm[:vm].vapp_id),
-        :snapshots           => []
+        :uid_ems                => vm[:vm].id,
+        :name                   => vm[:vm].name,
+        :hostname               => vm[:hostname],
+        :vendor                 => 'vmware',
+        :raw_power_state        => vm[:vm].status,
+        :orchestration_stack    => persister.orchestration_stacks.lazy_find(vm[:vm].vapp_id),
+        :snapshots              => [],
+        :cpu_hot_add_enabled    => vm[:vm].cpu_hot_add,
+        :memory_hot_add_enabled => vm[:vm].memory_hot_add,
       )
 
       if (resp = vm[:snapshot]) && (snapshot = resp.fetch_path(:body, :Snapshot))
@@ -54,20 +56,23 @@ class ManageIQ::Providers::Vmware::Inventory::Parser::CloudManager < ManageIQ::P
         :guest_os             => vm[:vm].operating_system,
         :guest_os_full_name   => vm[:vm].operating_system,
         :bitness              => vm[:vm].operating_system =~ /64-bit/ ? 64 : 32,
-        :cpu_sockets          => vm[:vm].cpu,
-        :cpu_cores_per_socket => 1,
+        :cpu_sockets          => vm[:vm].cpu / vm[:vm].cores_per_socket,
+        :cpu_cores_per_socket => vm[:vm].cores_per_socket,
         :cpu_total_cores      => vm[:vm].cpu,
         :memory_mb            => vm[:vm].memory,
         :disk_capacity        => vm[:vm].hard_disks.inject(0) { |sum, x| sum + x.values[0] } * 1.megabyte,
       )
 
-      vm[:vm].disks.all.select { |d| hdd? d.bus_type }.map do |disk|
-        persister.disks.find_or_build_by(:hardware => hardware, :device_name => disk.name).assign_attributes(
-          :device_type     => 'disk',
+      vm[:vm].disks.all.select { |d| hdd? d.bus_type }.each_with_index do |disk, i|
+        device_name = "Disk #{i}"
+        persister.disks.find_or_build_by(:hardware => hardware, :device_name => device_name).assign_attributes(
+          :device_name     => device_name,
+          :device_type     => "disk",
+          :disk_type       => controller_description(disk.bus_sub_type).sub(' controller', ''),
           :controller_type => controller_description(disk.bus_sub_type),
           :size            => disk.capacity * 1.megabyte,
-          :location        => "#{vm[:vm].id}-#{disk.id}",
-          :filename        => "#{vm[:vm].id}-#{disk.id}",
+          :location        => "#{vm[:vm].id}/#{disk.address}/#{disk.address_on_parent}/#{disk.id}",
+          :filename        => "Disk #{i}"
         )
       end
 

--- a/app/models/manageiq/providers/vmware/inventory_collection_default/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/inventory_collection_default/cloud_manager.rb
@@ -45,6 +45,8 @@ class ManageIQ::Providers::Vmware::InventoryCollectionDefault::CloudManager < Ma
           hardware
           operating_system
           orchestration_stack
+          cpu_hot_add_enabled
+          memory_hot_add_enabled
         )
       }
 
@@ -91,6 +93,7 @@ class ManageIQ::Providers::Vmware::InventoryCollectionDefault::CloudManager < Ma
         :inventory_object_attributes => %i(
           device_name
           device_type
+          disk_type
           controller_type
           size
           location

--- a/app/models/manageiq/providers/vmware/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/network_manager/refresh_parser.rb
@@ -311,7 +311,10 @@ module ManageIQ::Providers
     # managed, therefore we must handle errors by ourselves.
     def fetch_network_configurations_for_vapp(vapp_id)
       begin
-        data = @connection.get_vapp(vapp_id).body
+        # fog-vcloud-director now uses a more user-friendly parser that yields vApp instance. However, vapp networking
+        # is not parsed there yet so we need to fallback to basic ToHashDocument parser that only converts XML to hash.
+        # TODO(miha-plesko): update default parser to do the XML parsing for us.
+        data = @connection.get_vapp(vapp_id, :parser => Fog::ToHashDocument).body
       rescue Fog::VcloudDirector::Errors::ServiceError => e
         $vcloud_log.error("#{log_header} could not fetch network configuration for vapp #{vapp_id}: #{e}")
         return []

--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency("fog-vcloud-director", ["~> 0.1.10"])
+  s.add_dependency("fog-vcloud-director", ["~> 0.2.0"])
   s.add_dependency "fog-core",                "~>1.40"
   s.add_dependency "vmware_web_service",      "~>0.2.9"
   s.add_dependency "rbvmomi",                 "~>1.11.3"

--- a/spec/models/manageiq/providers/vmware/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/refresher_spec.rb
@@ -199,29 +199,31 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
   def assert_specific_vm_powered_on
     v = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => 'spec1-vm1')
     expect(v).to have_attributes(
-      :template              => false,
-      :ems_ref               => 'vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2',
-      :ems_ref_obj           => nil,
-      :uid_ems               => 'vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2',
-      :vendor                => 'vmware',
-      :power_state           => 'on',
-      :location              => 'unknown',
-      :tools_status          => nil,
-      :boot_time             => nil,
-      :standby_action        => nil,
-      :connection_state      => nil,
-      :cpu_affinity          => nil,
-      :memory_reserve        => nil,
-      :memory_reserve_expand => nil,
-      :memory_limit          => nil,
-      :memory_shares         => nil,
-      :memory_shares_level   => nil,
-      :cpu_reserve           => nil,
-      :cpu_reserve_expand    => nil,
-      :cpu_limit             => nil,
-      :cpu_shares            => nil,
-      :cpu_shares_level      => nil,
-      :hostname              => 'spec1-vm1'
+      :template               => false,
+      :ems_ref                => 'vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2',
+      :ems_ref_obj            => nil,
+      :uid_ems                => 'vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2',
+      :vendor                 => 'vmware',
+      :power_state            => 'on',
+      :location               => 'unknown',
+      :tools_status           => nil,
+      :boot_time              => nil,
+      :standby_action         => nil,
+      :connection_state       => nil,
+      :cpu_affinity           => nil,
+      :memory_reserve         => nil,
+      :memory_reserve_expand  => nil,
+      :memory_limit           => nil,
+      :memory_shares          => nil,
+      :memory_shares_level    => nil,
+      :memory_hot_add_enabled => true,
+      :cpu_reserve            => nil,
+      :cpu_reserve_expand     => nil,
+      :cpu_limit              => nil,
+      :cpu_shares             => nil,
+      :cpu_shares_level       => nil,
+      :cpu_hot_add_enabled    => true,
+      :hostname               => 'spec1-vm1'
     )
 
     expect(v.ext_management_system).to eq(@ems)
@@ -244,7 +246,7 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
       :virtual_hw_version   => nil,
       :guest_os             => 'Microsoft Windows Server 2016 (64-bit)',
       :guest_os_full_name   => 'Microsoft Windows Server 2016 (64-bit)',
-      :cpu_sockets          => 1,
+      :cpu_sockets          => 2,
       :bios                 => nil,
       :bios_location        => nil,
       :time_sync            => nil,
@@ -259,8 +261,8 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
       :number_of_nics       => nil,
       :cpu_usage            => nil,
       :memory_usage         => nil,
-      :cpu_cores_per_socket => 1,
-      :cpu_total_cores      => 1,
+      :cpu_cores_per_socket => 4,
+      :cpu_total_cores      => 8,
       :vmotion_enabled      => nil,
       :disk_free_space      => nil,
       :disk_capacity        => 10_737_418_240,
@@ -272,10 +274,13 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
 
     expect(v.hardware.disks.size).to eq(1)
     expect(v.hardware.disks.first).to have_attributes(
-      :device_name     => 'Hard disk 1',
+      :device_name     => 'Disk 0',
       :device_type     => 'disk',
+      :disk_type       => 'LSI Logic SAS SCSI',
       :controller_type => 'LSI Logic SAS SCSI controller',
       :size            => 10_737_418_240,
+      :location        => 'vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/0/0/2000',
+      :filename        => 'Disk 0'
     )
     expect(v.hardware.guest_devices.size).to eq(0)
     expect(v.hardware.nics.size).to eq(0)
@@ -358,10 +363,13 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
 
     expect(v.hardware.disks.size).to eq(1)
     expect(v.hardware.disks.first).to have_attributes(
-      :device_name     => 'Hard disk 1',
+      :device_name     => 'Disk 0',
       :device_type     => 'disk',
+      :disk_type       => 'Paravirtual SCSI',
       :controller_type => 'Paravirtual SCSI controller',
       :size            => 17_179_869_184,
+      :location        => 'vm-aaf94123-cbf9-4de9-841c-41dd41ac310e/0/0/2000',
+      :filename        => 'Disk 0'
     )
     expect(v.hardware.guest_devices.size).to eq(0)
     expect(v.hardware.nics.size).to eq(0)

--- a/spec/vcr_cassettes/manageiq/providers/vmware/cloud_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/vmware/cloud_manager/refresher.yml
@@ -590,7 +590,7 @@ http_interactions:
                             <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Description>Number of Virtual CPUs</rasd:Description>
-                            <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
+                            <rasd:ElementName>8 virtual CPU(s)</rasd:ElementName>
                             <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:InstanceID>4</rasd:InstanceID>
                             <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
@@ -601,9 +601,10 @@ http_interactions:
                             <rasd:Reservation>0</rasd:Reservation>
                             <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:ResourceType>3</rasd:ResourceType>
-                            <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>8</rasd:VirtualQuantity>
                             <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Weight>0</rasd:Weight>
+                            <vmw:CoresPerSocket ovf:required="false">4</vmw:CoresPerSocket>
                             <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
                         </ovf:Item>
                         <ovf:Item ns13:type="application/vnd.vmware.vcloud.rasdItem+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/memory">
@@ -686,8 +687,8 @@ http_interactions:
                     <VAppScopedLocalId>c209ef9f-25c8-4fe5-a7f4-c522fbd45ea7</VAppScopedLocalId>
                     <VmCapabilities href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
                         <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
-                        <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
-                        <CpuHotAddEnabled>false</CpuHotAddEnabled>
+                        <MemoryHotAddEnabled>true</MemoryHotAddEnabled>
+                        <CpuHotAddEnabled>true</CpuHotAddEnabled>
                     </VmCapabilities>
                     <StorageProfile href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/b652f213-33aa-4c1f-8f30-ea2919a30843" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
                 </Vm>
@@ -1874,7 +1875,7 @@ http_interactions:
                             <rasd:ConfigurationName xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:ConsumerVisibility xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Description>Number of Virtual CPUs</rasd:Description>
-                            <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
+                            <rasd:ElementName>8 virtual CPU(s)</rasd:ElementName>
                             <rasd:Generation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:InstanceID>4</rasd:InstanceID>
                             <rasd:Limit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
@@ -1885,9 +1886,10 @@ http_interactions:
                             <rasd:Reservation>0</rasd:Reservation>
                             <rasd:ResourceSubType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:ResourceType>3</rasd:ResourceType>
-                            <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>8</rasd:VirtualQuantity>
                             <rasd:VirtualQuantityUnits xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
                             <rasd:Weight>0</rasd:Weight>
+                            <vmw:CoresPerSocket ovf:required="false">4</vmw:CoresPerSocket>
                             <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
                         </ovf:Item>
                         <ovf:Item ns13:type="application/vnd.vmware.vcloud.rasdItem+xml" ns13:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/virtualHardwareSection/memory">
@@ -1970,8 +1972,8 @@ http_interactions:
                     <VAppScopedLocalId>c209ef9f-25c8-4fe5-a7f4-c522fbd45ea7</VAppScopedLocalId>
                     <VmCapabilities href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
                         <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
-                        <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
-                        <CpuHotAddEnabled>false</CpuHotAddEnabled>
+                        <MemoryHotAddEnabled>true</MemoryHotAddEnabled>
+                        <CpuHotAddEnabled>true</CpuHotAddEnabled>
                     </VmCapabilities>
                     <StorageProfile href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/b652f213-33aa-4c1f-8f30-ea2919a30843" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
                 </Vm>


### PR DESCRIPTION
With this commit we enhance vCloud's inventoring (both legacy and graph)
to now fetch following additional information for VM:

- vm.cores_per_socket
- vm.cpu_hot_add_enable
- vm.memory_hot_add_enable

Also, disk parsing is enhanched to better support VM reconfiguring:

- `disk.device_name` is updated to "Disk {idx}" to match what is displayed on vCloud itself
- `disk.disk_type` is added and reflects controller type disk is connected to
- `disk.location` now contains "{vm_id}/{disk_addr}/{addr_on_parent}/{disk_id}"
- `disk.filename` now contains same as device_name

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1572086

@miq-bot add_label enhancement,gaprindashvili/yes
@miq-bot assign @agrare