### PR TITLE
Shift fog-vcloud-director gem version

### DIFF
--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency("fog-vcloud-director", ["~> 0.2.0"])
+  s.add_dependency("fog-vcloud-director", ["~> 0.2.1"])
   s.add_dependency "fog-core",                "~>1.40"
   s.add_dependency "vmware_web_service",      "~>0.2.10"
   s.add_dependency "rbvmomi",                 "~>1.11.3"


### PR DESCRIPTION
With this commit we requiore fog-vcloud-director gem v0.2.1 over v0.2.0 to include important bugfix that prevented gem from being required on some platforms.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1572086

@miq-bot assign @agrare
@miq-bot add_label enhancement,gaprindashvili/yes