### PR TITLE
Recognize deployed vApp even if not powered on

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/orchestration_stack/status.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/orchestration_stack/status.rb
@@ -1,9 +1,9 @@
 class ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack::Status < ::OrchestrationStack::Status
   def succeeded?
-    status.casecmp("on") == 0
+    %w(on off suspended).include?(status.to_s.downcase)
   end
 
   def failed?
-    status.casecmp("failed_creation") == 0
+    %w(failed_creation).include?(status.to_s.downcase)
   end
 end

--- a/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_stack_spec.rb
@@ -65,12 +65,35 @@ describe ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack do
 
   describe 'stack status' do
     context '#raw_status and #raw_exists' do
-      it 'gets the stack status and reason' do
-        allow(the_raw_stack).to receive(:stack_status).and_return('on')
+      it 'gets the stack status and reason - on' do
+        allow(the_raw_stack).to receive(:human_status).and_return('on')
+        expect(orchestration_stack.raw_status).to have_attributes(:status => 'on', :reason => nil)
+        expect(orchestration_stack.raw_status.succeeded?).to be_truthy
+        expect(orchestration_stack.raw_status.failed?).to be_falsey
+        expect(orchestration_stack.raw_exists?).to be_truthy
+      end
 
-        rstatus = orchestration_stack.raw_status
-        expect(rstatus).to have_attributes(:status => 'on', :reason => nil)
+      it 'gets the stack status and reason - off' do
+        allow(the_raw_stack).to receive(:human_status).and_return('off')
+        expect(orchestration_stack.raw_status).to have_attributes(:status => 'off', :reason => nil)
+        expect(orchestration_stack.raw_status.succeeded?).to be_truthy
+        expect(orchestration_stack.raw_status.failed?).to be_falsey
+        expect(orchestration_stack.raw_exists?).to be_truthy
+      end
 
+      it 'gets the stack status and reason - suspended' do
+        allow(the_raw_stack).to receive(:human_status).and_return('suspended')
+        expect(orchestration_stack.raw_status).to have_attributes(:status => 'suspended', :reason => nil)
+        expect(orchestration_stack.raw_status.succeeded?).to be_truthy
+        expect(orchestration_stack.raw_status.failed?).to be_falsey
+        expect(orchestration_stack.raw_exists?).to be_truthy
+      end
+
+      it 'gets the stack status and reason - failed_creation' do
+        allow(the_raw_stack).to receive(:human_status).and_return('failed_creation')
+        expect(orchestration_stack.raw_status).to have_attributes(:status => 'failed_creation', :reason => nil)
+        expect(orchestration_stack.raw_status.succeeded?).to be_falsy
+        expect(orchestration_stack.raw_status.failed?).to be_truthy
         expect(orchestration_stack.raw_exists?).to be_truthy
       end
 


### PR DESCRIPTION
When user opts-in *not* to power-on vApp upon instantiation, it got provisioned into 'off' status while MIQ only recognizes 'on' status as successful provisioning result. With this commit we tell MIQ to recognize 'on', 'off' and 'suspended' statuses as provisioning success. UI in Services -> My Services then properly displays VMs when vApp gets provisioned.

![capture](https://user-images.githubusercontent.com/8102426/40426579-baafd306-5e9b-11e8-8239-77d95a025a6d.PNG)

Screenshot above ^ shows how vApp provisioning now results in a populated service details. If status wasn't matched correctly then everything was empty here.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1581708

@miq-bot assign @agrare
@miq-bot add_label enhancement,gaprindashvili/yes