### PR TITLE
Correct parent collection for custom_attributes and network

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -269,7 +269,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
       available_field.to_a.each { |af| key_to_name[af["key"]] = af["name"] }
 
       custom_values.to_a.each do |cv|
-        persister.custom_attributes.build(
+        persister.ems_custom_attributes.build(
           :resource => vm,
           :section  => "custom_field",
           :name     => key_to_name[cv["key"]],

--- a/app/models/manageiq/providers/vmware/inventory/persister/definitions/infra_collections.rb
+++ b/app/models/manageiq/providers/vmware/inventory/persister/definitions/infra_collections.rb
@@ -21,18 +21,12 @@ module ManageIQ::Providers::Vmware::Inventory::Persister::Definitions::InfraColl
     add_host_guest_devices
     add_host_system_services
 
-    %i(custom_attributes
-       networks).each do |name|
-
-      add_collection(infra,
-                     name,
-                     :parent_inventory_collections => nil)
-    end
-
     %i(disks
        guest_devices
        hardwares
-       operating_systems).each do |name|
+       operating_systems
+       ems_custom_attributes
+       networks).each do |name|
 
       add_collection(infra,
                      name,


### PR DESCRIPTION
Correct parent collection for custom_attributes and network. Also
custom attributes must be taken as ems_custom_attributes relation,
to avoid deleting user created attrs.