### PR TITLE
Set the last_inventory_date on an EMS

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -30,9 +30,10 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
     instance_uuid = about.instanceUuid
 
     persister.ext_management_system.build(
-      :guid        => object.guid,
-      :api_version => api_version,
-      :uid_ems     => instance_uuid,
+      :guid                => object.guid,
+      :api_version         => api_version,
+      :uid_ems             => instance_uuid,
+      :last_inventory_date => Time.now.utc,
     )
   end
 

--- a/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
@@ -35,6 +35,9 @@ module ManageIQ::Providers
 
         Benchmark.realtime_block(:get_vc_data_host_scsi) { get_vc_data_host_scsi(ems, filtered_host_mors) }
 
+        # After collecting all inventory mark the date of the data
+        @ems_data[:last_inventory_date] = Time.now.utc
+
         return targets_with_data
       ensure
         disconnect_from_ems(ems)

--- a/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
@@ -36,7 +36,7 @@ module ManageIQ::Providers
         Benchmark.realtime_block(:get_vc_data_host_scsi) { get_vc_data_host_scsi(ems, filtered_host_mors) }
 
         # After collecting all inventory mark the date of the data
-        @ems_data[:last_inventory_date] = Time.now.utc
+        @last_inventory_date = Time.now.utc
 
         return targets_with_data
       ensure
@@ -63,6 +63,11 @@ module ManageIQ::Providers
       end
 
       def post_refresh(ems, start_time)
+        # Update the last_inventory_date in post_refresh because save_ems_inventory is
+        # run on each target even though the inventory came from the same time.  This
+        # would allow for the ems's last_inventory_date to be updated before each target.
+        set_last_inventory_date(ems)
+
         log_header = format_ems_for_logging(ems)
         [VmOrTemplate, Host].each do |klass|
           next unless klass.respond_to?(:post_refresh_ems)
@@ -70,6 +75,10 @@ module ManageIQ::Providers
           klass.post_refresh_ems(ems.id, start_time)
           _log.info "#{log_header} Performing post-refresh operations for #{klass} instances...Complete"
         end
+      end
+
+      def set_last_inventory_date(ems)
+        ems.update_attributes!(:last_inventory_date => @last_inventory_date)
       end
 
       #

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -61,7 +61,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
 
         global_skip_attrs = ["created_on", "updated_on"]
         table_skip_attrs = {
-          "ExtManagementSystem" => ["last_refresh_date"],
+          "ExtManagementSystem" => ["last_refresh_date", "last_inventory_date"],
         }
 
         models.each_with_object({}) do |model, inventory|
@@ -562,6 +562,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
       expect(ems.api_version).to eq("5.5")
       expect(ems.last_refresh_error).to be_nil
       expect(ems.last_refresh_date).not_to be_nil
+      expect(ems.last_inventory_date).not_to be_nil
       expect(ems.uid_ems).to eq("D6EB1D64-05B2-4937-BFF6-6F77C6E647B7")
       expect(ems.ems_clusters.count).to eq(4)
       expect(ems.ems_folders.count).to eq(11)

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -280,6 +280,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :api_version => "4.1",
       :uid_ems     => "EF53782F-6F1A-4471-B338-72B27774AFDD"
     )
+    expect(@ems.last_inventory_date).not_to be_nil
 
     expect(@ems.ems_folders.size).to eq(32)
     expect(@ems.ems_clusters.size).to eq(1)


### PR DESCRIPTION
After collecting inventory data save a timestamp when it was collected
that will get saved to the EMS when the rest of the inventory is saved.

This allows us to know what time the inventory is from, not just when
the inventory was saved.

Needed for: https://github.com/ManageIQ/manageiq-content/pull/525