### PR TITLE
Add thick_eager disk_format option

### DIFF
--- a/content/miq_dialogs/miq_provision_vmware_cluster_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_cluster_dialogs_template.yaml
@@ -604,7 +604,8 @@
       :fields:
         :disk_format:
           :values:
-            thick: Thick
+            thick: Thick - Lazy Zero
+            thick_eager: Thick - Eager Zero
             thin: Thin
             unchanged: Default
           :description: Disk Format

--- a/content/miq_dialogs/miq_provision_vmware_dialogs_clone_to_template.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_dialogs_clone_to_template.yaml
@@ -641,7 +641,8 @@
       :fields:
         :disk_format:
           :values:
-            thick: Thick
+            thick: Thick - Lazy Zero
+            thick_eager: Thick - Eager Zero
             thin: Thin
             unchanged: Default
           :description: Disk Format

--- a/content/miq_dialogs/miq_provision_vmware_dialogs_clone_to_vm.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_dialogs_clone_to_vm.yaml
@@ -650,7 +650,8 @@
       :fields:
         :disk_format:
           :values:
-            thick: Thick
+            thick: Thick - Lazy Zero
+            thick_eager: Thick - Eager Zero
             thin: Thin
             unchanged: Default
           :description: Disk Format

--- a/content/miq_dialogs/miq_provision_vmware_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_dialogs_template.yaml
@@ -682,7 +682,8 @@
       :fields:
         :disk_format:
           :values:
-            thick: Thick
+            thick: Thick - Lazy Zero
+            thick_eager: Thick - Eager Zero
             thin: Thin
             unchanged: Default
           :description: Disk Format

--- a/content/miq_dialogs/miq_provision_vmware_folder_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_folder_dialogs_template.yaml
@@ -594,7 +594,8 @@
       :fields:
         :disk_format:
           :values:
-            thick: Thick
+            thick: Thick - Lazy Zero
+            thick_eager: Thick - Eager Zero
             thin: Thin
             unchanged: Default
           :description: Disk Format


### PR DESCRIPTION
For vmware disk_formats, we're missing an option at the moment. 

The "... dialog field option should be updated so that the exist "thick" option remains, but the display value is updated to read "Thick - Lazy Zero".  This supports backward-compatibility.  Then a new options for "thick_eager" should be added."

https://github.com/ManageIQ/manageiq-providers-vmware/pull/384 and https://github.com/ManageIQ/manageiq/pull/18614 moved the vmware prov dialogs from main to the vmware repo, and this adds the option in the yaml files. 

First half of work for https://bugzilla.redhat.com/show_bug.cgi?id=1633867