### PR TITLE
Use Optimist

### DIFF
--- a/tools/event_history.rb
+++ b/tools/event_history.rb
@@ -1,8 +1,8 @@
 require 'rbvmomi'
-require 'trollop'
+require 'optimist'
 
 def parse_args(argv)
-  opts = Trollop.options do
+  opts = Optimist.options do
     banner <<-EOS
 Print all event history from the VC specified by the ems parameter
 


### PR DESCRIPTION
`Trollop` is a deprecated gem, and has been renamed/replaced by [`Optimist`](https://github.com/ManageIQ/optimist).

This relies on https://github.com/ManageIQ/manageiq/pull/18246 being merged for this to work properly.  Since this is a tool, however, this shouldn't be a problem for the general use of the appliance (workers, miq_server, etc.).


Links
-----

* Org search of current usage of old gem (hides some irrelevant repos):  [search](https://github.com/search?l=&q=Trollop+repo%3AManageIQ%2Fmanageiq+repo%3AManageIQ%2Fmanageiq-release+repo%3AManageIQ%2Fmanageiq-appliance_console+repo%3AManageIQ%2Fmanageiq-appliance-build+repo%3AManageIQ%2Fmanageiq-api+repo%3AManageIQ%2Fmanageiq-providers-vmware+repo%3AManageIQ%2Fhttpd_configmap_generator+repo%3AManageIQ%2Fguides&type=Code)
* https://github.com/ManageIQ/manageiq/pull/18246