### PR TITLE
Fix storage.parent multiple parents found error

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -68,7 +68,6 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
     storage_hash = {
       :ems_ref     => object._ref,
       :ems_ref_obj => managed_object_to_vim_string(object),
-      :parent      => lazy_find_managed_object(props[:parent]),
     }
 
     parse_datastore_summary(storage_hash, props)

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -1245,7 +1245,10 @@ module ManageIQ::Providers
         inv.each do |mor, data|
           mor = data['MOR'] # Use the MOR directly from the data since the mor as a key may be corrupt
 
-          child_mors = get_mors(data, 'childEntity')
+          # Since datastores living in multiple datacenters map to a single Storage record
+          # the same record will live in multiple folders.  This leads to Multiple parents found
+          # exceptions if we allow datastores to be in child_uids.
+          child_mors = get_mors(data, 'childEntity').reject { |child| child.vimType == "Datastore" }
 
           new_result = {
             :type        => EmsFolder.name,

--- a/app/models/manageiq/providers/vmware/inventory/persister/definitions/infra_collections.rb
+++ b/app/models/manageiq/providers/vmware/inventory/persister/definitions/infra_collections.rb
@@ -220,7 +220,7 @@ module ManageIQ::Providers::Vmware::Inventory::Persister::Definitions::InfraColl
         child_recs.each do |model_class, children_by_id|
           children_by_id.each_value do |child|
             new_parent_klass, new_parent_id = parent_by_child[model_class][child.id]
-            prev_parent = child.with_relationship_type(relationship_type) { child.parent(:of_type => parent_type) }
+            prev_parent = child.with_relationship_type(relationship_type) { child.parents(:of_type => parent_type)&.first }
 
             next if prev_parent && (prev_parent.class.base_class == new_parent_klass && prev_parent.id == new_parent_id)
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -56,10 +56,10 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
       end
 
       def serialize_inventory
-        tables = [:vms, :hosts, :storages, :host_storages, :hardwares, :guest_devices,
-                  :disks, :networks, :system_services, :snapshots, :operating_systems,
+        tables = [:vms, :hosts, :storages, :host_storages, :hardwares,
+                  :disks, :system_services, :snapshots, :operating_systems,
                   :custom_attributes, :ems_clusters, :resource_pools, :subnets,
-                  #:ems_folders, :switches, :lans
+                  #:ems_folders, :switches, :lans, :guest_devices, :networks
                   :miq_scsi_luns, :miq_scsi_targets, :storage_profiles, :customization_specs]
 
         global_skip_attrs = ["created_on", "updated_on"]


### PR DESCRIPTION
Since datastores can live in multiple datacenters and map to a single
storage record they belong to multiple datacenter/datastoreFolder
folders.  This leads to multiple parents found errors when doing
storage.parent.