### PR TITLE
Don't collect storage profiles which can't be used

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
@@ -151,7 +151,10 @@ module ManageIQ::Providers
         cleanup_callback = proc { @vc_data = nil }
 
         retrieve_from_vc(ems, cleanup_callback) do
-          collect_and_log_inventory(ems, :storage_profile) { @vi.pbmProfilesByUid }
+          collect_and_log_inventory(ems, :storage_profile) do
+            # Ignore storage profiles which cannot be added to virtual machines or virtual disks
+            @vi.pbmProfilesByUid.reject { |_uid, profile| profile.profileCategory == "DATA_SERVICE_POLICY" }
+          end
 
           unless @vc_data[:storage_profile].blank?
             storage_profile_ids = @vc_data[:storage_profile].keys


### PR DESCRIPTION
Storage profiles in the DATA_SERVICE_POLICY category cannot be added to
virtual machines or virtual disks.  They can only be embedded in other
storage profiles.

Since we don't create/edit storage profiles we don't need to collect
these.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1670016