### PR TITLE
[WIP] InventoryCollection builder_params -> default_values

### DIFF
--- a/app/models/manageiq/providers/vmware/inventory/persister/definitions/cloud_collections.rb
+++ b/app/models/manageiq/providers/vmware/inventory/persister/definitions/cloud_collections.rb
@@ -40,7 +40,7 @@ module ManageIQ::Providers::Vmware::Inventory::Persister::Definitions::CloudColl
 
   def add_orchestration_templates
     add_collection(cloud, :orchestration_templates) do |builder|
-      builder.add_builder_params(:ems_id => manager.id)
+      builder.add_default_values(:ems_id => manager.id)
     end
   end
 end


### PR DESCRIPTION
Issue: #17396 

- [ ] **depends on** https://github.com/ManageIQ/manageiq/pull/17742

Removing "builder_params" term from all inventory_collection related classes
