### PR TITLE
Reconfigure VM network connectivity aka. NICs

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm.rb
@@ -12,6 +12,7 @@ class ManageIQ::Providers::Vmware::CloudManager::Vm < ManageIQ::Providers::Cloud
   supports :reconfigure_disksize do
     unsupported_reason_add(:reconfigure_disksize, 'Cannot resize disks of a VM with snapshots') unless snapshots.empty?
   end
+  supports :reconfigure_network_adapters
 
   def provider_object(connection = nil)
     connection ||= ext_management_system.connect

--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency("fog-vcloud-director", ["~> 0.2.1"])
+  s.add_dependency("fog-vcloud-director", ["~> 0.2.2"])
   s.add_dependency "fog-core",                "~>1.40"
   s.add_dependency "vmware_web_service",      "~>0.2.10"
   s.add_dependency "rbvmomi",                 "~>1.11.3"

--- a/spec/models/manageiq/providers/vmware/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager_spec.rb
@@ -191,6 +191,10 @@ describe ManageIQ::Providers::Vmware::CloudManager do
       end
     end
 
+    it 'supports reconfigure_network_adapters' do
+      expect(vm.supports_reconfigure_network_adapters?).to be_truthy
+    end
+
     it '.vm_reconfigure' do
       expect(connection).to receive(:get_vapp).with(vm.ems_ref, :parser => 'xml').and_return(double(:body => vm_xml))
       expect(connection).to receive(:post_reconfigure_vm).with(vm.ems_ref, vm_xml, 'fog-options').and_return(double(:body => nil))

--- a/spec/models/manageiq/providers/vmware/network_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/network_manager/refresher_spec.rb
@@ -63,7 +63,7 @@ describe ManageIQ::Providers::Vmware::NetworkManager::Refresher do
 
     def assert_specific_subnet
       expect(vdc_subnet).to have_attributes(
-        :name                           => 'subnet-RedHat external network',
+        :name                           => 'RedHat external network',
         :cidr                           => '10.12.0.1/16',
         :status                         => nil,
         :dhcp_enabled                   => nil,
@@ -88,7 +88,7 @@ describe ManageIQ::Providers::Vmware::NetworkManager::Refresher do
 
     def assert_specific_network_port
       expect(net_port).to have_attributes(
-        :name                  => 'RHEL7-001#NIC#0',
+        :name                  => 'NIC#0',
         :mac_address           => '00:50:56:01:00:09',
         :device_type           => 'VmOrTemplate',
         :source                => 'refresh',
@@ -151,7 +151,7 @@ describe ManageIQ::Providers::Vmware::NetworkManager::Refresher do
 
     def assert_specific_subnet
       expect(vapp_subnet).to have_attributes(
-        :name                  => 'subnet-vApp network test (RHEL7-web-002)',
+        :name                  => 'vApp network test (RHEL7-web-002)',
         :cidr                  => '192.168.2.1/24',
         :dhcp_enabled          => true,
         :gateway               => '192.168.2.1',
@@ -167,7 +167,7 @@ describe ManageIQ::Providers::Vmware::NetworkManager::Refresher do
 
     def assert_specific_network_port
       expect(net_port).to have_attributes(
-        :name                  => 'vAppRHEL7-w-002#NIC#0',
+        :name                  => 'NIC#0',
         :mac_address           => '00:50:56:01:00:0c',
         :device_type           => 'VmOrTemplate',
         :source                => 'refresh',


### PR DESCRIPTION
With this commit we support reconfiguration of VM's network adapters - since UI only supports add and remove operations, we focus on these as well.

Turns out vCloud's cloud_networks (vApp networks) were not hooked to corresponding orchestration_stack (vApp) yet so we needed to update the parser. Also, we modify parser to omit `subnet-` prefix from cloud_subnet names because it looks strange on the reconfigure UI.

Fog version is shifted to 0.2.2 since only this version supports NIC reconfiguration.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1572086
Needed for: https://github.com/ManageIQ/manageiq-ui-classic/pull/3972

Video: http://x.k00.fr/nicreconfigure

@miq-bot assign @agrare
@miq-bot add_label enhancement,gaprindashvili/yes