### PR TITLE
Removed deprecated InventoryCollectionDefault from persister

### DIFF
--- a/app/models/manageiq/providers/vmware/inventory/persister.rb
+++ b/app/models/manageiq/providers/vmware/inventory/persister.rb
@@ -1,26 +1,3 @@
 class ManageIQ::Providers::Vmware::Inventory::Persister < ManagerRefresh::Inventory::Persister
   require_nested :CloudManager
-
-  protected
-
-  def cloud
-    ManageIQ::Providers::Vmware::InventoryCollectionDefault::CloudManager
-  end
-
-  def targeted?
-    false
-  end
-
-  def strategy
-    nil
-  end
-
-  def shared_options
-    settings_options = options[:inventory_collections].try(:to_hash) || {}
-
-    settings_options.merge(
-      :strategy => strategy,
-      :targeted => targeted?,
-    )
-  end
 end


### PR DESCRIPTION
Also removed methods described by core class
`shared_options` are redefined in subclasses, not used in this format anymore. 

Issue: **https://github.com/ManageIQ/manageiq/issues/17396**

Cc @agrare 
