### PR TITLE
Parse if a datastore is accessible from a host

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/datastore.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/datastore.rb
@@ -30,10 +30,11 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
     def parse_datastore_host_mount(storage, datastore_ref, props)
       props[:host].to_a.each do |host_mount|
         persister.host_storages.build(
-          :storage   => storage,
-          :host      => persister.hosts.lazy_find(host_mount.key._ref),
-          :ems_ref   => datastore_ref,
-          :read_only => host_mount.mountInfo.accessMode == "readOnly",
+          :storage    => storage,
+          :host       => persister.hosts.lazy_find(host_mount.key._ref),
+          :ems_ref    => datastore_ref,
+          :read_only  => host_mount.mountInfo.accessMode == "readOnly",
+          :accessible => host_mount.mountInfo.accessible,
         )
       end
     end

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -770,12 +770,15 @@ module ManageIQ::Providers
           host_mount = Array.wrap(s_inv["host"]).detect { |host| host["key"] == inv["MOR"] }
           next if host_mount.nil?
 
-          read_only = host_mount.fetch_path("mountInfo", "accessMode") == "readOnly"
+          mount_info = host_mount["mountInfo"] || {}
+          read_only  = mount_info["accessMode"] == "readOnly"
+          accessible = mount_info["accessible"].present? ? mount_info["accessible"].to_s.downcase == "true" : true
 
           result << {
-            :storage   => storage_uids[s_mor],
-            :read_only => read_only,
-            :ems_ref   => s_mor
+            :storage    => storage_uids[s_mor],
+            :read_only  => read_only,
+            :accessible => accessible,
+            :ems_ref    => s_mor
           }
         end
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -469,6 +469,13 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :location           => "4dce5b88-623e8e7e-0dc0-00188b404015"
     )
 
+    expect(@host.host_storages.where(:accessible => false).count).to eq(1)
+    inaccessible_host_storage = @host.host_storages.find_by(:accessible => false)
+    expect(inaccessible_host_storage.storage).to have_attributes(
+      :ems_ref => "datastore-12281",
+      :name    => "StarM1-Backup1",
+    )
+
     expect(@host.operating_system).to have_attributes(
       :name         => "VI4ESXM1.manageiq.com",
       :product_name => "ESXi",

--- a/spec/tools/vim_data/miq_vim_inventory/dataStoresByMor.yml
+++ b/spec/tools/vim_data/miq_vim_inventory/dataStoresByMor.yml
@@ -18,6 +18,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -36,6 +40,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'false'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -140,6 +148,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -226,6 +238,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -312,6 +328,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -394,6 +414,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -480,6 +504,10 @@
               str: readOnly
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -498,6 +526,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -580,6 +612,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -662,6 +698,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -744,6 +784,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -762,6 +806,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -848,6 +896,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -934,6 +986,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -1016,6 +1072,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -1034,6 +1094,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -1116,6 +1180,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -1198,6 +1266,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -1216,6 +1288,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -1298,6 +1374,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -1384,6 +1464,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -1466,6 +1550,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -1484,6 +1572,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -1566,6 +1658,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -1648,6 +1744,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -1666,6 +1766,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -1748,6 +1852,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -1766,6 +1874,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -1852,6 +1964,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -1934,6 +2050,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -2016,6 +2136,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -2034,6 +2158,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -2120,6 +2248,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -2202,6 +2334,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -2284,6 +2420,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -2302,6 +2442,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -2384,6 +2528,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -2466,6 +2614,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -2484,6 +2636,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -2570,6 +2726,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -2656,6 +2816,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -2738,6 +2902,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -2756,6 +2924,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -2842,6 +3014,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -2924,6 +3100,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -2942,6 +3122,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -3028,6 +3212,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -3046,6 +3234,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -3132,6 +3324,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -3214,6 +3410,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -3232,6 +3432,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -3318,6 +3522,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -3336,6 +3544,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -3418,6 +3630,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -3436,6 +3652,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -3586,6 +3806,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -3668,6 +3892,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -3686,6 +3914,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -3768,6 +4000,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -3850,6 +4086,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -3932,6 +4172,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -3950,6 +4194,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -4032,6 +4280,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -4050,6 +4302,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -4200,6 +4456,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -4282,6 +4542,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -4300,6 +4564,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -4382,6 +4650,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -4464,6 +4736,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo
@@ -4482,6 +4758,10 @@
               str: readWrite
               vimType: 
               xsiType: :SOAP::SOAPString
+            accessible: !ruby/string:VimString
+              str: 'true'
+              vimType: 
+              xsiType: :SOAP::SOAPBoolean
           ivars:
             :@vimType: 
             :@xsiType: :HostMountInfo


### PR DESCRIPTION
Parse if a datastore is able to be accessed from a host into the
host_storage record.

Depends on:
- [x] https://github.com/ManageIQ/manageiq-schema/pull/329

https://bugzilla.redhat.com/show_bug.cgi?id=1668020