### PR TITLE
Log error and backtrace if save_inventory fails

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/saver.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/saver.rb
@@ -86,10 +86,19 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Saver
     persister.persist!
     update_ems_refresh_stats(persister.manager)
   rescue => err
+    log_header = log_header_for_ems(persister.manager)
+
+    _log.error("#{log_header} Save Inventory failed")
+    _log.log_backtrace(err)
+
     update_ems_refresh_stats(persister.manager, :error => err.to_s)
   end
 
   def update_ems_refresh_stats(ems, error: nil)
     ems.update_attributes(:last_refresh_error => error, :last_refresh_date => Time.now.utc)
+  end
+
+  def log_header_for_ems(ems)
+    "EMS: [#{ems.name}], id: [#{ems.id}]"
   end
 end


### PR DESCRIPTION
When save_inventory fails log the backtrace, follow-up to https://github.com/ManageIQ/manageiq-providers-vmware/pull/296#discussion_r201619252