### PR TITLE
Parse the VirtualEthernetCard model type

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -252,6 +252,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
           :controller_type => 'ethernet',
           :present         => present,
           :start_connected => start_connected,
+          :model           => device.class.wsdl_name,
           :address         => address,
           :lan             => parse_virtual_machine_guest_device_lan(vm, device),
         }

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -1045,6 +1045,7 @@ module ManageIQ::Providers
             :controller_type => 'ethernet',
             :present         => data.fetch_path('connectable', 'connected').to_s.downcase == 'true',
             :start_connected => data.fetch_path('connectable', 'startConnected').to_s.downcase == 'true',
+            :model           => data.xsiType,
             :address         => address,
           }
           new_result[:lan] = lan unless lan.nil?

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -666,6 +666,9 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         :device_name     => "Network adapter 1",
         :device_type     => "ethernet",
         :controller_type => "ethernet",
+        :present         => true,
+        :start_connected => true,
+        :model           => "VirtualE1000",
         :address         => "00:50:56:ab:a2:e2",
         :uid_ems         => "00:50:56:ab:a2:e2",
       )

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -734,6 +734,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :controller_type => "ethernet",
       :present         => false,
       :start_connected => true,
+      :model           => "VirtualE1000",
       :address         => "00:50:56:af:00:73"
     )
     expect(nic.lan).to eq(@lan)


### PR DESCRIPTION
There are a number of different types of VirtualEthernetCards [0]: E1000,
Vmxnet3, etc... and this can be useful information to know.

We set the GuestDevice#model attribute for storage adapters, this reuses
that column to set the NIC's "model" type.

[0] https://code.vmware.com/apis/358/vsphere#/doc/vim.vm.device.VirtualEthernetCard.html

https://bugzilla.redhat.com/show_bug.cgi?id=1583017