### PR TITLE
Grumpy Nick to readers:  I tend to look on the bright side of things

### DIFF
--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("fog-vcloud-director", ["~> 0.3.0"])
   s.add_dependency "vmware_web_service",      "~>0.3.0"
-  s.add_dependency "rbvmomi",                 "~>1.13.0"
+  s.add_dependency "rbvmomi",                 "~>2.0.0"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
`rbvmomi` is our only external dependency that uses `optimist`, and it just updated to use it in it's new version, which we are now a version behind.

Required because of https://github.com/vmware/rbvmomi/pull/145 and our recent switch to use `optimist` ourselves.

Thankfully, this change is less scary than it looks:

https://github.com/vmware/rbvmomi/compare/v1.13.0...v2.0.0


Links
-----

* Related PR:  https://github.com/ManageIQ/vmware_web_service/pull/49