### PR TITLE
Use the new VM's ems_ref instead of an annotation

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
@@ -5,16 +5,19 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
         task_props = ["info.state", "info.error", "info.result", "info.progress", "info.completeTime"]
         task = vim.getMoProp(clone_task_mor, task_props)
 
-        case task&.info&.state
+        task_info  = task&.info
+        task_state = task_info&.state
+
+        case task_state
         when TaskInfoState::Success
-          phase_context[:new_vm_ems_ref] = task&.info&.result
-          phase_context[:clone_vm_task_completion_time] = task&.info&.completeTime
+          phase_context[:new_vm_ems_ref] = task_info&.result
+          phase_context[:clone_vm_task_completion_time] = task_info&.completeTime
           return true
         when TaskInfoState::Running
-          progress = task&.info&.progress
+          progress = task_info&.progress
           return false, progress.nil? ? "beginning" : "#{progress}% complete"
         else
-          return false, task&.info&.state
+          return false, task_state
         end
       end
     end

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb
@@ -49,7 +49,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::StateMachine
       phase_context.delete(:new_vm_validation_guid)
       signal :customize_destination
     else
-      _log.info("Unable to find #{destination_type} [#{dest_name}] with validation guid [#{phase_context[:new_vm_validation_guid]}], will retry")
+      _log.info("Unable to find #{destination_type} [#{dest_name}] with ems_ref [#{phase_context[:new_vm_ems_ref]}], will retry")
       requeue_phase
     end
   end


### PR DESCRIPTION
Instead of setting a UUID to the annotations field check for the new
vm's ems_ref.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1724751