### PR TITLE
Shift fog-vcloud-director version to 0.3.0

### DIFF
--- a/app/models/manageiq/providers/vmware/manager_auth_mixin.rb
+++ b/app/models/manageiq/providers/vmware/manager_auth_mixin.rb
@@ -51,7 +51,7 @@ module ManageIQ::Providers::Vmware::ManagerAuthMixin
         }
       }
 
-      connect = Fog::Compute::VcloudDirector.new(params)
+      connect = Fog::VcloudDirector::Compute.new(params)
       connection_rescue_block { validate_connection(connect) } if validate
       connect
     end
@@ -70,7 +70,7 @@ module ManageIQ::Providers::Vmware::ManagerAuthMixin
 
     def translate_exception(err)
       case err
-      when Fog::Compute::VcloudDirector::Unauthorized
+      when Fog::VcloudDirector::Compute::Unauthorized
         MiqException::MiqInvalidCredentialsError.new "Login failed due to a bad username or password."
       when Excon::Errors::Timeout
         MiqException::MiqUnreachableError.new "Login attempt timed out"

--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -13,8 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency("fog-vcloud-director", ["~> 0.2.2"])
-  s.add_dependency "fog-core",                "~>1.40"
+  s.add_dependency("fog-vcloud-director", ["~> 0.3.0"])
   s.add_dependency "vmware_web_service",      "~>0.3.0"
   s.add_dependency "rbvmomi",                 "~>1.13.0"
 

--- a/spec/models/manageiq/providers/vmware/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager_spec.rb
@@ -52,14 +52,14 @@ describe ManageIQ::Providers::Vmware::CloudManager do
 
     it "decrypts the vcloud password" do
       encrypted = MiqPassword.encrypt("encrypted")
-      expect(::Fog::Compute::VcloudDirector).to receive(:new).with(params)
+      expect(::Fog::VcloudDirector::Compute).to receive(:new).with(params)
 
       described_class.raw_connect("server", "port", "username", encrypted, "api_version")
     end
 
     it "validates the password if validate is true if specified" do
-      expect(described_class).to receive(:validate_connection).and_raise(Fog::Compute::VcloudDirector::Unauthorized)
-      expect(::Fog::Compute::VcloudDirector).to receive(:new).with(params)
+      expect(described_class).to receive(:validate_connection).and_raise(Fog::VcloudDirector::Compute::Unauthorized)
+      expect(::Fog::VcloudDirector::Compute).to receive(:new).with(params)
 
       expect do
         described_class.raw_connect("server", "port", "username", "encrypted", "api_version", true)
@@ -68,7 +68,7 @@ describe ManageIQ::Providers::Vmware::CloudManager do
 
     it "does not validate the password unless specified" do
       expect(described_class).to_not receive(:validate_connection)
-      expect(::Fog::Compute::VcloudDirector).to receive(:new).with(params)
+      expect(::Fog::VcloudDirector::Compute).to receive(:new).with(params)
 
       described_class.raw_connect("server", "port", "username", "encrypted", "api_version")
     end

--- a/spec/models/manageiq/providers/vmware/network_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/vmware/network_manager/refresh_parser_spec.rb
@@ -274,7 +274,7 @@ describe ManageIQ::Providers::Vmware::NetworkManager::RefreshParser do
         },
         {
           :name     => 'error response',
-          :data     => -> { raise Fog::Compute::VcloudDirector::Forbidden, 'simulated error' },
+          :data     => -> { raise Fog::VcloudDirector::Compute::Forbidden, 'simulated error' },
           :expected => []
         }
       ].each do |test_case|
@@ -299,7 +299,7 @@ describe ManageIQ::Providers::Vmware::NetworkManager::RefreshParser do
         },
         {
           :name     => 'error response',
-          :data     => -> { raise Fog::Compute::VcloudDirector::Forbidden, 'simulated error' },
+          :data     => -> { raise Fog::VcloudDirector::Compute::Forbidden, 'simulated error' },
           :expected => []
         }
       ].each do |test_case|


### PR DESCRIPTION
With this commit we shift fog-vcloud-director version to 0.3.0 which is fog-core 2.1.x compliant, but remains fog-core 1.45 compatible.

Also, we omit the explicit fog-core requirement in vmware's Gemfile bacause we don't need it per se so we better let the fog-vcloud-director install whatever it needs.

Fixes https://github.com/ManageIQ/manageiq-providers-vmware/issues/319

@miq-bot assign @agrare
@miq-bot add_label enhancement