### PR TITLE
Set the root folder's parent and set hidden/is_default for folders and resource pools

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/inventory_collections.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/inventory_collections.rb
@@ -105,6 +105,26 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::InventoryCollections
       relationships(:resource_pool, :ems_metadata, "ResourcePool", :vm_resource_pools, extra_attributes)
     end
 
+    def root_folder_relationship(extra_attributes = {})
+      root_folder_save_block = lambda do |ems, inventory_collection|
+        folder_inv_collection = inventory_collection.dependency_attributes[:ems_folders]&.first
+        return if folder_inv_collection.nil?
+
+        # All folders must have a parent except for the root folder
+        root_folder_obj = folder_inv_collection.data.detect { |obj| obj.data[:parent].nil? }
+        return if root_folder_obj.nil?
+
+        root_folder = folder_inv_collection.model_class.find(root_folder_obj.id)
+        root_folder.with_relationship_type(:ems_metadata) { root_folder.parent = ems }
+      end
+
+      attributes = {
+        :association       => :root_folder_relationships,
+        :custom_save_block => root_folder_save_block,
+      }
+      attributes.merge!(extra_attributes)
+    end
+
     def relationships(relationship_key, relationship_type, parent_type, association, extra_attributes = {})
       relationship_save_block = lambda do |_ems, inventory_collection|
         parents  = Hash.new { |h, k| h[k] = {} }

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -99,12 +99,19 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
     persister.ems_folders.targeted_scope << object._ref
     return if kind == "leave"
 
+    # "Hidden" folders are folders which exist in the VIM API but are not shown
+    # on the vSphere UI.  These folders are the root folder above the datacenters
+    # named "Datacenters", and the 4 child folders of each datacenter (datastore,
+    # host, network, vm)
+    hidden = props[:parent].nil? || props[:parent].kind_of?(RbVmomi::VIM::Datacenter)
+
     folder_hash = {
       :ems_ref => object._ref,
       :uid_ems => object._ref,
       :type    => "EmsFolder",
       :name    => CGI.unescape(props[:name]),
       :parent  => lazy_find_managed_object(props[:parent]),
+      :hidden  => hidden,
     }
 
     persister.ems_folders.build(folder_hash)

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -187,12 +187,28 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
     persister.resource_pools.targeted_scope << object._ref
     return if kind == "leave"
 
+    parent = props[:parent]
+
+    # Default resource pools are ones whose parent is a Cluster or a Host,
+    # resource pools which show up on the vSphere UI all have resource pools
+    # as parents.
+    is_default = parent && !parent.kind_of?(RbVmomi::VIM::ResourcePool)
+    name       = if is_default
+                   cached_parent = cache.find(parent) if parent
+                   parent_model = persister.vim_class_to_collection(parent).base_class_name
+
+                   "Default for #{Dictionary.gettext(parent_model, :type => :model, :notfound => :titleize)} #{cached_parent[:name]}"
+                 else
+                   CGI.unescape(props[:name])
+                 end
+
     rp_hash = {
-      :ems_ref => object._ref,
-      :uid_ems => object._ref,
-      :name    => CGI.unescape(props[:name]),
-      :vapp    => object.kind_of?(RbVmomi::VIM::VirtualApp),
-      :parent  => lazy_find_managed_object(props[:parent]),
+      :ems_ref    => object._ref,
+      :uid_ems    => object._ref,
+      :name       => name,
+      :vapp       => object.kind_of?(RbVmomi::VIM::VirtualApp),
+      :parent     => lazy_find_managed_object(parent),
+      :is_default => is_default,
     }
 
     parse_resource_pool_memory_allocation(rp_hash, props)

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
@@ -24,6 +24,12 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister < ManagerR
         :dependency_attributes => {:vms_and_templates => [collections[:vms_and_templates]]},
       )
     )
+
+    add_inventory_collection(
+      default_inventory_collections.root_folder_relationship(
+        :dependency_attributes => {:ems_folders => [collections[:ems_folders]]},
+      )
+    )
   end
 
   def default_inventory_collections

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -229,6 +229,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         :ems_ref => "group-d1",
         :name    => "Datacenters",
         :uid_ems => "group-d1",
+        :hidden  => true,
       )
 
       expect(folder.parent).to eq(ems)

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -231,7 +231,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         :uid_ems => "group-d1",
       )
 
-      expect(folder.parent).to be_nil
+      expect(folder.parent).to eq(ems)
       expect(folder.children.count).to eq(4)
       expect(folder.children.map(&:name)).to match_array(%w(DC0 DC1 DC2 DC3))
     end

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -311,8 +311,9 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         :memory_reserve_expand => true,
         :memory_shares         => 163_840,
         :memory_shares_level   => "normal",
-        :name                  => "Resources",
+        :name                  => "Default for Cluster / Deployment Role DC0_C1",
         :vapp                  => false,
+        :is_default            => true,
       )
 
       expect(resource_pool.parent.ems_ref).to eq("domain-c91")


### PR DESCRIPTION
Set the root folder's parent to be the EMS, this has to be done in its
own inventory_collection because there is no inventory object to track
the EMS.