### PR TITLE
Fix clone vm to template check_provision

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
@@ -30,7 +30,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
     # to prevent issues with post-provision depending on data that isn't in VMDB yet
     return if source.ext_management_system.last_inventory_date < phase_context[:clone_vm_task_completion_time]
 
-    source.ext_management_system.vms_and_templates.find_by(:ems_ref => phase_context[:new_vm_ems_ref])
+    source.ext_management_system&.vms_and_templates&.find_by(:ems_ref => phase_context[:new_vm_ems_ref])
   end
 
   def prepare_for_clone_task

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
@@ -30,7 +30,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
     # to prevent issues with post-provision depending on data that isn't in VMDB yet
     return if source.ext_management_system.last_inventory_date < phase_context[:clone_vm_task_completion_time]
 
-    source.ext_management_system.vms.find_by(:ems_ref => phase_context[:new_vm_ems_ref])
+    source.ext_management_system.vms_and_templates.find_by(:ems_ref => phase_context[:new_vm_ems_ref])
   end
 
   def prepare_for_clone_task


### PR DESCRIPTION
The same find_destination_in_vmdb is used when cloning a vm to a
template, so we can't use ext_management_system.vms.find_by()

https://bugzilla.redhat.com/show_bug.cgi?id=1734051