### PR TITLE
Fix missing inventory_collector_running? method

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
@@ -20,7 +20,7 @@ class ManageIQ::Providers::Vmware::InfraManager::RefreshWorker::Runner < ManageI
   def do_work
     if ems.supports_streaming_refresh?
       ensure_inventory_collector
-    elsif inventory_collector_running?
+    elsif collector&.running?
       stop_inventory_collector
     end
 


### PR DESCRIPTION
When cleaning up how the collector thread was started and monitored
missed one place where one of the methods was called.