### PR TITLE
Fix setting the last_refresh_date on error

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -43,7 +43,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
     _log.error("#{log_header} Refresh failed")
     _log.log_backtrace(err)
 
-    ems.update_attributes(:last_refresh_error => err.to_s, :last_refresh_time => Time.now.utc)
+    ems.update_attributes(:last_refresh_error => err.to_s, :last_refresh_date => Time.now.utc)
   ensure
     saver.stop_thread
     destroy_property_filter(property_filter)


### PR DESCRIPTION
Fix an issue where the last_refresh_date is being set incorrectly in the
exception handler when a refresh fails.