### PR TITLE
Create a HTML5 console type on top of VNC and WebMKS

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm/remote_console.rb
@@ -65,6 +65,11 @@ module ManageIQ::Providers::Vmware::CloudManager::Vm::RemoteConsole
     )
   end
 
+  #
+  # HTML5
+  #
+  alias_method :remote_console_html5_acquire_ticket, :remote_console_webmks_acquire_ticket
+
   def validate_remote_console_webmks_support
     validate_remote_console_acquire_ticket('webmks')
     if (api_version = ext_management_system.api_version.to_f) && api_version < 5.5

--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -418,11 +418,6 @@ module ManageIQ::Providers
     end
     alias vm_remove_disk vm_remove_disk_by_file
 
-    def vm_acquire_mks_ticket(vm, options = {})
-      invoke_vim_ws(:acquireMksTicket, vm, options[:user_event])
-    end
-    alias_method :vm_remote_console_mks_acquire_ticket, :vm_acquire_mks_ticket
-
     def vm_acquire_ticket(vm, options = {})
       invoke_vim_ws(:acquireTicket, vm, options[:user_event], options[:ticket_type])
     end

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
@@ -81,12 +81,16 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole
   end
 
   #
-  # VNC
+  # HTML5 selects the best available console type (VNC or WebMKS)
   #
-  def remote_console_html5_acquire_ticket(userid, originating_server)
-    remote_console_vnc_acquire_ticket(userid, originating_server)
+  def remote_console_html5_acquire_ticket(userid, originating_server = nil)
+    protocol = with_provider_object { |v| v.extraConfig["RemoteDisplay.vnc.enabled"] == "true" } ? 'vnc' : 'webmks'
+    send("remote_console_#{protocol}_acquire_ticket", userid, originating_server)
   end
 
+  #
+  # VNC
+  #
   def remote_console_vnc_acquire_ticket(userid, originating_server)
     validate_remote_console_acquire_ticket("vnc")
 

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
@@ -2,7 +2,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole
   require_dependency 'securerandom'
 
   def console_supported?(type)
-    %w(VMRC VNC MKS WEBMKS).include?(type.upcase)
+    %w(VMRC VNC WEBMKS).include?(type.upcase)
   end
 
   def validate_remote_console_acquire_ticket(protocol, options = {})
@@ -35,15 +35,6 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole
     }
 
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
-  end
-
-  #
-  # MKS
-  #
-
-  def remote_console_mks_acquire_ticket(_userid = nil, _originating_server = nil)
-    validate_remote_console_acquire_ticket("mks", :check_if_running => false)
-    ext_management_system.vm_remote_console_mks_acquire_ticket(self)
   end
 
   #

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/remote_console_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/remote_console_spec.rb
@@ -10,11 +10,6 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
   let(:vm) { FactoryBot.create(:vm_with_ref, :ext_management_system => ems) }
 
   context '#remote_console_acquire_ticket' do
-    it 'with :mks' do
-      expect(vm).to receive(:remote_console_mks_acquire_ticket).with(user.userid, 1)
-      vm.remote_console_acquire_ticket(user.userid, 1, :mks)
-    end
-
     it 'with :webmks' do
       expect(vm).to receive(:remote_console_webmks_acquire_ticket).with(user.userid, 1)
       vm.remote_console_acquire_ticket(user.userid, 1, :webmks)
@@ -39,15 +34,6 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
       allow(server).to receive_messages(:my_zone => nil)
       allow(server).to receive_messages(:id => 1)
       allow(MiqServer).to receive_messages(:my_server => server)
-    end
-
-    it 'with :mks' do
-      vm.remote_console_acquire_ticket_queue(:mks, user.userid)
-
-      q_all = MiqQueue.all
-      expect(q_all.length).to eq(1)
-      expect(q_all[0].method_name).to eq('remote_console_acquire_ticket')
-      expect(q_all[0].args).to eq([user.userid, 1, :mks])
     end
 
     it 'with :webmks' do


### PR DESCRIPTION
First of all, the MKS console is no longer supported so I'm dropping it completely from the codebase. Then to achieve https://github.com/ManageIQ/manageiq-ui-service/issues/1520 we need to have https://github.com/ManageIQ/manageiq-providers-vmware/issues/392 which is implemented by this PR. 

The new meta console type (named HTML5) selects the right console type based on the VM's settings. According to @agrare, the operation determining the enablement of VNC is costly, so we're doing it in the background worker. The UI should ask for this new metatype only!

Closes https://github.com/ManageIQ/manageiq-providers-vmware/issues/392
https://bugzilla.redhat.com/show_bug.cgi?id=1532720