### PR TITLE
Support multiple targets to MetricsCapture

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/metrics_capture.rb
@@ -405,7 +405,7 @@ class ManageIQ::Providers::Vmware::InfraManager::MetricsCapture < ManageIQ::Prov
     if targets.size == 1
       "[#{target.class.name}], [#{target.id}], [#{target.name}]"
     else
-      "[#{targets.map { |obj| obj.class.name }.uniq.join(", ")}], [#{targets.count} targets]"
+      "[#{targets.map { |obj| obj.class.name }.uniq.join(", ")}], [#{targets.size} targets]"
     end
   end
 


### PR DESCRIPTION
The MetricsCapture class was designed to support multiple targets but
over time small changes have caused that functionality to be lost.

```
>> powered_on_vms = vc.vms.where(:power_state => "on")
>> powered_on_vms.count
=> 61
>> _, timings = Benchmark.realtime_block(:perf_collect_metrics) { ManageIQ::Providers::Vmware::InfraManager::MetricsCapture.new(powered_on_vms).perf_collect_metrics("realtime") }
>> pp timings
{:vim_connect=>0.452594518661499,
 :counter_info=>8.559226989746094e-05,
 :capture_intervals=>0.0021064281463623047,
 :build_query_params=>0.0008752346038818359,
 :num_vim_queries=>61,
 :vim_execute_time=>1.8647003173828125,
 :perf_processing=>2.436561107635498,
 :num_vim_trips=>4,
 :perf_collect_metrics=>4.807427883148193}

>> _, timings = Benchmark.realtime_block(:perf_collect_metrics) { powered_on_vms.each { |vm| ManageIQ::Providers::Vmware::InfraManager::MetricsCapture.new(vm).perf_collect_metrics("realtime") } }
>> pp timings
{:vim_connect=>3.4850261211395264,
 :counter_info=>0.004868268966674805,
 :capture_intervals=>0.0042645931243896484,
 :build_query_params=>0.015353202819824219,
 :num_vim_queries=>1,
 :vim_execute_time=>3.425865888595581,
 :perf_processing=>2.171560287475586,
 :num_vim_trips=>1,
 :perf_collect_metrics=>9.304028987884521}
```

NOTE: this was with a vim-broker running