### PR TITLE
Forcibly mark vCloud VMs as not disconnected

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm.rb
@@ -27,6 +27,14 @@ class ManageIQ::Providers::Vmware::CloudManager::Vm < ManageIQ::Providers::Cloud
     "suspended" => "suspended"
   }.freeze
 
+  def disconnected
+    false
+  end
+
+  def disconnected?
+    false
+  end
+
   def self.calculate_power_state(raw_power_state)
     # https://github.com/xlab-si/fog-vcloud-director/blob/master/lib/fog/vcloud_director/parsers/compute/vm.rb#L70
     POWER_STATES[raw_power_state.to_s] || "terminated"

--- a/spec/models/manageiq/providers/vmware/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/vm_spec.rb
@@ -83,5 +83,13 @@ describe ManageIQ::Providers::Vmware::CloudManager::Vm do
         vm.raw_suspend
       end
     end
+
+    it '.disconnected' do
+      expect(subject.disconnected).to be_falsey
+    end
+
+    it '.disconnected?' do
+      expect(subject.disconnected).to be_falsey
+    end
   end
 end


### PR DESCRIPTION
Like other cloud providers we have to override functions

```
def disconnected
def disconnected?
```

to always return false for vCloud cloud provider or else UI displays all its VMs as 'disconnected' regardless the actual power state.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1649403
Fixes ManageIQ/manageiq-ui-classic#4909

@miq-bot assign @agrare
@miq-bot add_label enhancement,hammer/yes

/cc @kbrock 
