### PR TITLE
[WIP] Parse the key and dev_type for guest devices

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/host_system.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/host_system.rb
@@ -167,10 +167,11 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
         name = uid = pnic.device
 
         persister.guest_devices.build(
+          :type            => "NetworkAdapter",
           :hardware        => hardware,
           :uid_ems         => uid,
           :device_name     => name,
-          :device_type     => 'ethernet',
+          :device_type     => pnic.class.wsdl_name,
           :location        => pnic.pci,
           :present         => true,
           :controller_type => 'ethernet',
@@ -205,10 +206,11 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
                           end
 
         persister.guest_devices.build(
+          :type              => "StorageAdapter",
           :hardware          => hardware,
           :uid_ems           => uid,
           :device_name       => name,
-          :device_type       => 'storage',
+          :device_type       => hba.class.wsdl_name,
           :present           => true,
           :iscsi_name        => iscsi_name,
           :iscsi_alias       => iscsi_alias,

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -245,14 +245,16 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
         start_connected = device.connectable.startConnected
 
         guest_device_hash = {
+          :type            => "NetworkAdapter",
           :hardware        => hardware,
           :uid_ems         => uid,
           :device_name     => name,
-          :device_type     => 'ethernet',
+          :device_type     => device.class.wsdl_name,
           :controller_type => 'ethernet',
           :present         => present,
           :start_connected => start_connected,
           :address         => address,
+          :key             => device.key,
           :lan             => parse_virtual_machine_guest_device_lan(vm, device),
         }
 

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -157,8 +157,27 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
 
       hardware = persister.hardwares.build(hardware_hash)
 
+      parse_virtual_machine_controllers(vm, hardware, props)
       parse_virtual_machine_disks(vm, hardware, props)
       parse_virtual_machine_guest_devices(vm, hardware, props)
+    end
+
+    def parse_virtual_machine_controllers(_vm, hardware, props)
+      devices = props.fetch_path(:config, :hardware, :device).to_a
+      devices.each do |device|
+        next unless device.kind_of?(RbVmomi::VIM::VirtualController)
+
+        persister.guest_devices.build(
+          :type            => "Controller",
+          :hardware        => hardware,
+          :uid_ems         => device.key,
+          :device_type     => device.class.wsdl_name,
+          :device_name     => device.deviceInfo.label,
+          :location        => device.busNumber,
+          :controller_type => 'controller',
+          :key             => device.key,
+        )
+      end
     end
 
     def parse_virtual_machine_disks(_vm, hardware, props)
@@ -196,7 +215,10 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
           :device_type     => device_type,
           :controller_type => controller_type,
           :present         => true,
-          :location        => "#{controller.busNumber}:#{device.unitNumber}"
+          :location        => "#{controller.busNumber}:#{device.unitNumber}",
+          :key             => device.key,
+          :unit_number     => device.unitNumber,
+          :controller      => persister.guest_devices.lazy_find(:hardware => hardware, :uid_ems => controller.key),
         }
 
         case backing

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -564,9 +564,10 @@ module ManageIQ::Providers
             name = uid = data['device']
 
             new_result = {
+              :type            => "NetworkAdapter",
               :uid_ems         => uid,
               :device_name     => name,
-              :device_type     => 'ethernet',
+              :device_type     => data.xsiType,
               :location        => data['pci'],
               :present         => true,
               :controller_type => 'ethernet',
@@ -587,9 +588,10 @@ module ManageIQ::Providers
             chap_auth_enabled = data.fetch_path('authenticationProperties', 'chapAuthEnabled')
 
             new_result = {
+              :type              => "StorageAdapter",
               :uid_ems           => uid,
               :device_name       => name,
-              :device_type       => 'storage',
+              :device_type       => data.xsiType,
               :present           => true,
 
               :iscsi_name        => data['iScsiName'].blank? ? nil : data['iScsiName'],
@@ -1039,13 +1041,15 @@ module ManageIQ::Providers
           lan = lan_uids[lan_uid] unless lan_uid.nil? || lan_uids.nil?
 
           new_result = {
+            :type            => "NetworkAdapter",
             :uid_ems         => uid,
             :device_name     => name,
-            :device_type     => 'ethernet',
+            :device_type     => data.xsiType,
             :controller_type => 'ethernet',
             :present         => data.fetch_path('connectable', 'connected').to_s.downcase == 'true',
             :start_connected => data.fetch_path('connectable', 'startConnected').to_s.downcase == 'true',
             :address         => address,
+            :key             => data['key'],
           }
           new_result[:lan] = lan unless lan.nil?
 

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -901,8 +901,8 @@ module ManageIQ::Providers
 
           host_mor = runtime['host']
           hardware = vm_inv_to_hardware_hash(vm_inv)
-          hardware[:disks] = vm_inv_to_disk_hashes(vm_inv, storage_uids, storage_profile_by_disk_mor)
           hardware[:guest_devices], guest_device_uids[mor] = vm_inv_to_guest_device_hashes(vm_inv, lan_uids[host_mor])
+          hardware[:disks] = vm_inv_to_disk_hashes(vm_inv, storage_uids, guest_device_uids[mor], storage_profile_by_disk_mor)
           hardware[:networks] = vm_inv_to_network_hashes(vm_inv, guest_device_uids[mor])
           uid = hardware[:bios]
 
@@ -1026,6 +1026,25 @@ module ManageIQ::Providers
         result_uids = {}
         return result, result_uids if inv.nil?
 
+        inv.to_miq_a.each do |data|
+          next unless data.xsiType =~ /Controller/
+
+          uid = data['key']
+
+          new_result = {
+            :type            => "Controller",
+            :uid_ems         => uid,
+            :device_name     => data.fetch_path('deviceInfo', 'label'),
+            :device_type     => data.xsiType,
+            :location        => data['busNumber'],
+            :controller_type => 'controller',
+            :key             => uid,
+          }
+
+          result << new_result
+          result_uids[uid] = new_result
+        end
+
         inv.to_miq_a.find_all { |d| d.key?('macAddress') }.each do |data|
           uid = address = data['macAddress']
           name = data.fetch_path('deviceInfo', 'label')
@@ -1059,7 +1078,7 @@ module ManageIQ::Providers
         return result, result_uids
       end
 
-      def self.vm_inv_to_disk_hashes(inv, storage_uids, storage_profile_by_disk_mor = {})
+      def self.vm_inv_to_disk_hashes(inv, storage_uids, guest_device_uids = {}, storage_profile_by_disk_mor = {})
         vm_mor = inv['MOR']
         inv = inv.fetch_path('config', 'hardware', 'device')
 
@@ -1098,7 +1117,10 @@ module ManageIQ::Providers
             :controller_type => controller_type,
             :present         => true,
             :filename        => backing['fileName'] || backing['deviceName'],
-            :location        => controller ? "#{controller['busNumber']}:#{device['unitNumber']}" : nil
+            :location        => controller ? "#{controller['busNumber']}:#{device['unitNumber']}" : nil,
+            :controller      => guest_device_uids[device['controllerKey']],
+            :key             => device['key'],
+            :unit_number     => device['unitNumber'],
           }
 
           if device_type == 'disk'

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -488,15 +488,26 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         :type              => "ManageIQ::Providers::Vmware::InfraManager::HostVirtualSwitch",
       )
 
-      vnic = host.hardware.guest_devices.find_by(:uid_ems => "vmnic0")
+      vnic = host.hardware.network_adapters.find_by(:uid_ems => "vmnic0")
       expect(vnic).not_to be_nil
       expect(vnic).to have_attributes(
         :device_name     => "vmnic0",
-        :device_type     => "ethernet",
+        :device_type     => "PhysicalNic",
         :location        => "03:00.0",
         :controller_type => "ethernet",
         :uid_ems         => "vmnic0",
         # TODO: :switch          => switch,
+      )
+
+      hba = host.hardware.storage_adapters.first
+      expect(hba).not_to be_nil
+      expect(hba).to have_attributes(
+        :device_name     => "vmhba0",
+        :device_type     => "HostBlockHba",
+        :location        => "00:1f.1",
+        :controller_type => "Block",
+        :model           => "631xESB/632xESB IDE Controller",
+        :uid_ems         => "vmhba0",
       )
     end
 
@@ -661,13 +672,14 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         :virtual_hw_version   => "07",
       )
 
-      nic = vm.hardware.guest_devices.find_by(:uid_ems => "00:50:56:ab:a2:e2")
+      nic = vm.hardware.network_adapters.find_by(:uid_ems => "00:50:56:ab:a2:e2")
       expect(nic).to have_attributes(
         :device_name     => "Network adapter 1",
-        :device_type     => "ethernet",
+        :device_type     => "VirtualE1000",
         :controller_type => "ethernet",
         :address         => "00:50:56:ab:a2:e2",
         :uid_ems         => "00:50:56:ab:a2:e2",
+        :key             => 4000,
       )
 
       expect(nic.lan).not_to be_nil

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -401,7 +401,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
       expect(ems.ems_folders.count).to eq(21)
       expect(ems.ems_folders.where(:type => "Datacenter").count).to eq(4)
       expect(ems.disks.count).to eq(512)
-      expect(ems.guest_devices.count).to eq(512)
+      expect(ems.guest_devices.count).to eq(3584)
       expect(ems.hardwares.count).to eq(512)
       expect(ems.hosts.count).to eq(32)
       expect(ems.host_operating_systems.count).to eq(32)
@@ -697,6 +697,15 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         :mode            => "persistent",
         :size            => 536_870_912,
         :start_connected => true,
+        :unit_number     => 0,
+        :key             => 2000,
+      )
+
+      expect(disk.controller).not_to be_nil
+      expect(disk.controller).to have_attributes(
+        :device_name => "SCSI controller 0",
+        :device_type => "VirtualLsiLogicSASController",
+        :uid_ems     => "1000",
       )
 
       expect(vm.ems_cluster).not_to be_nil


### PR DESCRIPTION
This parses the key and device type for guest devices, adds controller parsing, and sets the controller for disks.

Depends on: https://github.com/ManageIQ/manageiq/pull/17471, https://github.com/ManageIQ/manageiq-schema/pull/204