### PR TITLE
Fix verify_credentials returning nil

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
@@ -40,6 +40,7 @@ module ManageIQ::Providers::Vmware::InfraManager::VimConnectMixin
       validate_connection do
         vim = MiqFaultTolerantVim.new(options)
         raise MiqException::Error, _("Adding ESX/ESXi Hosts is not supported") unless vim.isVirtualCenter
+        true
       end
     end
 


### PR DESCRIPTION
When raw_connect returns nil verify_credentials assumes this is invalid so we have to return true.

Introduced by refactoring in https://github.com/ManageIQ/manageiq-providers-vmware/pull/415