### PR TITLE
Don't allow adding ESX hosts as VMware providers

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -145,10 +145,7 @@ module ManageIQ::Providers
     end
 
     def verify_credentials(auth_type = nil, _options = {})
-      self.class.validate_connection do
-        with_provider_connection(:use_broker => false, :auth_type => auth_type) {}
-      end
-      true
+      self.class.raw_connect(:use_broker => false, :ems => self)
     end
 
     def reset_vim_cache

--- a/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
@@ -38,7 +38,8 @@ module ManageIQ::Providers::Vmware::InfraManager::VimConnectMixin
 
       options[:pass] = ManageIQ::Password.try_decrypt(options[:pass])
       validate_connection do
-        MiqFaultTolerantVim.new(options)
+        vim = MiqFaultTolerantVim.new(options)
+        raise MiqException::Error, _("Adding ESX/ESXi Hosts is not supported") unless vim.isVirtualCenter
       end
     end
 
@@ -54,6 +55,9 @@ module ManageIQ::Providers::Vmware::InfraManager::VimConnectMixin
         raise $!.reason
       end
       raise $!.message
+    rescue MiqException::Error
+      _log.warn($!.inspect)
+      raise
     rescue Exception
       _log.warn($!.inspect)
       raise "Unexpected response returned from Provider, see log for details"


### PR DESCRIPTION
When validating credentials check that the entity that we are connected
to is a vCenter server not an ESX host.

![Screenshot from 2019-07-22 14-25-29](https://user-images.githubusercontent.com/12851112/61655553-cdd1fa00-ac8c-11e9-92b3-851b3599b050.png)

NOTE: for that screenshot I had to modify the code to raise that exception on a VC since we don't have any hosts that still have the `/mob` endpoint exposed.  I believe that ended with 6.0 or 6.5.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1731548