### PR TITLE
Add note about thick eager zero taking a while to complete

### DIFF
--- a/content/miq_dialogs/miq_provision_vmware_cluster_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_cluster_dialogs_template.yaml
@@ -610,6 +610,8 @@
             unchanged: Default
           :description: Disk Format
           :required: false
+          :notes: (The Eager Zero option will greatly increase the time required to complete provisioning.)
+          :notes_display: :show
           :display: :edit
           :default: unchanged
           :data_type: :string

--- a/content/miq_dialogs/miq_provision_vmware_dialogs_clone_to_template.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_dialogs_clone_to_template.yaml
@@ -647,6 +647,8 @@
             unchanged: Default
           :description: Disk Format
           :required: false
+          :notes: (The Eager Zero option will greatly increase the time required to complete provisioning.)
+          :notes_display: :show
           :display: :edit
           :default: unchanged
           :data_type: :string

--- a/content/miq_dialogs/miq_provision_vmware_dialogs_clone_to_vm.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_dialogs_clone_to_vm.yaml
@@ -655,6 +655,8 @@
             thin: Thin
             unchanged: Default
           :description: Disk Format
+          :notes: (The Eager Zero option will greatly increase the time required to complete provisioning.)
+          :notes_display: :show
           :required: false
           :display: :edit
           :default: unchanged

--- a/content/miq_dialogs/miq_provision_vmware_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_dialogs_template.yaml
@@ -688,6 +688,8 @@
             unchanged: Default
           :description: Disk Format
           :required: false
+          :notes: (The Eager Zero option will greatly increase the time required to complete provisioning.)
+          :notes_display: :show
           :display: :edit
           :default: unchanged
           :data_type: :string

--- a/content/miq_dialogs/miq_provision_vmware_folder_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_folder_dialogs_template.yaml
@@ -600,6 +600,8 @@
             unchanged: Default
           :description: Disk Format
           :required: false
+          :notes: (The Eager Zero option will greatly increase the time required to complete provisioning.)
+          :notes_display: :show
           :display: :edit
           :default: unchanged
           :data_type: :string


### PR DESCRIPTION
Thick eager zero disk optioning, added in https://github.com/ManageIQ/manageiq-providers-vmware/pull/385, needs a note about how long it takes per convo with Dennis and GM. 

@miq-bot add_label enhancement

@miq-bot assign @agrare

<img width="748" alt="Screen Shot 2019-08-01 at 2 55 41 PM" src="https://user-images.githubusercontent.com/16326669/62319663-78f06980-b46c-11e9-8498-fa233bf4cb11.png">
