### PR TITLE
Handle duplicate storages in the refresh parser

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -43,6 +43,7 @@ module ManageIQ::Providers
       def self.storage_inv_to_hashes(inv)
         result = []
         result_uids = {}
+        result_locs = {}
         return result, result_uids if inv.nil?
 
         inv.each do |mor, storage_inv|
@@ -54,6 +55,10 @@ module ManageIQ::Providers
           capability = storage_inv["capability"]
 
           loc = uid = normalize_storage_uid(storage_inv)
+          unless result_locs[loc].nil?
+            result_uids[mor] = result_locs[loc]
+            next
+          end
 
           new_result = {
             :ems_ref            => mor,
@@ -77,6 +82,7 @@ module ManageIQ::Providers
 
           result << new_result
           result_uids[mor] = new_result
+          result_locs[loc] = new_result
         end
         return result, result_uids
       end

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -23,23 +23,25 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
   end
 
   it "will perform a full refresh" do
-    EmsRefresh.refresh(@ems)
-    @ems.reload
+    2.times do
+      EmsRefresh.refresh(@ems)
+      @ems.reload
 
-    assert_table_counts
-    assert_ems
-    assert_specific_datacenter
-    assert_specific_folder
-    assert_specific_cluster
-    assert_specific_storage
-    assert_specific_storage_cluster
-    assert_specific_storage_profile
-    assert_specific_dvportgroup
-    assert_specific_host
-    assert_specific_vm
-    assert_specific_vm_missing_uuid
-    assert_cpu_layout
-    assert_relationship_tree
+      assert_table_counts
+      assert_ems
+      assert_specific_datacenter
+      assert_specific_folder
+      assert_specific_cluster
+      assert_specific_storage
+      assert_specific_storage_cluster
+      assert_specific_storage_profile
+      assert_specific_dvportgroup
+      assert_specific_host
+      assert_specific_vm
+      assert_specific_vm_missing_uuid
+      assert_cpu_layout
+      assert_relationship_tree
+    end
   end
 
   it 'handles switch deletion' do
@@ -252,7 +254,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     expect(VmOrTemplate.count).to eq(101)
     expect(Vm.count).to eq(92)
     expect(MiqTemplate.count).to eq(9)
-    expect(Storage.count).to eq(50)
+    expect(Storage.count).to eq(33)
     expect(StorageProfile.count).to eq(6)
 
     expect(CustomAttribute.count).to eq(3)
@@ -282,7 +284,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     expect(@ems.ems_folders.size).to eq(32)
     expect(@ems.ems_clusters.size).to eq(1)
     expect(@ems.resource_pools.size).to eq(17)
-    expect(@ems.storages.size).to eq(47)
+    expect(@ems.storages.size).to eq(30)
     expect(@ems.hosts.size).to eq(4)
     expect(@ems.vms_and_templates.size).to eq(101)
     expect(@ems.vms.size).to eq(92)


### PR DESCRIPTION
VMware datastores in multiple datacenters will have the same location but different ems_refs.  This leads to "duplicate" storages in the parser that will lead to a single storage record.

Due to an issue with the saver if duplicate storages are sent from the parser they will actually be all created so we get duplicate storage records, then subsequent refreshes pick up only the first one leading to orphans.

This change adapts the parser to handle these "duplicate" storages in the parser.  One trick is that we need to handle mapping multiple ems_refs (mors) to the single storage record.