### PR TITLE
Set EMS attributes with an inventory_collection

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -59,10 +59,6 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
     persister = full_persister_klass.new(ems)
     parser    = parser_klass.new(inventory_cache, persister)
 
-    # Set the ems.api_version and ems.uid_ems manually until there is a way to
-    # set it with an inventory_collection
-    set_ems_attributes(vim)
-
     monitor_updates(vim, property_filter, "", persister, parser)
   end
 
@@ -77,6 +73,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
       updated_objects.concat(process_update_set(property_filter, update_set))
     end while update_set.truncated
 
+    parser.parse_ext_management_system(ems, vim.serviceContent.about)
     parse_updates(updated_objects, parser)
     save_inventory(persister)
 
@@ -115,13 +112,6 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
     return if vim.nil?
 
     vim.close
-  end
-
-  def set_ems_attributes(vim)
-    api_version   = vim.serviceContent.about.apiVersion
-    instance_uuid = vim.serviceContent.about.instanceUuid
-
-    ems.update_attributes(:api_version => api_version, :uid_ems => instance_uuid)
   end
 
   def wait_for_updates(vim, version)

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -25,6 +25,17 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
     send(parse_method, object, kind, props)
   end
 
+  def parse_ext_management_system(object, about)
+    api_version   = about.apiVersion
+    instance_uuid = about.instanceUuid
+
+    persister.ext_management_system.build(
+      :guid        => object.guid,
+      :api_version => api_version,
+      :uid_ems     => instance_uuid,
+    )
+  end
+
   def parse_compute_resource(object, kind, props)
     persister.ems_clusters.targeted_scope << object._ref
     return if kind == "leave"

--- a/app/models/manageiq/providers/vmware/inventory/persister/definitions/infra_collections.rb
+++ b/app/models/manageiq/providers/vmware/inventory/persister/definitions/infra_collections.rb
@@ -5,6 +5,7 @@ module ManageIQ::Providers::Vmware::Inventory::Persister::Definitions::InfraColl
     add_vms_and_templates
 
     %i(customization_specs
+       ext_management_system
        host_hardwares
        host_guest_devices
        host_networks


### PR DESCRIPTION
Instead of updating the ext_management_system record directly add the
properties to the ext_management_system inventory_collection.

Depends on: https://github.com/ManageIQ/manageiq/pull/18484