### PR TITLE
Add the ability to rename a VM

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -274,6 +274,10 @@ module ManageIQ::Providers
       invoke_vim_ws(:cloneVM, vm, options[:user_event], options[:name], options[:folder], options[:pool], options[:host], options[:datastore], options[:powerOn], options[:template], options[:transform], options[:config], options[:customization], options[:disk])
     end
 
+    def vm_rename(vm, options = {})
+      invoke_vim_ws(:renameVM, vm, options[:user_event], options[:new_name])
+    end
+
     def vm_connect_all(vm, options = {})
       defaults = {:onStartup => false}
       options  = defaults.merge(options)

--- a/app/models/manageiq/providers/vmware/infra_manager/template.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/template.rb
@@ -8,4 +8,6 @@ class ManageIQ::Providers::Vmware::InfraManager::Template < ManageIQ::Providers:
       unsupported_reason_add(:provisioning, _('not connected to ems'))
     end
   end
+
+  supports :rename
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm.rb
@@ -14,6 +14,8 @@ class ManageIQ::Providers::Vmware::InfraManager::Vm < ManageIQ::Providers::Infra
   supports :reconfigure_disksize
   supports :reconfigure_cdroms
 
+  supports :rename
+
   def add_miq_alarm
     raise "VM has no EMS, unable to add alarm" unless ext_management_system
     ext_management_system.vm_add_miq_alarm(self)

--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("fog-vcloud-director", ["~> 0.2.2"])
   s.add_dependency "fog-core",                "~>1.40"
-  s.add_dependency "vmware_web_service",      "~>0.2.10"
+  s.add_dependency "vmware_web_service",      "~>0.2.13"
   s.add_dependency "rbvmomi",                 "~>1.13.0"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
Add a vm_rename method to VMware VMs.

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/17658
- [x] https://github.com/ManageIQ/vmware_web_service/pull/41

https://bugzilla.redhat.com/show_bug.cgi?id=1559184