### PR TITLE
Add method vm_move_into_folder.

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -249,6 +249,10 @@ module ManageIQ::Providers
       invoke_vim_ws(:relocateVM, vm, options[:user_event], options[:host], options[:pool], options[:datastore], options[:disk_move_type], options[:transform], options[:priority], options[:disk])
     end
 
+    def vm_move_into_folder(vm, options = {})
+      invoke_vim_ws(:moveIntoFolder, options[:folder], options[:user_event], vm.ems_ref_obj)
+    end
+
     def vm_clone(vm, options = {})
       defaults = {
         :pool          => nil,


### PR DESCRIPTION
Add method vm_move_into_folder to move VM to a new folder.

Part of https://github.com/ManageIQ/manageiq/pull/17519.

https://bugzilla.redhat.com/show_bug.cgi?id=1090957

@miq-bot add_label gaprindashvili/no, enhancement