### PR TITLE
Moving orchestration_template builder property to core infra builder

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
@@ -40,7 +40,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister < ManageIQ
     add_collection(infra, :vm_parent_blue_folders)
     add_collection(infra, :vm_resource_pools)
     add_collection(infra, :root_folder_relationship)
-    add_collection(infra, :orchestration_templates, &:add_common_default_values)
+    add_collection(infra, :orchestration_templates)
   end
 
   def vim_class_to_collection(managed_object)


### PR DESCRIPTION
Depending on https://github.com/ManageIQ/manageiq/pull/19273