### PR TITLE
Bump vmware_web_service to 0.4.0

### DIFF
--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*"]
 
   s.add_dependency("fog-vcloud-director", ["~> 0.3.0"])
-  s.add_dependency "vmware_web_service",      "~>0.3.0"
+  s.add_dependency "vmware_web_service",      "~>0.4.0"
   s.add_dependency "rbvmomi",                 "~>2.0.0"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
As documented in https://github.com/ManageIQ/manageiq/pull/18398 - this is upstream only change to pick up the latest vmware_web_service.

@roliveri @agrare @simaishi @NickLaMuro for your reading pleasure.

Helps fix https://bugzilla.redhat.com/show_bug.cgi?id=1651702.