### PR TITLE
Set rubocop channel in codeclimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -34,6 +34,7 @@ engines:
   rubocop:
     enabled: true
     config: '.rubocop_cc.yml'
+    channel: 'rubocop-0-69'
 prepare:
   fetch:
   - url: "https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml"


### PR DESCRIPTION
See https://github.com/ManageIQ/manageiq/pull/18840 for more information.

This updates the codeclimate config to use a rubocop channel so that it can deal with the splitout of the rubocop-performance gem.