### PR TITLE
Add thumbprint_sha1 method to host_esx

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/host_esx.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/host_esx.rb
@@ -177,4 +177,8 @@ class ManageIQ::Providers::Vmware::InfraManager::HostEsx < ManageIQ::Providers::
   def self.display_name(number = 1)
     n_('Host (Vmware)', 'Hosts (Vmware)', number)
   end
+
+  def thumbprint_sha1
+    ESXThumbPrint.new(ipaddress, authentication_userid, authentication_password).to_sha1
+  end 
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/host_esx.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/host_esx.rb
@@ -179,6 +179,7 @@ class ManageIQ::Providers::Vmware::InfraManager::HostEsx < ManageIQ::Providers::
   end
 
   def thumbprint_sha1
+    require 'VMwareWebService/esx_thumb_print'
     ESXThumbPrint.new(ipaddress, authentication_userid, authentication_password).to_sha1
   end 
 end


### PR DESCRIPTION
For VM migration, we need the thumbprint of the ESX host where the VM resides (`vm.host`). This PR adds a method named `thumbprint_sha1` that returns the needed fingerprint.

Required by: https://github.com/ManageIQ/manageiq/pull/18033