### PR TITLE
Fix params_for_create for vCloud

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -90,8 +90,8 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
         {
           :component => "text-field",
           :name      => "endpoints.events.password",
-          :label     => "Password",
-          :type      => "AMQP password"
+          :label     => "AMQP Password",
+          :type      => "password"
         }
       ]
     }.freeze


### PR DESCRIPTION
Password field for AMQP Password had the wrong label and type