### PR TITLE
Define through association before trying to use it

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -30,9 +30,9 @@ module ManageIQ::Providers
       unsupported_reason_add(:streaming_refresh, "Streaming refresh not enabled") unless streaming_refresh_enabled?
     end
 
+    has_many :host_guest_devices, :through => :host_hardwares, :source => :guest_devices
     has_many :miq_scsi_targets, -> { distinct }, :through => :host_guest_devices
     has_many :miq_scsi_luns, -> { distinct }, :through => :miq_scsi_targets
-    has_many :host_guest_devices,             :through => :host_hardwares, :source => :guest_devices
     has_many :host_system_services, :through => :hosts, :source => :system_services
     has_many :distributed_virtual_switches, :dependent => :destroy, :foreign_key => :ems_id
 


### PR DESCRIPTION
Fixes a rails 5.1 failure below.  The solution is 5.0/5.1 safe.

```
  1) ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector#monitor_updates full refresh Performs a full refresh
     Failure/Error: expect(ems.last_refresh_error).to be_nil

       expected: nil
            got: "Cannot have a has_many :through association 'ManageIQ::Providers::Vmware::InfraManager#miq_scsi_targ...eIQ::Providers::Vmware::InfraManager#host_guest_devices' before the through association is defined."
     # ./spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb:534:in `assert_ems'
     # ./spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb:28:in `block (5 levels) in <top (required)>'
     # ./spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb:24:in `times'
     # ./spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb:24:in `block (4 levels) in <top (required)>'
```