### PR TITLE
Don't cache host config.storageDevice

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/cache.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/cache.rb
@@ -1,134 +1,28 @@
 class ManageIQ::Providers::Vmware::InfraManager::Inventory::Cache
+  attr_reader :data
+  private     :data
+
+  delegate :[], :keys, :to => :data
+
   def initialize
     @data = Hash.new { |h, k| h[k] = {} }
   end
 
-  def insert(obj, change_set = [])
-    props = data[obj.class.wsdl_name][obj._ref] = {}
-    process_change_set(props, change_set)
-    props
+  def insert(obj, props = {})
+    data[obj.class.wsdl_name][obj._ref] = props
   end
 
   def delete(obj)
     data[obj.class.wsdl_name].delete(obj._ref)
   end
 
-  def update(obj, change_set)
+  def update(obj)
     props = data[obj.class.wsdl_name][obj._ref]
-    process_change_set(props, change_set) unless props.nil?
+    yield props
     props
   end
 
   def find(obj)
     data[obj.class.wsdl_name][obj._ref] unless obj.nil?
-  end
-
-  delegate :[], :keys, :to => :data
-
-  private
-
-  attr_reader :data
-
-  def process_change_set(props, change_set)
-    change_set.each do |prop_change|
-      process_prop_change(props, prop_change)
-    end
-  end
-
-  def process_prop_change(prop_hash, prop_change)
-    h, prop_str = hash_target(prop_hash, prop_change.name)
-    tag, key    = tag_and_key(prop_str)
-
-    case prop_change.op
-    when "add"
-      h[tag] ||= []
-      h[tag] << prop_change.val
-    when "remove", "indirectRemove"
-      if key
-        a, i = get_array_entry(h[tag], key)
-        a.delete_at(i)
-      else
-        h.delete(tag)
-      end
-    when "assign"
-      if key
-        # TODO
-        raise "Array properties aren't supported yet"
-      else
-        h[tag] = prop_change.val
-      end
-    end
-  end
-
-  def hash_target(base_hash, key_string)
-    h = base_hash
-    prop_keys = split_prop_path(key_string)
-
-    prop_keys[0...-1].each do |key|
-      key, array_key = tag_and_key(key)
-      if array_key
-        array, idx = get_array_entry(h[key], array_key)
-        raise "hashTarget: Could not traverse tree through array element #{k}[#{array_key}] in #{key_string}" unless array
-        h = array[idx]
-      else
-        h[key] ||= {}
-        h = h[key]
-      end
-    end
-
-    return h, prop_keys[-1]
-  end
-
-  def split_prop_path(prop_path)
-    path_array = []
-    in_key     = false
-    pc         = ""
-
-    prop_path.split(//).each do |c|
-      case c
-      when "."
-        unless in_key
-          path_array << pc
-          pc = ""
-          next
-        end
-      when "["
-        in_key = true
-      when "]"
-        in_key = false
-      end
-      pc << c
-    end
-
-    path_array << pc unless pc.empty?
-    path_array
-  end
-
-  def tag_and_key(prop_str)
-    return prop_str.to_sym, nil unless prop_str.include?("[")
-
-    if prop_str =~ /([^\[]+)\[([^\]]+)\]/
-      tag, key = $1, $2
-    else
-      raise "tagAndKey: malformed property string #{prop_str}"
-    end
-    key = key[1...-1] if key[0, 1] == '"' && key[-1, 1] == '"'
-    return tag.to_sym, key
-  end
-
-  def get_array_entry(array, key)
-    return nil, nil unless array.kind_of?(Array)
-
-    array.each_index do |n|
-      array_entry = array[n]
-
-      entry_key = array_entry.respond_to?("key") ? array_entry.key : array_entry
-      case entry_key
-      when RbVmomi::BasicTypes::ManagedObject
-        return array, n if entry_key._ref == key
-      else
-        return array, n if entry_key.to_s == key
-      end
-    end
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -172,11 +172,13 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
   end
 
   def process_object_update_enter(obj, change_set, _missing_set = [])
-    inventory_cache.insert(obj, change_set)
+    inventory_cache.insert(obj, process_change_set(change_set))
   end
 
   def process_object_update_modify(obj, change_set, _missing_set = [])
-    inventory_cache.update(obj, change_set)
+    inventory_cache.update(obj) do |props|
+      process_change_set(change_set, props)
+    end
   end
 
   def process_object_update_leave(obj)

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/cache_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/cache_spec.rb
@@ -4,50 +4,45 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Cache do
   let(:cache) { described_class.new }
   let(:vm) { RbVmomi::VIM.VirtualMachine(nil, "vm-123") }
   let(:vm_folder) { RbVmomi::VIM.Folder(nil, "group-v3") }
-  let(:device) do
-    [
-      RbVmomi::VIM::VirtualLsiLogicController(
-        :dynamicProperty    => [],
-        :key                => 1000,
-        :deviceInfo         => RbVmomi::VIM::Description(:label => "SCSI controller 0", :summary => "LSI Logic"),
-        :controllerKey      => 100,
-        :unitNumber         => 3,
-        :busNumber          => 0,
-        :device             => [2000],
-        :hotAddRemove       => true,
-        :sharedBus          => "noSharing",
-        :scsiCtlrUnitNumber => 7,
-      ),
-      RbVmomi::VIM::VirtualDisk(
-        :dynamicProperty => [],
-        :key             => 2000,
-        :deviceInfo      => RbVmomi::VIM::Description(:label => "Hard disk 1", :summary => "41,943,040 KB"),
-        :backing         => RbVmomi::VIM::VirtualDiskFlatVer2BackingInfo(
-          :fileName        => "[datastore] vm1/vm1.vmdk",
-          :datastore       => RbVmomi::VIM::Datastore(nil, "datastore-1"),
-          :diskMode        => "persistent",
-          :thinProvisioned => true,
-          :uuid            => "6000C294-264b-3f91-8e5c-8c2ebac1bfe8",
-        ),
-        :controllerKey   => 1000,
-        :unitNumber      => 0,
-        :capacityInKB    => 41_943_040,
-      ),
-    ]
-  end
-  let(:folder_change_set) do
-    [
-      RbVmomi::VIM::PropertyChange(:dynamicProperty => [], :name => "name", :op => "assign", :val => "vm"),
-      RbVmomi::VIM::PropertyChange(:dynamicProperty => [], :name => "childEntity", :op => "assign", :val => [vm]),
-    ]
-  end
-  let(:vm_change_set) do
-    [
-      RbVmomi::VIM::PropertyChange(:dynamicProperty => [], :name => "config.hardware.device", :op => "assign", :val => device),
-      RbVmomi::VIM::PropertyChange(:dynamicProperty => [], :name => "config.version",         :op => "assign", :val => "vmx-08"),
-      RbVmomi::VIM::PropertyChange(:dynamicProperty => [], :name => "name",                   :op => "assign", :val => "vm1"),
-      RbVmomi::VIM::PropertyChange(:dynamicProperty => [], :name => "parent",                 :op => "assign", :val => vm_folder),
-    ]
+  let(:vm_props) do
+    {
+      :config => {
+        :hardware => {
+          :device => [
+            RbVmomi::VIM::VirtualLsiLogicController(
+              :dynamicProperty    => [],
+              :key                => 1000,
+              :deviceInfo         => RbVmomi::VIM::Description(:label => "SCSI controller 0", :summary => "LSI Logic"),
+              :controllerKey      => 100,
+              :unitNumber         => 3,
+              :busNumber          => 0,
+              :device             => [2000],
+              :hotAddRemove       => true,
+              :sharedBus          => "noSharing",
+              :scsiCtlrUnitNumber => 7,
+            ),
+            RbVmomi::VIM::VirtualDisk(
+              :dynamicProperty => [],
+              :key             => 2000,
+              :deviceInfo      => RbVmomi::VIM::Description(:label => "Hard disk 1", :summary => "41,943,040 KB"),
+              :backing         => RbVmomi::VIM::VirtualDiskFlatVer2BackingInfo(
+                :fileName        => "[datastore] vm1/vm1.vmdk",
+                :datastore       => RbVmomi::VIM::Datastore(nil, "datastore-1"),
+                :diskMode        => "persistent",
+                :thinProvisioned => true,
+                :uuid            => "6000C294-264b-3f91-8e5c-8c2ebac1bfe8",
+              ),
+              :controllerKey   => 1000,
+              :unitNumber      => 0,
+              :capacityInKB    => 41_943_040,
+            ),
+          ],
+        },
+        :version  => "vmx-08",
+      },
+      :name   => "vm1",
+      :parent => vm_folder,
+    }
   end
 
   context "#insert" do
@@ -61,7 +56,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Cache do
     end
 
     context "with an initial change_set" do
-      before { cache.insert(vm, vm_change_set) }
+      before { cache.insert(vm, vm_props) }
 
       it "caches the properties" do
         props = cache["VirtualMachine"]["vm-123"]
@@ -93,129 +88,23 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Cache do
   context "#update" do
     context "of an object not in the cache" do
       it "does nothing" do
-        expect(cache.update(vm, [])).to be_nil
+        expect(cache.update(vm) { |_| }).to be_nil
       end
     end
 
     context "of an object in the cache" do
       before do
-        cache.insert(vm_folder, folder_change_set)
-        cache.insert(vm, vm_change_set)
+        cache.insert(vm, vm_props)
       end
 
       it "updates a top-level value" do
-        update_change_set = [RbVmomi::VIM::PropertyChange(:name => "name", :op => "assign", :val => "vm2")]
-        props = cache.update(vm, update_change_set)
+        props = cache.update(vm) { |p| p[:name] = "vm2" }
         expect(props[:name]).to eq("vm2")
       end
 
       it "updates a nested value" do
-        update_change_set = [RbVmomi::VIM::PropertyChange(:name => "config.version", :op => "assign", :val => "vmx-09")]
-        props = cache.update(vm, update_change_set)
+        props = cache.update(vm) { |p| p[:config][:version] = "vmx-09" }
         expect(props[:config][:version]).to eq("vmx-09")
-      end
-
-      it "updates a value in an array" do
-        update_change_set = [
-          RbVmomi::VIM::PropertyChange(
-            :dynamicProperty => [],
-            :name            => "config.hardware.device[1000].device",
-            :op              => "assign",
-            :val             => [2000, 2001]
-          ),
-          RbVmomi::VIM::PropertyChange(
-            :dynamicProperty => [],
-            :name            => "config.hardware.device[2002]",
-            :op              => "add",
-            :val             => RbVmomi::VIM::VirtualDisk(
-              :dynamicProperty => [],
-              :key             => 2001,
-              :deviceInfo      => RbVmomi::VIM::Description(:dynamicProperty => [], :label => "Hard disk 2", :summary => "16,777,216 KB"),
-              :backing         => RbVmomi::VIM::VirtualDiskFlatVer2BackingInfo(),
-              :controllerKey   => 1000,
-              :unitNumber      => 2,
-              :capacityInKB    => 16_777_216,
-            )
-          ),
-        ]
-
-        props = cache.update(vm, update_change_set)
-
-        controller = props[:config][:hardware][:device].detect { |dev| dev.key == 1000 }
-        expect(controller[:device]).to match_array([2000, 2001])
-      end
-
-      it "removes a managed entity in an array by mor" do
-        update_change_set = [
-          RbVmomi::VIM::PropertyChange(:dynamicProperty => [], :name => "childEntity[\"vm-123\"]", :op => "remove")
-        ]
-
-        props = cache.update(vm_folder, update_change_set)
-        expect(props[:childEntity]).not_to include(vm)
-      end
-
-      it "removes a data object in an array by key" do
-        update_change_set = [
-          RbVmomi::VIM.PropertyChange(:name => "config.hardware.device[1000].device", :op => "assign", :val => []),
-          RbVmomi::VIM.PropertyChange(:name => "config.hardware.device[2000]", :op => "remove"),
-          RbVmomi::VIM.PropertyChange(:name => "summary.storage.committed", :op => "assign", :val => 1422),
-          RbVmomi::VIM.PropertyChange(:name => "summary.storage.unshared", :op => "assign", :val => 0),
-        ]
-
-        props = cache.update(vm, update_change_set)
-
-        device_keys = props[:config][:hardware][:device].map(&:key)
-        expect(device_keys).not_to include(2000)
-      end
-
-      it "assigns to array with a ref as an array key" do
-        datastore = RbVmomi::VIM.Datastore(nil, "datastore-1")
-        datastore_host = [
-          RbVmomi::VIM.DatastoreHostMount(
-            :key       => RbVmomi::VIM.HostSystem(nil, "host-815"),
-            :mountInfo => RbVmomi::VIM.HostMountInfo(
-              :path       => "/vmfs/volumes/b4db3893-29a32816",
-              :accessMode => "readWrite",
-              :mounted    => true,
-              :accessible => true
-            )
-          ),
-          RbVmomi::VIM.DatastoreHostMount(
-            :key       => RbVmomi::VIM.HostSystem(nil, "host-244"),
-            :mountInfo => RbVmomi::VIM.HostMountInfo(
-              :path       => "/vmfs/volumes/b4db3893-29a32816",
-              :accessMode => "readWrite",
-              :mounted    => true,
-              :accessible => true
-            )
-          ),
-        ]
-
-        initial_change_set = [
-          RbVmomi::VIM.PropertyChange(:dynamicProperty => [], :name => "host", :op => "assign", :val => datastore_host),
-        ]
-
-        cache.insert(datastore, initial_change_set)
-
-        update_change_set = [
-          RbVmomi::VIM::PropertyChange(
-            :dynamicProperty => [],
-            :name            => "host[\"host-244\"].mountInfo",
-            :op              => "assign",
-            :val             => RbVmomi::VIM::HostMountInfo(
-              :dynamicProperty => [],
-              :path            => "/vmfs/volumes/b4db3893-29a32816",
-              :accessMode      => "readWrite",
-              :mounted         => false,
-              :accessible      => false
-            )
-          )
-        ]
-
-        props = cache.update(datastore, update_change_set)
-
-        host_mount = props[:host].detect { |h| h.key._ref == "host-244" }
-        expect(host_mount.mountInfo.props).to include(:mounted => false, :accessible => false)
       end
     end
   end

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -65,9 +65,9 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
       it "migrate a virtual machine" do
         vm = ems.vms.find_by(:ems_ref => 'vm-107')
 
-        expect(vm.host.ems_ref).to eq("host-93")
+        expect(vm.host.ems_ref).to eq("host-98")
         run_targeted_refresh(targeted_update_set([vm_migrate_object_update]))
-        expect(vm.reload.host.ems_ref).to eq("host-94")
+        expect(vm.reload.host.ems_ref).to eq("host-99")
       end
 
       it "deleting a virtual machine" do
@@ -84,7 +84,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         prev_folder  = vm.parent_blue_folder
         prev_respool = vm.parent_resource_pool
 
-        expect(prev_folder.ems_ref).to eq("group-v3")
+        expect(prev_folder.ems_ref).to eq("group-v62")
         expect(prev_folder.children).to include(vm)
 
         run_targeted_refresh(targeted_update_set(vm_new_folder_object_updates))
@@ -95,7 +95,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         expect(new_folder.ems_ref).to eq("group-v2000")
         expect(prev_folder.reload.children).not_to include(vm)
 
-        expect(new_respool.ems_ref).to eq("resgroup-92")
+        expect(new_respool.ems_ref).to eq("resgroup-111")
         expect(prev_respool.reload.children).not_to include(vm)
       end
 
@@ -129,12 +129,11 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
       end
 
       def run_targeted_refresh(update_set)
-        persister  = ems.class::Inventory::Persister::Targeted.new(ems)
-        parser     = ems.class::Inventory::Parser.new(cache, persister)
-        update_set = collector.send(:process_update_set, property_filter, update_set)
+        persister       = ems.class::Inventory::Persister::Targeted.new(ems)
+        parser          = ems.class::Inventory::Parser.new(cache, persister)
+        updated_objects = collector.send(:process_update_set, property_filter, update_set)
 
-        update_set.each { |managed_object, kind, props| parser.parse(managed_object, kind, props) }
-
+        collector.send(:parse_updates, updated_objects, parser)
         collector.send(:save_inventory, persister)
       end
 
@@ -173,7 +172,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
           :kind            => "modify",
           :obj             => RbVmomi::VIM.VirtualMachine(vim, "vm-107"),
           :changeSet       => [
-            RbVmomi::VIM.PropertyChange(:name => "summary.runtime.host", :op => "assign", :val => RbVmomi::VIM.HostSystem(vim, "host-94")),
+            RbVmomi::VIM.PropertyChange(:name => "summary.runtime.host", :op => "assign", :val => RbVmomi::VIM.HostSystem(vim, "host-99")),
           ],
           :missingSet      => [],
         )
@@ -191,7 +190,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
           RbVmomi::VIM.ObjectUpdate(
             :dynamicProperty => [],
             :kind            => "modify",
-            :obj             => RbVmomi::VIM.ClusterComputeResource(vim, "domain-c91"),
+            :obj             => RbVmomi::VIM.ClusterComputeResource(vim, "domain-c96"),
             :changeSet       => [
               RbVmomi::VIM.PropertyChange(
                 :dynamicProperty => [],
@@ -248,7 +247,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
                 :dynamicProperty => [],
                 :name            => "resourcePool",
                 :op              => "assign",
-                :val             => RbVmomi::VIM.ResourcePool(vim, "resgroup-92"),
+                :val             => RbVmomi::VIM.ResourcePool(vim, "resgroup-111"),
               ),
             ],
             :missingSet      => [],
@@ -397,20 +396,20 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
     def assert_ems
       expect(ems.api_version).to eq("5.5")
       expect(ems.uid_ems).to eq("D6EB1D64-05B2-4937-BFF6-6F77C6E647B7")
-      expect(ems.ems_clusters.count).to eq(8)
-      expect(ems.ems_folders.count).to eq(21)
-      expect(ems.ems_folders.where(:type => "Datacenter").count).to eq(4)
-      expect(ems.disks.count).to eq(512)
-      expect(ems.guest_devices.count).to eq(512)
-      expect(ems.hardwares.count).to eq(512)
-      expect(ems.hosts.count).to eq(32)
-      expect(ems.host_operating_systems.count).to eq(32)
-      expect(ems.operating_systems.count).to eq(512)
-      expect(ems.resource_pools.count).to eq(72)
+      expect(ems.ems_clusters.count).to eq(4)
+      expect(ems.ems_folders.count).to eq(11)
+      expect(ems.ems_folders.where(:type => "Datacenter").count).to eq(2)
+      expect(ems.disks.count).to eq(64)
+      expect(ems.guest_devices.count).to eq(64)
+      expect(ems.hardwares.count).to eq(64)
+      expect(ems.hosts.count).to eq(16)
+      expect(ems.host_operating_systems.count).to eq(16)
+      expect(ems.operating_systems.count).to eq(64)
+      expect(ems.resource_pools.count).to eq(12)
       expect(ems.storages.count).to eq(1)
-      expect(ems.vms_and_templates.count).to eq(512)
-      expect(ems.switches.count).to eq(36)
-      expect(ems.lans.count).to eq(76)
+      expect(ems.vms_and_templates.count).to eq(64)
+      expect(ems.switches.count).to eq(18)
+      expect(ems.lans.count).to eq(38)
     end
 
     def assert_specific_datacenter
@@ -445,9 +444,9 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         :raw_disk_mappings_supported   => true,
       )
 
-      expect(storage.hosts.count).to eq(32)
-      expect(storage.disks.count).to eq(512)
-      expect(storage.vms.count).to   eq(512)
+      expect(storage.hosts.count).to eq(16)
+      expect(storage.disks.count).to eq(64)
+      expect(storage.vms.count).to   eq(64)
     end
 
     def assert_specific_folder
@@ -462,8 +461,8 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
       )
 
       expect(folder.parent).to eq(ems)
-      expect(folder.children.count).to eq(4)
-      expect(folder.children.map(&:name)).to match_array(%w(DC0 DC1 DC2 DC3))
+      expect(folder.children.count).to eq(2)
+      expect(folder.children.map(&:name)).to match_array(%w(DC0 DC1))
     end
 
     def assert_specific_host
@@ -526,7 +525,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
     end
 
     def assert_specific_resource_pool
-      resource_pool = ems.resource_pools.find_by(:ems_ref => "resgroup-92")
+      resource_pool = ems.resource_pools.find_by(:ems_ref => "resgroup-13")
 
       expect(resource_pool).not_to be_nil
       expect(resource_pool).to have_attributes(
@@ -540,17 +539,15 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         :memory_reserve_expand => true,
         :memory_shares         => 163_840,
         :memory_shares_level   => "normal",
-        :name                  => "Default for Cluster / Deployment Role DC0_C1",
+        :name                  => "Default for Cluster / Deployment Role DC0_C0",
         :vapp                  => false,
         :is_default            => true,
       )
 
-      expect(resource_pool.parent.ems_ref).to eq("domain-c91")
+      expect(resource_pool.parent.ems_ref).to eq("domain-c12")
 
-      expect(resource_pool.children.count).to eq(8)
-      expect(resource_pool.children.map(&:ems_ref)).to match_array(
-        %w(resgroup-106 resgroup-115 resgroup-124 resgroup-133 resgroup-142 resgroup-151 resgroup-160 resgroup-97)
-      )
+      expect(resource_pool.children.count).to eq(2)
+      expect(resource_pool.children.map(&:ems_ref)).to match_array(%w(resgroup-28 resgroup-19))
     end
 
     def assert_specific_switch
@@ -601,7 +598,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         :uid_ems           => "dvs-8",
         :name              => "DC0_DVS",
         :ports             => 288,
-        :switch_uuid       => "4e 1f 2b 50 19 20 4c f7-f3 11 41 90 35 76 52 7b",
+        :switch_uuid       => "a9 af 24 50 51 3a 40 48-56 b4 3d fe 0c 8b a0 5f",
         :type              => "ManageIQ::Providers::Vmware::InfraManager::DistributedVirtualSwitch",
         :allow_promiscuous => false,
         :forged_transmits  => false,
@@ -649,19 +646,19 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         :name                  => "DC0_C0_RP0_VM1",
         :raw_power_state       => "poweredOn",
         :type                  => "ManageIQ::Providers::Vmware::InfraManager::Vm",
-        :uid_ems               => "422bf630-7e83-c7dd-f226-56b41f3c50ef",
+        :uid_ems               => "42243da9-7676-d9ec-7a9b-e61e5db3725c",
         :vendor                => "vmware",
       )
 
       expect(vm.hardware).to have_attributes(
-        :bios                 => "422bf630-7e83-c7dd-f226-56b41f3c50ef",
+        :bios                 => "42243da9-7676-d9ec-7a9b-e61e5db3725c",
         :cpu_cores_per_socket => 1,
         :cpu_sockets          => 1,
         :cpu_total_cores      => 1,
         :virtual_hw_version   => "07",
       )
 
-      nic = vm.hardware.guest_devices.find_by(:uid_ems => "00:50:56:ab:a2:e2")
+      nic = vm.hardware.guest_devices.find_by(:uid_ems => "00:50:56:a4:01:01")
       expect(nic).to have_attributes(
         :device_name     => "Network adapter 1",
         :device_type     => "ethernet",
@@ -669,11 +666,12 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         :present         => true,
         :start_connected => true,
         :model           => "VirtualE1000",
-        :address         => "00:50:56:ab:a2:e2",
-        :uid_ems         => "00:50:56:ab:a2:e2",
+        :address         => "00:50:56:a4:01:01",
+        :uid_ems         => "00:50:56:a4:01:01",
       )
 
       expect(nic.lan).not_to be_nil
+      expect(nic.lan.uid_ems).to eq("dvportgroup-11")
 
       expect(vm.disks.count).to eq(1)
 
@@ -694,7 +692,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
       expect(vm.ems_cluster.ems_ref).to eq("domain-c12")
 
       expect(vm.host).not_to be_nil
-      expect(vm.host.ems_ref).to eq("host-17")
+      expect(vm.host.ems_ref).to eq("host-16")
 
       expect(vm.storage).not_to be_nil
       expect(vm.storage.name).to eq("GlobalDS_0")


### PR DESCRIPTION
This particular property can blow out the memory consumption on larger deployments.  Currently these are collected one at a time per host to prevent memory usage growing too large.

This change removes these properties from the propertyCollector update set and cache and instead retrieves them per host prior to parsing.