### PR TITLE
Add test for datastore targeted refresh

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
@@ -18,7 +18,9 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister < ManageIQ
     add_collection(infra, :host_hardwares)
     add_collection(infra, :host_guest_devices)
     add_collection(infra, :host_networks)
-    add_collection(infra, :host_storages, :parent_inventory_collections => %i[storages])
+    add_collection(infra, :host_storages, :parent_inventory_collections => %i[storages]) do |builder|
+      builder.add_properties(:arel => manager.host_storages.joins(:storage))
+    end
     add_collection(infra, :host_switches)
     add_collection(infra, :host_system_services)
     add_collection(infra, :host_operating_systems)

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -90,6 +90,10 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         distributed_virtual_portgroup = RbVmomi::VIM::DistributedVirtualPortgroup(vim, "dvportgroup-11")
         run_targeted_refresh(targeted_update_set([targeted_object_update(distributed_virtual_portgroup)]))
         assert_ems
+
+        datastore = RbVmomi::VIM::Datastore(vim, "datastore-15")
+        run_targeted_refresh(targeted_update_set([targeted_object_update(datastore)]))
+        assert_ems
       end
 
       it "power on a virtual machine" do


### PR DESCRIPTION
Datastore targeted refresh yields the following error
```
[----] I, [2019-07-30T16:29:18.057279 #14687:2ac7797d65c0]  INFO -- : EMS: [ems_0000000000001], id: [61000000000033] Saving EMS Inventory...
[----] E, [2019-07-30T16:29:18.088618 #14687:2ac7797d65c0] ERROR -- : Error when saving InventoryCollection:<HostStorage>, strategy: local_db_find_missing_references with strategy:      local_db_find_missing_references, saver_strategy: default, targeted: true. Message: PG::UndefinedTable: ERROR:  missing FROM-clause entry for table "storages"
LINE 1: ... = "hosts"."id" WHERE "hosts"."ems_id" = $1 AND (("storages"...
                                                             ^
: SELECT "host_storages".* FROM "host_storages" INNER JOIN "hosts" ON "host_storages"."host_id" = "hosts"."id" WHERE "hosts"."ems_id" = $1 AND (("storages"."location" = 'ds:///vmfs/     volumes/5280a4c3-b5e2-7dc7-5c31-7a344d35466c/'))
```