### PR TITLE
Simplify the RefreshWorker by moving thread logic

### DIFF
--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -566,7 +566,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
 
     def run_full_refresh
       collector.stop # Calling stop before run only runs this once
-      collector.run
+      collector.send(:vim_collector)
     end
 
     def assert_ems


### PR DESCRIPTION
Move the thread start, stop, and running? logic out of the
refresh_worker::runner and into the collector itself.

As we add more types of collectors (e.g. pbm, content-library) this
allows us to keep the knowledge of these compartmentalized.