### PR TITLE
Fix HostStorages being deleted by host targeted refresh

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
@@ -18,7 +18,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister < ManageIQ
     add_collection(infra, :host_hardwares)
     add_collection(infra, :host_guest_devices)
     add_collection(infra, :host_networks)
-    add_collection(infra, :host_storages)
+    add_collection(infra, :host_storages, :parent_inventory_collections => %i[storages])
     add_collection(infra, :host_switches)
     add_collection(infra, :host_system_services)
     add_collection(infra, :host_operating_systems)

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -529,12 +529,12 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         :kind            => "modify",
         :obj             => obj,
         :changeSet       => [
-          #RbVmomi::VIM.PropertyChange(:name => "config.network.portgroup[\"key-vim.host.PortGroup-VM Network\"].port[\"key-vim.host.PortGroup.Port-33554449\"]", :op => "assign"),
-          #RbVmomi::VIM.PropertyChange(:name => "config.network.portgroup[\"key-vim.host.PortGroup-VM Network\"].port[\"key-vim.host.PortGroup.Port-33554449\"]", :op => "assign"),
-          #RbVmomi::VIM.PropertyChange(:name => "config.network.portgroup[\"key-vim.host.PortGroup-VM Network\"].port[\"key-vim.host.PortGroup.Port-33554455\"]", :op => "assign"),
-          RbVmomi::VIM.PropertyChange(:name => "config.network.vswitch[\"key-vim.host.VirtualSwitch-vSwitch0\"].numPortsAvailable", :op => "assign"),
+          RbVmomi::VIM.PropertyChange(
+            :name => "config.network.vswitch[\"key-vim.host.VirtualSwitch-vSwitch0\"].numPortsAvailable",
+            :op   => "assign"
+          )
         ],
-        :missingSet      => [],
+        :missingSet      => []
       )
     end
 


### PR DESCRIPTION
A host targeted refresh was deleting related host_storages because the host_storages are actually refreshed by the storage target.