### PR TITLE
update_attributes deprecated

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm/operations.rb
@@ -15,6 +15,6 @@ module ManageIQ::Providers::Vmware::CloudManager::Vm::Operations
       response = service.delete_vapp(ems_ref)
       service.process_task(response.body)
     end
-    update_attributes!(:raw_power_state => "off")
+    update!(:raw_power_state => "off")
   end
 end

--- a/app/models/manageiq/providers/vmware/cloud_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm/operations/power.rb
@@ -5,7 +5,7 @@ module ManageIQ::Providers::Vmware::CloudManager::Vm::Operations::Power
 
   def raw_start
     with_provider_object(&:power_on)
-    update_attributes!(:raw_power_state => "on")
+    update!(:raw_power_state => "on")
   end
 
   def raw_stop
@@ -13,7 +13,7 @@ module ManageIQ::Providers::Vmware::CloudManager::Vm::Operations::Power
       response = service.post_undeploy_vapp(ems_ref, :UndeployPowerAction => 'powerOff')
       service.process_task(response.body)
     end
-    update_attributes!(:raw_power_state => "off")
+    update!(:raw_power_state => "off")
   end
 
   def raw_suspend
@@ -21,11 +21,11 @@ module ManageIQ::Providers::Vmware::CloudManager::Vm::Operations::Power
       response = service.post_undeploy_vapp(ems_ref, :UndeployPowerAction => 'suspend')
       service.process_task(response.body)
     end
-    update_attributes!(:raw_power_state => "suspended")
+    update!(:raw_power_state => "suspended")
   end
 
   def raw_restart
     with_provider_object(&:reset)
-    update_attributes!(:raw_power_state => "on")
+    update!(:raw_power_state => "on")
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/host.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/host.rb
@@ -38,7 +38,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Host < ::Host
       port = port_start unless port.in?(port_start..port_end)
 
       next_port = (port == port_end ? port_start : port + 1)
-      update_attributes(:next_available_vnc_port => next_port)
+      update(:next_available_vnc_port => next_port)
 
       port
     end

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -53,7 +53,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
     _log.error("#{log_header} Refresh failed")
     _log.log_backtrace(err)
 
-    ems.update_attributes(:last_refresh_error => err.to_s, :last_refresh_date => Time.now.utc)
+    ems.update(:last_refresh_error => err.to_s, :last_refresh_date => Time.now.utc)
   ensure
     destroy_property_filter(property_filter)
     disconnect(vim)

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/saver.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/saver.rb
@@ -95,7 +95,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Saver
   end
 
   def update_ems_refresh_stats(ems, error: nil)
-    ems.update_attributes(:last_refresh_error => error, :last_refresh_date => Time.now.utc)
+    ems.update(:last_refresh_error => error, :last_refresh_date => Time.now.utc)
   end
 
   def log_header_for_ems(ems)

--- a/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
@@ -57,7 +57,7 @@ module ManageIQ::Providers
       def save_inventory(ems, target, hashes)
         Benchmark.realtime_block(:db_save_inventory) do
           # TODO: really wanna kill this @ems_data instance var
-          ems.update_attributes(@ems_data) unless @ems_data.nil?
+          ems.update(@ems_data) unless @ems_data.nil?
           EmsRefresh.save_ems_inventory(ems, hashes, target)
         end
       end
@@ -78,7 +78,7 @@ module ManageIQ::Providers
       end
 
       def set_last_inventory_date(ems)
-        ems.update_attributes!(:last_inventory_date => @last_inventory_date)
+        ems.update!(:last_inventory_date => @last_inventory_date)
       end
 
       #

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
@@ -113,7 +113,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole
     with_provider_object do |vim_vm|
       vim_vm.setRemoteDisplayVncAttributes(:enabled => true, :port => host_port, :password => password)
     end
-    update_attributes(:vnc_port => host_port)
+    update(:vnc_port => host_port)
 
     SystemConsole.force_vm_invalid_token(id)
 

--- a/app/models/miq_ems_refresh_core_worker/runner.rb
+++ b/app/models/miq_ems_refresh_core_worker/runner.rb
@@ -134,7 +134,7 @@ class MiqEmsRefreshCoreWorker::Runner < MiqWorker::Runner
 
     unless new_attrs.blank?
       _log.info("#{log_prefix} Updating Vm id: [#{vm.id}], name: [#{vm.name}] with the following attributes: #{new_attrs.inspect}")
-      vm.update_attributes(new_attrs)
+      vm.update(new_attrs)
     end
   end
 
@@ -169,7 +169,7 @@ class MiqEmsRefreshCoreWorker::Runner < MiqWorker::Runner
 
     unless new_attrs_by_nic_uid.empty?
       _log.info("#{log_prefix} Updating Vm id: [#{vm.id}], name: [#{vm.name}] with the following network attributes: #{new_attrs_by_nic_uid.inspect}")
-      new_attrs_by_nic_uid.each { |uid, new_attrs| nics_by_uid[uid].network.update_attributes(new_attrs) }
+      new_attrs_by_nic_uid.each { |uid, new_attrs| nics_by_uid[uid].network.update(new_attrs) }
     end
   end
 end

--- a/app/models/miq_vim_broker_worker/runner.rb
+++ b/app/models/miq_vim_broker_worker/runner.rb
@@ -7,7 +7,7 @@ class MiqVimBrokerWorker::Runner < MiqWorker::Runner
 
     @initial_emses_to_monitor, invalid_emses = MiqVimBrokerWorker.emses_to_monitor.partition { |e| e.authentication_check.first }
     start_broker_server(@initial_emses_to_monitor)
-    @worker.update_attributes(:uri => DRb.uri)
+    @worker.update(:uri => DRb.uri)
     _log.info("#{log_prefix} DRb URI: #{DRb.uri}")
 
     invalid_emses.each do |e|

--- a/spec/models/manageiq/providers/vmware/infra_manager/host_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/host_spec.rb
@@ -11,35 +11,35 @@ describe ManageIQ::Providers::Vmware::InfraManager::Host do
       end
 
       it "normal case" do
-        @host.update_attributes(:next_available_vnc_port => 5901)
+        @host.update(:next_available_vnc_port => 5901)
 
         expect(@host.reserve_next_available_vnc_port).to eq(5901)
         expect(@host.next_available_vnc_port).to eq(5902)
       end
 
       it "with last value of nil" do
-        @host.update_attributes(:next_available_vnc_port => nil)
+        @host.update(:next_available_vnc_port => nil)
 
         expect(@host.reserve_next_available_vnc_port).to eq(5900)
         expect(@host.next_available_vnc_port).to eq(5901)
       end
 
       it "with last value at end of range" do
-        @host.update_attributes(:next_available_vnc_port => 5999)
+        @host.update(:next_available_vnc_port => 5999)
 
         expect(@host.reserve_next_available_vnc_port).to eq(5999)
         expect(@host.next_available_vnc_port).to eq(5900)
       end
 
       it "with last value before start of range" do
-        @host.update_attributes(:next_available_vnc_port => 5899)
+        @host.update(:next_available_vnc_port => 5899)
 
         expect(@host.reserve_next_available_vnc_port).to eq(5900)
         expect(@host.next_available_vnc_port).to eq(5901)
       end
 
       it "with last value after end of range" do
-        @host.update_attributes(:next_available_vnc_port => 6000)
+        @host.update(:next_available_vnc_port => 6000)
 
         expect(@host.reserve_next_available_vnc_port).to eq(5900)
         expect(@host.next_available_vnc_port).to eq(5901)
@@ -53,35 +53,35 @@ describe ManageIQ::Providers::Vmware::InfraManager::Host do
       end
 
       it "normal case" do
-        @host.update_attributes(:next_available_vnc_port => 5926)
+        @host.update(:next_available_vnc_port => 5926)
 
         expect(@host.reserve_next_available_vnc_port).to eq(5926)
         expect(@host.next_available_vnc_port).to eq(5927)
       end
 
       it "with last value of nil" do
-        @host.update_attributes(:next_available_vnc_port => nil)
+        @host.update(:next_available_vnc_port => nil)
 
         expect(@host.reserve_next_available_vnc_port).to eq(5925)
         expect(@host.next_available_vnc_port).to eq(5926)
       end
 
       it "with last value at end of range" do
-        @host.update_attributes(:next_available_vnc_port => 5930)
+        @host.update(:next_available_vnc_port => 5930)
 
         expect(@host.reserve_next_available_vnc_port).to eq(5930)
         expect(@host.next_available_vnc_port).to eq(5925)
       end
 
       it "with last value before start of range" do
-        @host.update_attributes(:next_available_vnc_port => 5924)
+        @host.update(:next_available_vnc_port => 5924)
 
         expect(@host.reserve_next_available_vnc_port).to eq(5925)
         expect(@host.next_available_vnc_port).to eq(5926)
       end
 
       it "with last value after end of range" do
-        @host.update_attributes(:next_available_vnc_port => 5931)
+        @host.update(:next_available_vnc_port => 5931)
 
         expect(@host.reserve_next_available_vnc_port).to eq(5925)
         expect(@host.next_available_vnc_port).to eq(5926)

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
@@ -378,7 +378,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
 
       describe '#get_next_vm_name' do
         before do
-          @vm_prov.update_attributes(:options => @options.merge(:miq_force_unique_name => true))
+          @vm_prov.update(:options => @options.merge(:miq_force_unique_name => true))
           allow(MiqRegion).to receive_message_chain('my_region.next_naming_sequence').and_return(123)
         end
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
@@ -33,28 +33,28 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
       end
 
       it "08" do
-        vm.hardware.update_attributes(:virtual_hw_version => "08")
+        vm.hardware.update(:virtual_hw_version => "08")
         expect(subject).to eq(32)
       end
 
       it "09" do
-        vm.hardware.update_attributes(:virtual_hw_version => "09")
+        vm.hardware.update(:virtual_hw_version => "09")
         expect(subject).to eq(64)
       end
 
       it "10" do
-        vm.hardware.update_attributes(:virtual_hw_version => "10")
+        vm.hardware.update(:virtual_hw_version => "10")
         expect(subject).to eq(64)
       end
 
       it "11" do
-        vm.hardware.update_attributes(:virtual_hw_version => "11")
+        vm.hardware.update(:virtual_hw_version => "11")
         expect(subject).to eq(128)
       end
     end
 
     it "small host logical cpus" do
-      @host.hardware.update_attributes(:cpu_total_cores => 4)
+      @host.hardware.update(:cpu_total_cores => 4)
       expect(subject).to eq(4)
     end
 
@@ -63,7 +63,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
     end
 
     it 'when no host' do
-      vm.update_attributes(:host_id => nil)
+      vm.update(:host_id => nil)
       expect(subject).to eq(vm.max_total_vcpus_by_version)
     end
   end
@@ -86,14 +86,14 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
       end
 
       it "vm_vmware virtual_hw_version != 07" do
-        vm.hardware.update_attributes(:virtual_hw_version => "08")
+        vm.hardware.update(:virtual_hw_version => "08")
         expect(subject["numCoresPerSocket"]).to eq(2)
       end
     end
 
     context "Running VM" do
       before do
-        vm.update_attributes(:raw_power_state => 'poweredOn')
+        vm.update(:raw_power_state => 'poweredOn')
       end
 
       context "with CPU Hot-Add disabled" do
@@ -105,7 +105,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
 
       context "with CPU Hot-Add enabled" do
         before do
-          vm.update_attributes(:cpu_hot_add_enabled    => true,
+          vm.update(:cpu_hot_add_enabled    => true,
                                :cpu_hot_remove_enabled => false)
         end
 
@@ -138,7 +138,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
 
       context "with Memory Hot-Add enabled" do
         before do
-          vm.update_attributes(:memory_hot_add_enabled => true,
+          vm.update(:memory_hot_add_enabled => true,
                                :memory_hot_add_limit   => 2048)
         end
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/remote_console_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/remote_console_spec.rb
@@ -158,7 +158,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
 
     it 'normal case' do
       EvmSpecHelper.create_guid_miq_server_zone
-      ems.update_attributes(:ipaddress => '192.168.252.14', :hostname => '192.168.252.14')
+      ems.update(:ipaddress => '192.168.252.14', :hostname => '192.168.252.14')
       auth = FactoryBot.create(:authentication,
                                 :userid   => 'dev1',
                                 :password => 'dev1pass',

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm_spec.rb
@@ -51,14 +51,14 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm do
 
       it 'is not available if tools is not installed' do
         vm_status[:tools_status] = 'toolsNotInstalled'
-        vm.update_attributes(vm_status)
+        vm.update(vm_status)
         expect(vm.public_send("supports_#{op}?")).to be false
         expect(vm.unsupported_reason(op)).to include("power")
       end
 
       it 'is not available even if tools is installed' do
         vm_status[:tools_status] = nil
-        vm.update_attributes(vm_status)
+        vm.update(vm_status)
         expect(vm.public_send("supports_#{op}?")).to be false
         expect(vm.unsupported_reason(op)).to include("power")
       end
@@ -69,7 +69,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm do
 
       it 'is not available if tools not installed' do
         vm_status[:tools_status] = 'toolsNotInstalled'
-        vm.update_attributes(vm_status)
+        vm.update(vm_status)
         expect(vm.public_send("supports_#{op}?")).to be false
         expect(vm.unsupported_reason(op)).to include("tools")
       end
@@ -89,14 +89,14 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm do
 
       it 'is not available if tools is not installed' do
         vm_status[:tools_status] = 'toolsNotInstalled'
-        vm.update_attributes(vm_status)
+        vm.update(vm_status)
         expect(vm.public_send("supports_#{op}?")).to be false
         expect(vm.unsupported_reason(op)).to include("power")
       end
 
       it 'is not available even if tools is installed' do
         vm_status[:tools_status] = nil
-        vm.update_attributes(vm_status)
+        vm.update(vm_status)
         expect(vm.public_send("supports_#{op}?")).to be false
         expect(vm.unsupported_reason(op)).to include("power")
       end
@@ -107,7 +107,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm do
 
       it 'is not available if tools not installed' do
         vm_status[:tools_status] = 'toolsNotInstalled'
-        vm.update_attributes(vm_status)
+        vm.update(vm_status)
         expect(vm.public_send("supports_#{op}?")).to be false
         expect(vm.unsupported_reason(op)).to include("tools")
       end
@@ -124,7 +124,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm do
       let(:power_state) {{:raw_power_state => power_state_on}}
 
       it "is allowed" do
-        vm.update_attributes(power_state)
+        vm.update(power_state)
         expect(vm.snapshotting_memory_allowed?).to be_truthy
       end
     end
@@ -132,7 +132,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm do
     context "when powered off" do
       let(:power_state) {{:raw_power_state => power_state_suspended}}
       it "is not allowed" do
-        vm.update_attributes(power_state)
+        vm.update(power_state)
         expect(vm.snapshotting_memory_allowed?).to be_falsy
       end
     end

--- a/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
@@ -20,22 +20,22 @@ describe ManageIQ::Providers::Vmware::InfraManager do
     end
 
     it "not raise for api_version == 5.0" do
-      @ems.update_attributes(:api_version => "5.0", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
+      @ems.update(:api_version => "5.0", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
       expect { @ems.validate_remote_console_vmrc_support }.not_to raise_error
     end
 
     it "raise for api_version == 4.0" do
-      @ems.update_attributes(:api_version => "4.0", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
+      @ems.update(:api_version => "4.0", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
       expect { @ems.validate_remote_console_vmrc_support }.to raise_error MiqException::RemoteConsoleNotSupportedError
     end
 
     it "raise for api_version == 4.1" do
-      @ems.update_attributes(:api_version => "4.1", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
+      @ems.update(:api_version => "4.1", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
       expect { @ems.validate_remote_console_vmrc_support }.to raise_error MiqException::RemoteConsoleNotSupportedError
     end
 
     it "raise for missing/blank values" do
-      @ems.update_attributes(:api_version => "", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
+      @ems.update(:api_version => "", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
       expect { @ems.validate_remote_console_vmrc_support }.to raise_error MiqException::RemoteConsoleNotSupportedError
     end
   end
@@ -46,32 +46,32 @@ describe ManageIQ::Providers::Vmware::InfraManager do
     end
 
     it "true with nothing missing/blank" do
-      @ems.update_attributes(:api_version => "5.0", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
+      @ems.update(:api_version => "5.0", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
       expect(@ems.remote_console_vmrc_support_known?).to be_truthy
     end
 
     it "false for blank hostname" do
-      @ems.update_attributes(:hostname => "", :api_version => "5.0", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
+      @ems.update(:hostname => "", :api_version => "5.0", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
       expect(@ems.remote_console_vmrc_support_known?).not_to be_truthy
     end
 
     it "false for missing api_version" do
-      @ems.update_attributes(:api_version => nil, :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
+      @ems.update(:api_version => nil, :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
       expect(@ems.remote_console_vmrc_support_known?).not_to be_truthy
     end
 
     it "false for blank api_version" do
-      @ems.update_attributes(:api_version => "", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
+      @ems.update(:api_version => "", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
       expect(@ems.remote_console_vmrc_support_known?).not_to be_truthy
     end
 
     it "false for missing uid_ems" do
-      @ems.update_attributes(:api_version => "5.0", :uid_ems => nil)
+      @ems.update(:api_version => "5.0", :uid_ems => nil)
       expect(@ems.remote_console_vmrc_support_known?).not_to be_truthy
     end
 
     it "false for blank uid_ems" do
-      @ems.update_attributes(:api_version => "5.0", :uid_ems => "")
+      @ems.update(:api_version => "5.0", :uid_ems => "")
       expect(@ems.remote_console_vmrc_support_known?).not_to be_truthy
     end
   end
@@ -120,12 +120,12 @@ describe ManageIQ::Providers::Vmware::InfraManager do
     end
 
     it "will restart EventCatcher when ipaddress changes" do
-      @ems.update_attributes(:ipaddress => "1.1.1.1")
+      @ems.update(:ipaddress => "1.1.1.1")
       assert_event_catcher_restart_queued
     end
 
     it "will restart EventCatcher when hostname changes" do
-      @ems.update_attributes(:hostname => "something-else")
+      @ems.update(:hostname => "something-else")
       assert_event_catcher_restart_queued
     end
 
@@ -135,13 +135,13 @@ describe ManageIQ::Providers::Vmware::InfraManager do
     end
 
     it "will not put multiple restarts of the EventCatcher on the queue" do
-      @ems.update_attributes(:ipaddress => "1.1.1.1")
-      @ems.update_attributes(:hostname => "something else")
+      @ems.update(:ipaddress => "1.1.1.1")
+      @ems.update(:hostname => "something else")
       assert_event_catcher_restart_queued
     end
 
     it "will not restart EventCatcher when name changes" do
-      @ems.update_attributes(:name => "something else")
+      @ems.update(:name => "something else")
       expect(MiqQueue.count).to eq(0)
     end
   end

--- a/spec/models/miq_ems_refresh_core_worker_spec.rb
+++ b/spec/models/miq_ems_refresh_core_worker_spec.rb
@@ -3,7 +3,7 @@ describe MiqEmsRefreshCoreWorker do
   before do
     FactoryBot.create(:server_role, :name => 'ems_inventory')
     my_server = EvmSpecHelper.local_miq_server
-    my_server.update_attributes(:role => "ems_inventory")
+    my_server.update(:role => "ems_inventory")
     my_server.activate_roles("ems_inventory")
   end
 


### PR DESCRIPTION
update_attributes and update_attributes! are deprecated starting in Rails 6

See https://rubyinrails.com/2019/04/09/rails-6-1-activerecord-deprecates-update-attributes-methods/ for details and Rails PR links.

@miq-bot add_label technical debt