### PR TITLE
Don't start_inventory_collector in do_before_work

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
@@ -11,9 +11,6 @@ class ManageIQ::Providers::Vmware::InfraManager::RefreshWorker::Runner < ManageI
   def do_before_work_loop
     # Override Standard EmsRefreshWorker's method of queueing up a Refresh
     # This will be done by the VimBrokerWorker, when he is ready.
-    return unless ems.supports_streaming_refresh?
-
-    start_inventory_collector
   end
 
   def before_exit(_message, _exit_code)


### PR DESCRIPTION
The very next thing that runs is do_work which will start the inventory
collector thread anyway.