### PR TITLE
Don't require cloud tenant upon vApp instantiation

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/orchestration_template.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/orchestration_template.rb
@@ -275,6 +275,15 @@ class ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate < Orchest
   end
 
   def deployment_options(_manager_class = nil)
+    stack_name_opt = OrchestrationTemplate::OrchestrationParameter.new(
+      :name           => "stack_name",
+      :label          => "vApp Name",
+      :data_type      => "string",
+      :description    => "Desired name of the vApp we're about to create",
+      :required       => true,
+      :reconfigurable => false
+    )
+
     availability_opt = OrchestrationTemplate::OrchestrationParameter.new(
       :name        => "availability_zone",
       :label       => "Availability zone",
@@ -301,7 +310,7 @@ class ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate < Orchest
       ]
     )
 
-    super << availability_opt << vapp_template
+    [stack_name_opt, availability_opt, vapp_template]
   end
 
   def self.eligible_manager_types

--- a/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_template_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_template_spec.rb
@@ -77,9 +77,9 @@ describe ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate do
 
       it 'creates correct deployment options' do
         options = tabs[0][:stack_group]
-        assert_deployment_option(options[0], 'tenant_name', :OrchestrationParameterAllowedDynamic)
-        assert_deployment_option(options[1], 'stack_name', :OrchestrationParameterPattern)
-        assert_deployment_option(options[2], 'availability_zone', :OrchestrationParameterAllowedDynamic)
+        assert_deployment_option(options[0], 'stack_name')
+        assert_deployment_option(options[1], 'availability_zone', :OrchestrationParameterAllowedDynamic)
+        assert_deployment_option(options[2], 'stack_template', :OrchestrationParameterAllowed)
       end
 
       it 'creates Networks tab' do
@@ -400,14 +400,14 @@ describe ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate do
   describe '#deployment_options' do
     it do
       options = subject.deployment_options
-      assert_deployment_option(options[0], "tenant_name", :OrchestrationParameterAllowedDynamic)
-      assert_deployment_option(options[1], "stack_name", :OrchestrationParameterPattern)
-      assert_deployment_option(options[2], "availability_zone", :OrchestrationParameterAllowedDynamic)
+      assert_deployment_option(options[0], "stack_name")
+      assert_deployment_option(options[1], "availability_zone", :OrchestrationParameterAllowedDynamic)
+      assert_deployment_option(options[2], "stack_template", :OrchestrationParameterAllowed)
     end
   end
 
-  def assert_deployment_option(option, name, constraint_type)
+  def assert_deployment_option(option, name, constraint_type = nil)
     expect(option.name).to eq(name)
-    expect(option.constraints[0]).to be_kind_of("OrchestrationTemplate::#{constraint_type}".constantize)
+    expect(option.constraints[0]).to be_kind_of("OrchestrationTemplate::#{constraint_type}".constantize) if constraint_type
   end
 end


### PR DESCRIPTION
It used to be valid if user didn't pick anything in the Tenant field on the vApp provisioning dialog - but now the form won't let you through. Which is a problem for vCloud's vApp provisioning as we don't even inventory Cloud Tenants, so the drop-down options are always empty:

![capture](https://user-images.githubusercontent.com/8102426/45808322-d56bef80-bcc5-11e8-85e8-f77a6f43b79f.PNG)

Looking at the code, the `tenant_name` field is in fact marked as required in the parent class of the vCloud's OrchestrationTemplate!

With this commit we fix the vCloud's OrchestrationTemplate so that it now fully customizes its buttons, not just extends from base class. Having such power in hand we perform following changes:

- drop `'tenant_name'` field entirely from our dialog
- copy `'stack_name'` field from the base class to our dialog
- modify `'stack_name'` field so that it now allows any string as vapp name
  because vCloud does not limit it in any way (even '!! 123 ?? ŠČŽ' is valid, verified)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1631216

@miq-bot add_label bug,gaprindashvili/yes
@miq-bot assign @agrare