### PR TITLE
Collect the host NIC speed

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/host_system.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/host_system.rb
@@ -212,6 +212,9 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
       pnics.to_a.each do |pnic|
         name = uid = pnic.device
 
+        link_speed  = pnic.linkSpeed&.speedMb
+        link_speed *= 1000 if link_speed
+
         persister.host_guest_devices.build(
           :hardware        => hardware,
           :uid_ems         => uid,
@@ -221,6 +224,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
           :present         => true,
           :controller_type => 'ethernet',
           :address         => pnic.mac,
+          :speed           => link_speed
         )
       end
     end

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -565,6 +565,9 @@ module ManageIQ::Providers
 
             name = uid = data['device']
 
+            link_speed  = data.dig("linkSpeed", "speedMb")&.to_i
+            link_speed *= 1000 if link_speed
+
             new_result = {
               :uid_ems         => uid,
               :device_name     => name,
@@ -572,7 +575,8 @@ module ManageIQ::Providers
               :location        => data['pci'],
               :present         => true,
               :controller_type => 'ethernet',
-              :address         => data['mac']
+              :address         => data['mac'],
+              :speed           => link_speed
             }
             new_result[:switch] = switch unless switch.nil?
 

--- a/app/models/manageiq/providers/vmware/infra_manager/selector_spec.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/selector_spec.rb
@@ -18,6 +18,7 @@ module ManageIQ::Providers::Vmware::InfraManager::SelectorSpec
       "config.network.pnic[*].key",
       "config.network.pnic[*].pci",
       "config.network.pnic[*].mac",
+      "config.network.pnic[*].linkSpeed",
       "config.network.portgroup[*].computedPolicy.security.allowPromiscuous",
       "config.network.portgroup[*].computedPolicy.security.forgedTransmits",
       "config.network.portgroup[*].computedPolicy.security.macChanges",


### PR DESCRIPTION
Set the GuestDevice.speed for host physical nics to the linkSpeed in
bits-per-second.

Schema change: https://github.com/ManageIQ/manageiq-schema/pull/411