### PR TITLE
Build the remote console URL for VMRC consoles when making a ticket

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -75,7 +75,7 @@ module ManageIQ::Providers
         end
       end
 
-      {:ticket => ticket}
+      ticket
     end
 
     def remote_console_vmrc_support_known?

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/remote_console_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/remote_console_spec.rb
@@ -2,10 +2,17 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
   let(:user) { FactoryBot.create(:user) }
   let(:ems) do
     FactoryBot.create(:ems_vmware,
-                       :hostname    => '192.168.252.16',
-                       :ipaddress   => '192.168.252.16',
-                       :api_version => '5.0',
-                       :uid_ems     => '2E1C1E82-BD83-4E54-9271-630C6DFAD4D1')
+                      :hostname    => '192.168.252.16',
+                      :ipaddress   => '192.168.252.16',
+                      :api_version => '5.0',
+                      :uid_ems     => '2E1C1E82-BD83-4E54-9271-630C6DFAD4D1')
+  end
+  let(:host) do
+    FactoryBot.create(:host_vmware,
+                      :ext_management_system   => ems,
+                      :hostname                => '192.168.252.4',
+                      :ipaddress               => '192.168.252.4',
+                      :next_available_vnc_port => 5901)
   end
   let(:vm) { FactoryBot.create(:vm_with_ref, :ext_management_system => ems) }
 
@@ -147,6 +154,8 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
   end
 
   context '#remote_console_vmrc_acquire_ticket' do
+    let(:vm) { FactoryBot.create(:vm_with_ref, :ext_management_system => ems, :host => host) }
+
     it 'normal case' do
       EvmSpecHelper.create_guid_miq_server_zone
       ems.update_attributes(:ipaddress => '192.168.252.14', :hostname => '192.168.252.14')
@@ -202,13 +211,6 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
 
   context '#remote_console_vnc_acquire_ticket' do
     let(:ems) { FactoryBot.create(:ems_vmware) }
-    let(:host) do
-      FactoryBot.create(:host_vmware,
-                         :ext_management_system   => ems,
-                         :hostname                => '192.168.252.4',
-                         :ipaddress               => '192.168.252.4',
-                         :next_available_vnc_port => 5901)
-    end
     let(:vm) { FactoryBot.create(:vm_with_ref, :ext_management_system => ems, :host => host) }
 
     let(:server) { double('MiqServer') }


### PR DESCRIPTION
Instead of generating the URL for the VMRC consoles in the [UI repo](https://github.com/ManageIQ/manageiq-ui-classic/blob/53ae47a11a85bd7268156e3a552030f39fd91279/app/controllers/vm_remote.rb#L112-L121), I'm moving the code here so we can consume it from the SUI as well. This will enable us to have VMRC support in [SUI](https://github.com/ManageIQ/manageiq/issues/18718).

@miq-bot assign @agrare 