### PR TITLE
Fix URL building for VMRC to use EMS host/ip instead of the host's

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
@@ -136,7 +136,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole
   def build_vmrc_url(ticket)
     url = URI::Generic.build(:scheme   => "vmrc",
                              :userinfo => "clone:#{ticket}",
-                             :host     => host.hostname || host.ipaddress,
+                             :host     => ext_management_system.hostname || ext_management_system.ipaddress,
                              :port     => 443,
                              :path     => "/",
                              :query    => "moid=#{ems_ref}").to_s


### PR DESCRIPTION
This is a very nasty regression, originally we were building the address from the EMS's host/ip and when it has been moved to this repo, somehow I wrote it with the host :see_no_evil: . Unfortunately, the host also responds to VMRC, but only with a bad password error.

@miq-bot add_label hammer/no, ivanchuk/yes, bug
@miq-bot assign @agrare 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1744981