### PR TITLE
Added unsupported reason for reconfiguring disksize

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm.rb
@@ -11,7 +11,9 @@ class ManageIQ::Providers::Vmware::InfraManager::Vm < ManageIQ::Providers::Infra
 
   supports :reconfigure_disks
   supports :reconfigure_network_adapters
-  supports :reconfigure_disksize
+  supports :reconfigure_disksize do
+    unsupported_reason_add(:reconfigure_disksize, 'Cannot resize disks of a VM with snapshots') unless snapshots.empty?
+  end
   supports :reconfigure_cdroms
 
   supports :rename


### PR DESCRIPTION
Cannot reconfigure disk size when the VM has snapshots. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1631448