### PR TITLE
Ignore pg_stat_activity table in collector specs

### DIFF
--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -56,7 +56,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
       end
 
       def serialize_inventory
-        internal_models = [MiqRegionRemote, VmdbDatabaseLock, VmdbDatabaseSetting]
+        internal_models = [MiqRegionRemote, VmdbDatabaseConnection, VmdbDatabaseLock, VmdbDatabaseSetting]
         temp_failures = [GuestDevice, HostSwitch, Lan, Network, Relationship, Switch]
         models = ApplicationRecord.subclasses - internal_models - temp_failures
 


### PR DESCRIPTION
Fix an issue introduced in https://github.com/ManageIQ/manageiq-providers-vmware/pull/369 where the internal pg_stats_activity table wasn't being skipped when doing full db comparisons.