### PR TITLE
Bug 1518304: Don't show events tab for openstack network provider edit

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -17,6 +17,8 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
 
   has_many :snapshots, :through => :vms_and_templates
 
+  supports :configure_events
+
   before_create :ensure_managers
 
   def ensure_network_manager


### PR DESCRIPTION
Add supports entry for events configuration for vmware cloud provider.

After https://github.com/ManageIQ/manageiq-ui-classic/pull/3832 this is needed to show the event tab for the cloud and infra provider edit page.

Depends on: https://github.com/ManageIQ/manageiq/pull/17479