### PR TITLE
Support vm_destroy for vmware templates

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/template.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/template.rb
@@ -9,5 +9,6 @@ class ManageIQ::Providers::Vmware::InfraManager::Template < ManageIQ::Providers:
     end
   end
 
+  supports :terminate
   supports :rename
 end


### PR DESCRIPTION
VMware templates can be destroyed just like normal VMs (there is no real
difference between the two objects other than config.template = t).

This is the backend component of https://bugzilla.redhat.com/show_bug.cgi?id=1712128