### PR TITLE
Check EmsEvents when disconnecting storage

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared.rb
@@ -2,6 +2,7 @@ module ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared
   extend ActiveSupport::Concern
   include_concern 'RefreshOnScan'
   include_concern 'Scanning'
+  include_concern 'Disconnect'
 
   POWER_STATES = {
     "poweredOn"  => "on",

--- a/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/disconnect.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/disconnect.rb
@@ -1,0 +1,27 @@
+module ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared::Disconnect
+  extend ActiveSupport::Concern
+
+  def disconnect_storage
+    # If the VM was unregistered don't clear the storage because the disks
+    # are still on the underlying datastore
+    super unless unregistered?
+  end
+
+  def destroyed?
+    disconnect_events.last&.event_type == "DestroyVM_Task_Complete"
+  end
+
+  def unregistered?
+    disconnect_events.last&.event_type == "UnregisterVM_Complete"
+  end
+
+  private
+
+  def disconnect_events
+    ems_events.where(:event_type => disconnect_event_types)
+  end
+
+  def disconnect_event_types
+    %w(DestroyVM_Task_Complete UnregisterVM_Complete)
+  end
+end


### PR DESCRIPTION
Instead of the EventHandler calling disconnect_storage when
DestroyVM_Task_Complete is processed check the ems_events for
UnregisterVM_Complete.

Depends: https://github.com/ManageIQ/manageiq/pull/18200

https://bugzilla.redhat.com/show_bug.cgi?id=1644770