### PR TITLE
Fixes ProvisionWorkflow#available_vlans_and_hosts

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
@@ -134,13 +134,15 @@ class ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow < ManageIQ::P
     # dvportgroups key-value transformed
     if options[:dvs]
       dvlans      = Hash.new { |h, k| h[k] = [] }
-      shared_lans = Lan.distinct.select(:id, :switch_id, :name)
-                       .includes(:switch)
-                       .joins(:switch => :host_switches)
-                       .where(:host_switches => {:host_id => hosts.map(&:id)})
-                       .merge(Switch.shareable)
+      unless hosts.nil?
+        shared_lans = Lan.distinct.select(:id, :switch_id, :name)
+                         .includes(:switch)
+                         .joins(:switch => :host_switches)
+                         .where(:host_switches => {:host_id => hosts.map(&:id)})
+                         .merge(Switch.shareable)
 
-      shared_lans.each { |l| dvlans[l.name] << l.switch.name }
+        shared_lans.each { |l| dvlans[l.name] << l.switch.name }
+      end
       dvlans.each do |l, v|
         vlans["dvs_#{l}"] = "#{l} (#{v.sort.uniq.join('/')})"
       end

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_workflow_spec.rb
@@ -28,6 +28,25 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
     end
   end
 
+  describe "#init_from_dialog" do
+    let(:user)     { FactoryGirl.create(:user_with_email, :role => 'super_administrator', :password => 'x') }
+    let(:ems)      { FactoryGirl.create(:ems_vmware_with_authentication) }
+    let(:template) { FactoryGirl.create(:template_vmware, :ext_management_system => ems) }
+    let(:req)      { FactoryGirl.create(:miq_provision_request, :requester => user, :source => template) }
+    let(:options)  { req.get_options.merge(:org_controller=>"vm") }
+
+    subject        { req.workflow(options) }
+
+    before do
+      EvmSpecHelper.create_guid_miq_server_zone
+      MiqDialog.seed
+    end
+
+    it "does not raise an error" do
+      expect { subject.init_from_dialog(options) }.to_not raise_error
+    end
+  end
+
   describe "#make_request" do
     let(:alt_user) { FactoryGirl.create(:user_with_group) }
     it "creates and update a request" do


### PR DESCRIPTION
When the `super` form of this method returns `nil` for hosts, the `.map(&:id)` call would no work properly.

In previous forms, `hosts` had `to_miq_a`, which will effectively run an `Array.wrap` around the object.  I figured moving away from specialty code for this was a better option moving forward, so I skipped that an opted for an `unless` check instead.

The tests added in this PR mimic what is done in `manageiq-ui-classic`, which was the original "canary in the coal mine" that exposed this error.

Links
-----
* PR causing the error:  https://github.com/ManageIQ/manageiq-providers-vmware/pull/249
* Reported here:  https://gitter.im/ManageIQ/manageiq/ui?at=5aff42acbd10f34a68135465
* Example failure:  https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/380758498#L2944