### PR TITLE
Use the full URI for the broker connection

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
@@ -7,7 +7,7 @@ module ManageIQ::Providers::Vmware::InfraManager::VimConnectMixin
     raise _("no credentials defined") if missing_credentials?(options[:auth_type])
 
     options[:use_broker] = (self.class.respond_to?(:use_vim_broker?) ? self.class.use_vim_broker? : ManageIQ::Providers::Vmware::InfraManager.use_vim_broker?) unless options.key?(:use_broker)
-    options[:vim_broker_drb_port] ||= MiqVimBrokerWorker.method(:drb_port) if options[:use_broker]
+    options[:vim_broker_drb_uri] ||= MiqVimBrokerWorker.method(:drb_uri) if options[:use_broker]
 
     # The following require pulls in both MiqFaultTolerantVim and MiqVim
     require 'VMwareWebService/miq_fault_tolerant_vim'

--- a/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/scanning.rb
@@ -18,8 +18,8 @@ module ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared::Scanning
     $log.debug "#{log_pref} VM = #{vm_name}"
 
     args1 = ost.args[1]
-    args1['ems'][:use_vim_broker]      = MiqServer.use_broker_for_embedded_proxy?(args1['ems']['connect_to'])
-    args1['ems'][:vim_broker_drb_port] = MiqVimBrokerWorker.drb_port if args1['ems'][:use_vim_broker]
+    args1['ems'][:use_vim_broker]     = MiqServer.use_broker_for_embedded_proxy?(args1['ems']['connect_to'])
+    args1['ems'][:vim_broker_drb_uri] = MiqVimBrokerWorker.drb_uri if args1['ems'][:use_vim_broker]
 
     begin
       @vm_cfg_file = vm_name
@@ -66,7 +66,7 @@ module ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared::Scanning
         begin
           require 'VMwareWebService/miq_fault_tolerant_vim'
           # TODO: Should this move to the EMS?
-          ost.miqVim = MiqFaultTolerantVim.new(:ip => host_address, :user => miqVimHost[:username], :pass => password_decrypt, :use_broker => use_broker, :vim_broker_drb_port => ost.scanData['ems'][:vim_broker_drb_port])
+          ost.miqVim = MiqFaultTolerantVim.new(:ip => host_address, :user => miqVimHost[:username], :pass => password_decrypt, :use_broker => use_broker, :vim_broker_drb_uri => ost.scanData['ems'][:vim_broker_drb_uri])
           # ost.snapId = opts.snapId if opts.snapId
           $log.info "Connection to [#{ems_display_text}] completed for VM:[#{@vmCfgFile}] in [#{Time.now - st}] seconds"
         rescue Timeout::Error => err

--- a/app/models/miq_vim_broker_worker.rb
+++ b/app/models/miq_vim_broker_worker.rb
@@ -62,11 +62,7 @@ class MiqVimBrokerWorker < MiqWorker
   end
 
   def self.drb_port
-    uri = drb_uri
-    return nil if uri.nil?
-    _scheme, _userinfo, _host, port, _registry, _path, _opaque, _query, _fragment = URI.split(uri)
-    _log.debug("Active VimBroker DRb Port is #{port}")
-    port.to_i
+    drb_uri
   end
 
   def self.broker_unavailable(err_class, message)

--- a/app/models/miq_vim_broker_worker.rb
+++ b/app/models/miq_vim_broker_worker.rb
@@ -61,10 +61,6 @@ class MiqVimBrokerWorker < MiqWorker
     broker.uri
   end
 
-  def self.drb_port
-    drb_uri
-  end
-
   def self.broker_unavailable(err_class, message)
     _log.warn("The following error was encountered, '#{message}', the broker server should be restarted on the next heartbeat")
     broker = find_current.first

--- a/app/models/miq_vim_broker_worker/runner.rb
+++ b/app/models/miq_vim_broker_worker/runner.rb
@@ -253,7 +253,7 @@ class MiqVimBrokerWorker::Runner < MiqWorker::Runner
 
     _log.info("#{log_prefix} Creating broker server with [#{MiqVimBroker.cacheScope}]")
 
-    @vim_broker_server = MiqVimBroker.new(:server, 0)   # Port 0 means to let it pick any available port
+    @vim_broker_server = MiqVimBroker.new(:server)
   end
 
   def start_broker_server(emses_to_prime = nil)

--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("fog-vcloud-director", ["~> 0.2.2"])
   s.add_dependency "fog-core",                "~>1.40"
-  s.add_dependency "vmware_web_service",      "~>0.2.13"
+  s.add_dependency "vmware_web_service",      "~>0.3.0"
   s.add_dependency "rbvmomi",                 "~>1.13.0"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"

--- a/spec/models/miq_vim_broker_worker/runner_spec.rb
+++ b/spec/models/miq_vim_broker_worker/runner_spec.rb
@@ -140,14 +140,14 @@ describe MiqVimBrokerWorker::Runner do
     context "#create_miq_vim_broker_server" do
       it "with ems_inventory role" do
         @vim_broker_worker.instance_variable_set(:@active_roles, ['ems_inventory'])
-        expect(MiqVimBroker).to receive(:new).with(:server, 0).once
+        expect(MiqVimBroker).to receive(:new).with(:server).once
         @vim_broker_worker.create_miq_vim_broker_server
         expect(MiqVimBroker.cacheScope).to eq(:cache_scope_ems_refresh)
       end
 
       it "without ems_inventory role" do
         @vim_broker_worker.instance_variable_set(:@active_roles, ['ems_operations'])
-        expect(MiqVimBroker).to receive(:new).with(:server, 0).once
+        expect(MiqVimBroker).to receive(:new).with(:server).once
         @vim_broker_worker.create_miq_vim_broker_server
         expect(MiqVimBroker.cacheScope).to eq(:cache_scope_core)
       end
@@ -155,7 +155,7 @@ describe MiqVimBrokerWorker::Runner do
       it "with ems_inventory role using update_driven_refresh" do
         stub_settings(:prototype => {:ems_vmware => {:update_driven_refresh => true}})
         @vim_broker_worker.instance_variable_set(:@active_roles, ['ems_inventory'])
-        expect(MiqVimBroker).to receive(:new).with(:server, 0).once
+        expect(MiqVimBroker).to receive(:new).with(:server).once
         @vim_broker_worker.create_miq_vim_broker_server
         expect(MiqVimBroker.cacheScope).to eq(:cache_scope_core)
       end


### PR DESCRIPTION
This changes the vmware provider to pass in the full URI that the broker
server is running on to allow for a UNIX file path to be used.

CVE Number: CVE-2018-10905
https://bugzilla.redhat.com/show_bug.cgi?id=1599389

Depends on: https://github.com/ManageIQ/vmware_web_service/pull/42 (merged and 0.3.0 released)
Depends on: https://github.com/ManageIQ/manageiq-smartstate/pull/76 (merged and 0.2.13 release)