### PR TITLE
Let the RefreshWorker queue the first full refresh

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
@@ -8,11 +8,6 @@ class ManageIQ::Providers::Vmware::InfraManager::RefreshWorker::Runner < ManageI
     self.ems = @emss.first
   end
 
-  def do_before_work_loop
-    # Override Standard EmsRefreshWorker's method of queueing up a Refresh
-    # This will be done by the VimBrokerWorker, when he is ready.
-  end
-
   def before_exit(_message, _exit_code)
     stop_inventory_collector if ems.supports_streaming_refresh?
   end

--- a/app/models/miq_vim_broker_worker/runner.rb
+++ b/app/models/miq_vim_broker_worker/runner.rb
@@ -115,13 +115,6 @@ class MiqVimBrokerWorker::Runner < MiqWorker::Runner
     ret == :ignore ? nil : ret
   end
 
-  def do_before_work_loop
-    if has_ems_inventory_role? && @initial_emses_to_monitor.length > 0
-      _log.info("#{log_prefix} Queueing initial refresh for EMS.")
-      EmsRefresh.queue_refresh(@initial_emses_to_monitor)
-    end
-  end
-
   def log_status
     t = Time.now.utc
     interval = worker_settings[:vim_broker_status_interval] || 15.minutes

--- a/spec/models/miq_vim_broker_worker/runner_spec.rb
+++ b/spec/models/miq_vim_broker_worker/runner_spec.rb
@@ -114,29 +114,6 @@ describe MiqVimBrokerWorker::Runner do
       @vim_broker_worker.do_heartbeat_work
     end
 
-    context "#do_before_work_loop" do
-      it "should do nothing when active roles does not include 'ems_inventory'" do
-        @vim_broker_worker.instance_variable_set(:@active_roles, ['foo', 'bar'])
-        expect(EmsRefresh).to receive(:queue_refresh).never
-        @vim_broker_worker.do_before_work_loop
-      end
-
-      it "should do nothing when active roles includes 'ems_inventory' and there are no EMSes to monitor" do
-        @vim_broker_worker.instance_variable_set(:@active_roles, ['foo', 'bar', 'ems_inventory'])
-        @vim_broker_worker.instance_variable_set(:@initial_emses_to_monitor, [])
-        expect(EmsRefresh).to receive(:queue_refresh).never
-        @vim_broker_worker.do_before_work_loop
-      end
-
-      it "should call EmsRefresh.queue_refresh when active roles includes 'ems_inventory' and there are EMSes to monitor" do
-        @vim_broker_worker.instance_variable_set(:@active_roles, ['foo', 'bar', 'ems_inventory'])
-        emses = @zone.ext_management_systems
-        @vim_broker_worker.instance_variable_set(:@initial_emses_to_monitor, emses)
-        expect(EmsRefresh).to receive(:queue_refresh).with(emses).once
-        @vim_broker_worker.do_before_work_loop
-      end
-    end
-
     context "#create_miq_vim_broker_server" do
       it "with ems_inventory role" do
         @vim_broker_worker.instance_variable_set(:@active_roles, ['ems_inventory'])


### PR DESCRIPTION
Move VMware more in line with the other providers by allowing the
RefreshWorker to queue the first full when it starts up.

This used to be done by the VimBrokerWorker because the RefreshWorkers
restarted every 2 hours. Now that https://github.com/ManageIQ/manageiq/pull/19010 does restart the
refresh_worker every 2 hours we can go back to just handling this in the
RefreshWorker.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1439387
Fixes https://github.com/ManageIQ/manageiq/issues/14813