### PR TITLE
Replace custom snapshot_parent saver

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -296,6 +296,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
       return if snap.nil?
 
       create_time = snapshot[:createTime]
+      parent = persister.snapshots.lazy_find(:vm_or_template => vm, :uid => Time.parse(parent_uid).iso8601(6)) if parent_uid
 
       snapshot_hash = {
         :vm_or_template => vm,
@@ -304,6 +305,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
         :uid_ems        => create_time.to_s,
         :uid            => create_time.iso8601(6),
         :parent_uid     => parent_uid,
+        :parent         => parent,
         :name           => CGI.unescape(snapshot[:name]),
         :description    => snapshot[:description],
         :create_time    => create_time.to_s,

--- a/app/models/manageiq/providers/vmware/inventory/persister/definitions/infra_collections.rb
+++ b/app/models/manageiq/providers/vmware/inventory/persister/definitions/infra_collections.rb
@@ -51,7 +51,6 @@ module ManageIQ::Providers::Vmware::Inventory::Persister::Definitions::InfraColl
     add_vm_parent_blue_folders
     add_vm_resource_pools
     add_root_folder_relationship
-    add_snapshot_parent
   end
 
   # ------ IC provider specific definitions -------------------------
@@ -170,18 +169,6 @@ module ManageIQ::Providers::Vmware::Inventory::Persister::Definitions::InfraColl
 
       builder.add_dependency_attributes(
         :ems_folders => [collections[:ems_folders]]
-      )
-    end
-  end
-
-  def add_snapshot_parent
-    add_collection(infra,
-                   :snapshot_parent,
-                   shared_options_overrides,
-                   :without_model_class => true) do |builder|
-
-      builder.add_dependency_attributes(
-        :snapshots => [collections[:snapshots]]
       )
     end
   end


### PR DESCRIPTION
Use a standard lazy_find for the snapshot parent link instead of a
custom saver.