### PR TITLE
Remove ems_ref_obj and use ems_ref_type instead

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/cluster.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/cluster.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Vmware::InfraManager::Cluster < ManageIQ::Providers::InfraManager::Cluster
+  include ManageIQ::Providers::Vmware::InfraManager::EmsRefObjMixin
+
   def provider_object(connection)
     connection.getVimClusterByMor(ems_ref_obj)
   end

--- a/app/models/manageiq/providers/vmware/infra_manager/ems_ref_obj_mixin.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/ems_ref_obj_mixin.rb
@@ -1,0 +1,7 @@
+module ManageIQ::Providers::Vmware::InfraManager::EmsRefObjMixin
+  extend ActiveSupport::Concern
+
+  def ems_ref_obj
+    @ems_ref_obj ||= VimString.new(ems_ref, ems_ref_type, :ManagedObjectReference)
+  end
+end

--- a/app/models/manageiq/providers/vmware/infra_manager/ems_ref_obj_mixin.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/ems_ref_obj_mixin.rb
@@ -2,7 +2,7 @@ module ManageIQ::Providers::Vmware::InfraManager::EmsRefObjMixin
   extend ActiveSupport::Concern
 
   def ems_ref_obj
-    @ems_ref_obj ||= VimString.new(ems_ref, ems_ref_type, :ManagedObjectReference) if ems_ref.present?
+    @ems_ref_obj ||= VimString.new(ems_ref, ems_ref_type, :ManagedObjectReference) if ems_ref.present? && ems_ref_type.present?
   end
 
   def ems_ref=(val)

--- a/app/models/manageiq/providers/vmware/infra_manager/ems_ref_obj_mixin.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/ems_ref_obj_mixin.rb
@@ -2,6 +2,11 @@ module ManageIQ::Providers::Vmware::InfraManager::EmsRefObjMixin
   extend ActiveSupport::Concern
 
   def ems_ref_obj
-    @ems_ref_obj ||= VimString.new(ems_ref, ems_ref_type, :ManagedObjectReference)
+    @ems_ref_obj ||= VimString.new(ems_ref, ems_ref_type, :ManagedObjectReference) if ems_ref.present?
+  end
+
+  def ems_ref=(val)
+    @ems_ref_obj = nil
+    super
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/event_parser.rb
@@ -140,10 +140,10 @@ module ManageIQ::Providers::Vmware::InfraManager::EventParser
     hash = {
       :folders => [
         {
-          :type        => klass,
-          :ems_ref     => mor,
-          :ems_ref_obj => mor,
-          :uid_ems     => mor
+          :type         => klass,
+          :ems_ref      => mor,
+          :ems_ref_type => "Folder",
+          :uid_ems      => mor
         }
       ]
     }

--- a/app/models/manageiq/providers/vmware/infra_manager/host.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/host.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Vmware::InfraManager::Host < ::Host
   include ManageIQ::Providers::Vmware::InfraManager::VimConnectMixin
+  include ManageIQ::Providers::Vmware::InfraManager::EmsRefObjMixin
 
   def provider_object(connection)
     api_type = connection.about["apiType"]

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -42,11 +42,11 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
     return if kind == "leave"
 
     cluster_hash = {
-      :ems_ref     => object._ref,
-      :ems_ref_obj => managed_object_to_vim_string(object),
-      :uid_ems     => object._ref,
-      :name        => CGI.unescape(props[:name]),
-      :parent      => lazy_find_managed_object(props[:parent]),
+      :ems_ref      => object._ref,
+      :ems_ref_type => object.class.wsdl_name,
+      :uid_ems      => object._ref,
+      :name         => CGI.unescape(props[:name]),
+      :parent       => lazy_find_managed_object(props[:parent]),
     }
 
     parse_compute_resource_summary(cluster_hash, props)
@@ -62,12 +62,12 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
     return if kind == "leave"
 
     dc_hash = {
-      :ems_ref     => object._ref,
-      :ems_ref_obj => managed_object_to_vim_string(object),
-      :uid_ems     => object._ref,
-      :type        => "Datacenter",
-      :name        => CGI.unescape(props[:name]),
-      :parent      => lazy_find_managed_object(props[:parent]),
+      :ems_ref      => object._ref,
+      :ems_ref_type => object.class.wsdl_name,
+      :uid_ems      => object._ref,
+      :type         => "Datacenter",
+      :name         => CGI.unescape(props[:name]),
+      :parent       => lazy_find_managed_object(props[:parent]),
     }
 
     persister.ems_folders.build(dc_hash)
@@ -78,8 +78,8 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
     return if kind == "leave"
 
     storage_hash = {
-      :ems_ref     => object._ref,
-      :ems_ref_obj => managed_object_to_vim_string(object),
+      :ems_ref      => object._ref,
+      :ems_ref_type => object.class.wsdl_name,
     }
 
     parse_datastore_summary(storage_hash, props)
@@ -137,12 +137,12 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
     hidden = props[:parent].nil? || props[:parent].kind_of?(RbVmomi::VIM::Datacenter)
 
     folder_hash = {
-      :ems_ref     => object._ref,
-      :ems_ref_obj => managed_object_to_vim_string(object),
-      :uid_ems     => object._ref,
-      :name        => CGI.unescape(props[:name]),
-      :parent      => lazy_find_managed_object(props[:parent]),
-      :hidden      => hidden,
+      :ems_ref      => object._ref,
+      :ems_ref_type => object.class.wsdl_name,
+      :uid_ems      => object._ref,
+      :name         => CGI.unescape(props[:name]),
+      :parent       => lazy_find_managed_object(props[:parent]),
+      :hidden       => hidden,
     }
 
     persister.ems_folders.build(folder_hash)
@@ -154,10 +154,10 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
 
     cluster = lazy_find_managed_object(props[:parent])
     host_hash = {
-      :ems_ref     => object._ref,
-      :ems_ref_obj => managed_object_to_vim_string(object),
-      :ems_cluster => cluster,
-      :type        => "ManageIQ::Providers::Vmware::InfraManager::HostEsx",
+      :ems_ref      => object._ref,
+      :ems_ref_type => object.class.wsdl_name,
+      :ems_cluster  => cluster,
+      :type         => "ManageIQ::Providers::Vmware::InfraManager::HostEsx",
     }
 
     parse_host_system_summary(host_hash, props)
@@ -254,13 +254,13 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
                  end
 
     rp_hash = {
-      :ems_ref     => object._ref,
-      :ems_ref_obj => managed_object_to_vim_string(object),
-      :uid_ems     => object._ref,
-      :name        => name,
-      :vapp        => object.kind_of?(RbVmomi::VIM::VirtualApp),
-      :parent      => lazy_find_managed_object(parent),
-      :is_default  => is_default,
+      :ems_ref      => object._ref,
+      :ems_ref_type => object.class.wsdl_name,
+      :uid_ems      => object._ref,
+      :name         => name,
+      :vapp         => object.kind_of?(RbVmomi::VIM::VirtualApp),
+      :parent       => lazy_find_managed_object(parent),
+      :is_default   => is_default,
     }
 
     parse_resource_pool_memory_allocation(rp_hash, props)
@@ -313,7 +313,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
 
     vm_hash = {
       :ems_ref       => object._ref,
-      :ems_ref_obj   => managed_object_to_vim_string(object),
+      :ems_ref_type  => object.class.wsdl_name,
       :vendor        => "vmware",
       :parent        => lazy_find_managed_object(props[:parent]),
       :resource_pool => lazy_find_managed_object(props[:resourcePool]),
@@ -347,13 +347,5 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
 
     parent_collection = persister.vim_class_to_collection(managed_object)
     parent_collection.lazy_find(managed_object._ref)
-  end
-
-  def managed_object_to_vim_string(object)
-    ref = object._ref
-    vim_type = object.class.wsdl_name.to_sym
-    xsi_type = :ManagedObjectReference
-
-    VimString.new(ref, vim_type, xsi_type)
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -331,7 +331,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
       snapshot_hash = {
         :vm_or_template => vm,
         :ems_ref        => snap._ref,
-        :ems_ref_obj    => managed_object_to_vim_string(snap),
+        :ems_ref_type   => snap.class.wsdl_name,
         :uid_ems        => create_time.to_s,
         :uid            => create_time.iso8601(6),
         :parent_uid     => parent_uid,

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -142,7 +142,7 @@ module ManageIQ::Providers
 
           new_result = {
             :ems_ref            => mor,
-            :ems_ref_obj        => mor,
+            :ems_ref_type       => mor.vimType,
             :name               => summary["name"],
             :store_type         => summary["type"].to_s.upcase,
             :total_space        => summary["capacity"],
@@ -247,9 +247,9 @@ module ManageIQ::Providers
             _log.warn "#{err} Skipping."
 
             new_result = {
-              :invalid     => true,
-              :ems_ref     => mor,
-              :ems_ref_obj => mor
+              :invalid      => true,
+              :ems_ref      => mor,
+              :ems_ref_type => mor.vimType
             }
             result << new_result
             result_uids[mor] = new_result
@@ -322,7 +322,7 @@ module ManageIQ::Providers
           new_result = {
             :type             => %w(esx esxi).include?(product_name.to_s.downcase) ? "ManageIQ::Providers::Vmware::InfraManager::HostEsx" : "ManageIQ::Providers::Vmware::InfraManager::Host",
             :ems_ref          => mor,
-            :ems_ref_obj      => mor,
+            :ems_ref_type     => mor.vimType,
             :name             => hostname,
             :hostname         => hostname,
             :ipaddress        => ipaddress,
@@ -884,9 +884,9 @@ module ManageIQ::Providers
             _log.warn "#{err} Skipping."
 
             new_result = {
-              :invalid     => true,
-              :ems_ref     => mor,
-              :ems_ref_obj => mor
+              :invalid      => true,
+              :ems_ref      => mor,
+              :ems_ref_type => mor.vimType
             }
             result << new_result
             result_uids[mor] = new_result
@@ -953,7 +953,7 @@ module ManageIQ::Providers
           new_result = {
             :type                  => template ? ManageIQ::Providers::Vmware::InfraManager::Template.name : ManageIQ::Providers::Vmware::InfraManager::Vm.name,
             :ems_ref               => mor,
-            :ems_ref_obj           => mor,
+            :ems_ref_type          => mor.vimType,
             :uid_ems               => uid,
             :name                  => URI.decode(summary_config["name"]),
             :vendor                => "vmware",
@@ -1242,15 +1242,15 @@ module ManageIQ::Providers
         description = nil if description.kind_of?(Hash)
 
         nh = {
-          :ems_ref     => inv['snapshot'],
-          :ems_ref_obj => inv['snapshot'],
-          :uid_ems     => create_time_ems,
-          :uid         => create_time.iso8601(6),
-          :parent_uid  => parent_uid,
-          :name        => URI.decode(inv['name']),
-          :description => description,
-          :create_time => create_time,
-          :current     => inv['snapshot'] == current,
+          :ems_ref      => inv['snapshot'],
+          :ems_ref_type => inv['snapshot'].vimType,
+          :uid_ems      => create_time_ems,
+          :uid          => create_time.iso8601(6),
+          :parent_uid   => parent_uid,
+          :name         => URI.decode(inv['name']),
+          :description  => description,
+          :create_time  => create_time,
+          :current      => inv['snapshot'] == current,
         }
 
         result << nh
@@ -1285,13 +1285,13 @@ module ManageIQ::Providers
           child_mors = get_mors(data, 'childEntity').reject { |child| child.vimType == "Datastore" }
 
           new_result = {
-            :type        => EmsFolder.name,
-            :ems_ref     => mor,
-            :ems_ref_obj => mor,
-            :uid_ems     => mor,
-            :name        => URI.decode(data["name"]),
-            :child_uids  => child_mors,
-            :hidden      => false
+            :type         => EmsFolder.name,
+            :ems_ref      => mor,
+            :ems_ref_type => mor.vimType,
+            :uid_ems      => mor,
+            :name         => URI.decode(data["name"]),
+            :child_uids   => child_mors,
+            :hidden       => false
           }
           result << new_result
           result_uids[mor] = new_result
@@ -1308,13 +1308,13 @@ module ManageIQ::Providers
           child_mors = get_mors(data, 'hostFolder') + get_mors(data, 'vmFolder') + get_mors(data, 'datastoreFolder') + get_mors(data, 'networkFolder')
 
           new_result = {
-            :type        => Datacenter.name,
-            :ems_ref     => mor,
-            :ems_ref_obj => mor,
-            :uid_ems     => mor,
-            :name        => URI.decode(data["name"]),
-            :child_uids  => child_mors,
-            :hidden      => false
+            :type         => Datacenter.name,
+            :ems_ref      => mor,
+            :ems_ref_type => mor.vimType,
+            :uid_ems      => mor,
+            :name         => URI.decode(data["name"]),
+            :child_uids   => child_mors,
+            :hidden       => false
           }
           result << new_result
           result_uids[mor] = new_result
@@ -1332,13 +1332,13 @@ module ManageIQ::Providers
           name       = data.fetch_path('summary', 'name')
 
           new_result = {
-            :type        => StorageCluster.name,
-            :ems_ref     => mor,
-            :ems_ref_obj => mor,
-            :uid_ems     => mor,
-            :name        => name,
-            :child_uids  => child_mors,
-            :hidden      => false
+            :type         => StorageCluster.name,
+            :ems_ref      => mor,
+            :ems_ref_type => mor.vimType,
+            :uid_ems      => mor,
+            :name         => name,
+            :child_uids   => child_mors,
+            :hidden       => false
           }
 
           result << new_result
@@ -1368,7 +1368,7 @@ module ManageIQ::Providers
 
           new_result = {
             :ems_ref                 => mor,
-            :ems_ref_obj             => mor,
+            :ems_ref_type            => mor.vimType,
             :uid_ems                 => mor,
             :name                    => URI.decode(data["name"]),
             :effective_cpu           => effective_cpu,
@@ -1407,7 +1407,7 @@ module ManageIQ::Providers
 
           new_result = {
             :ems_ref               => mor,
-            :ems_ref_obj           => mor,
+            :ems_ref_type          => mor.vimType,
             :uid_ems               => mor,
             :name                  => URI.decode(data["name"].to_s),
             :type                  => "ManageIQ::Providers::Vmware::InfraManager::ResourcePool",

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser/filter.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser/filter.rb
@@ -88,8 +88,9 @@ class ManageIQ::Providers::Vmware::InfraManager
     # Since a Folder and a Datacenter are both an EmsFolder
     # we need to handle @vc_data[:folder] and @vc_data[:dc]
     def folder_inv_by_folder(folder)
-      mor = folder.ems_ref_obj
-      return nil if mor.nil?
+      return nil if folder&.ems_ref.nil?
+
+      mor = VimString.new(folder.ems_ref, folder.ems_ref_type, :ManagedObjectReference)
 
       _type, target = RefreshParser.inv_target_by_mor(mor, @vc_data)
       target.nil? ? nil : {mor => target}

--- a/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared.rb
@@ -1,6 +1,8 @@
 module ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared
   extend ActiveSupport::Concern
 
+  include ManageIQ::Providers::Vmware::InfraManager::EmsRefObjMixin
+
   include_concern 'Disconnect'
   include_concern 'Operations'
   include_concern 'RefreshOnScan'

--- a/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/operations.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/operations.rb
@@ -13,7 +13,7 @@ module ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared::Operations
     folder_mor    = folder.ems_ref_obj    if folder.respond_to?(:ems_ref_obj)
     pool_mor      = pool.ems_ref_obj      if pool.respond_to?(:ems_ref_obj)
     host_mor      = host.ems_ref_obj      if host.respond_to?(:ems_ref_obj)
-    datastore_mor = datastore.ems_ref_obj if datastore.respond_to?(:ems_ref_obj)
+    datastore_mor = VimString.new(datastore.ems_ref, datastore.ems_ref_type, :ManagedObjectReference) if datastore
     run_command_via_parent(:vm_clone, :name => name, :folder => folder_mor, :pool => pool_mor, :host => host_mor, :datastore => datastore_mor, :powerOn => powerOn, :template => template_flag, :transform => transform, :config => config, :customization => customization, :disk => disk)
   end
 

--- a/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/operations/relocation.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/operations/relocation.rb
@@ -50,7 +50,7 @@ module ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared::Operations
 
     host_mor      = host.ems_ref_obj if host
     pool_mor      = pool.ems_ref_obj if pool
-    datastore_mor = datastore.ems_ref_obj if datastore
+    datastore_mor = VimString.new(datastore.ems_ref, datastore.ems_ref_type, :ManagedObjectReference) if datastore
 
     run_command_via_parent(:vm_relocate, :host => host_mor, :pool => pool_mor, :datastore => datastore_mor, :disk_move_type => disk_move_type, :transform => transform, :priority => priority, :disk => disk)
   end

--- a/spec/models/manageiq/providers/vmware/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/refresher_spec.rb
@@ -167,7 +167,6 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(@template).to have_attributes(
       :template              => true,
       :ems_ref               => 'vm-ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6',
-      :ems_ref_obj           => nil,
       :uid_ems               => 'vm-ac90bd58-3bc4-47a5-bc8c-f1c8f5c468b6',
       :vendor                => 'vmware',
       :power_state           => 'never',
@@ -201,7 +200,6 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(v).to have_attributes(
       :template               => false,
       :ems_ref                => 'vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2',
-      :ems_ref_obj            => nil,
       :uid_ems                => 'vm-84faa107-c0b9-4a21-adc5-b17e0c5355a2',
       :vendor                 => 'vmware',
       :power_state            => 'on',
@@ -291,7 +289,6 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(v).to have_attributes(
       :template              => false,
       :ems_ref               => 'vm-aaf94123-cbf9-4de9-841c-41dd41ac310e',
-      :ems_ref_obj           => nil,
       :uid_ems               => 'vm-aaf94123-cbf9-4de9-841c-41dd41ac310e',
       :vendor                => 'vmware',
       :power_state           => 'off',

--- a/spec/models/manageiq/providers/vmware/infra_manager/ems_event_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/ems_event_spec.rb
@@ -92,12 +92,12 @@ describe EmsEvent do
     end
 
     def mock_raw_event_host(raw_event)
-      raw_event["host"]["host"] = @host.ems_ref_obj
+      raw_event["host"]["host"] = @host.ems_ref
       raw_event["host"]["name"] = @host.hostname
     end
 
     def mock_raw_event_vm(raw_event)
-      raw_event["vm"]["vm"]     = @vm1.ems_ref_obj
+      raw_event["vm"]["vm"]     = @vm1.ems_ref
       raw_event["vm"]["name"]   = @vm1.name
       raw_event["vm"]["path"]   = @vm1.location
     end

--- a/spec/models/manageiq/providers/vmware/infra_manager/ems_ref_obj_mixin.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/ems_ref_obj_mixin.rb
@@ -1,0 +1,38 @@
+describe ManageIQ::Providers::Vmware::InfraManager::EmsRefObjMixin do
+  let(:vm) { FactoryBot.create(:vm_vmware, :ems_ref_type => "VirtualMachine") }
+
+  describe ".ems_ref_obj" do
+    context "when ems_ref is nil" do
+      before { vm.ems_ref = nil }
+      it "returns nil" do
+        expect(vm.ems_ref_obj).to be_nil
+      end
+
+      it "returns a VimString when ems_ref is set" do
+        expect(vm.ems_ref_obj).to be_nil
+        vm.ems_ref = "vm-123"
+        expect(vm.ems_ref_obj).to eq(VimString.new("vm-123", :VirtualMachine, :ManagedObjectReference))
+      end
+    end
+
+    context "when ems_ref is present" do
+      before { vm.ems_ref = "vm-123" }
+
+      it "returns a VimString" do
+        expect(vm.ems_ref_obj).to eq(VimString.new("vm-123", :VirtualMachine, :ManagedObjectReference))
+      end
+
+      it "returns nil when ems_ref is cleared" do
+        expect(vm.ems_ref_obj).to eq(VimString.new("vm-123", :VirtualMachine, :ManagedObjectReference))
+        vm.ems_ref = nil
+        expect(vm.ems_ref_obj).to be_nil
+      end
+
+      it "returns a new VimString when ems_ref is updated" do
+        expect(vm.ems_ref_obj).to eq(VimString.new("vm-123", :VirtualMachine, :ManagedObjectReference))
+        vm.ems_ref = "vm-456"
+        expect(vm.ems_ref_obj).to eq(VimString.new("vm-456", :VirtualMachine, :ManagedObjectReference))
+      end
+    end
+  end
+end

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
@@ -293,7 +293,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
       context "#start_clone" do
         before(:each) do
           ds_mor = "datastore-0"
-          storage = FactoryBot.create(:storage_nfs, :ems_ref => ds_mor, :ems_ref_obj => ds_mor)
+          storage = FactoryBot.create(:storage_nfs, :ems_ref => ds_mor, :ems_ref_type => "Datastore")
 
           Array.new(2) do |i|
             cluster_mor = "cluster-#{i}"
@@ -304,7 +304,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
               :ext_management_system => @ems,
               :ems_cluster           => cluster,
               :ems_ref               => host_mor,
-              :ems_ref_obj           => host_mor
+              :ems_ref_type          => "HostSystem"
             }
 
             FactoryBot.create(:host_vmware, host_props).tap do |host|

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -307,18 +307,18 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
   def assert_specific_datacenter
     @datacenter = Datacenter.find_by(:ems_id => @ems.id, :ems_ref => "datacenter-672")
     expect(@datacenter).to have_attributes(
-      :ems_ref     => "datacenter-672",
-      :ems_ref_obj => VimString.new("datacenter-672", :Datacenter, :ManagedObjectReference),
-      :name        => "New / Datacenter"
+      :ems_ref      => "datacenter-672",
+      :ems_ref_type => "Datacenter",
+      :name         => "New / Datacenter"
     )
   end
 
   def assert_specific_folder
     @folder = EmsFolder.find_by(:ems_id => @ems.id, :ems_ref => "group-v674")
     expect(@folder).to have_attributes(
-      :ems_ref     => "group-v674",
-      :ems_ref_obj => VimString.new("group-v674", :Folder, :ManagedObjectReference),
-      :name        => "Test / Folder"
+      :ems_ref      => "group-v674",
+      :ems_ref_type => "Folder",
+      :name         => "Test / Folder"
     )
   end
 
@@ -326,7 +326,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     @cluster = EmsCluster.find_by(:ems_id => @ems.id, :ems_ref => "domain-c871")
     expect(@cluster).to have_attributes(
       :ems_ref                 => "domain-c871",
-      :ems_ref_obj             => VimString.new("domain-c871", :ClusterComputeResource, :ManagedObjectReference),
+      :ems_ref_type            => "ClusterComputeResource",
       :uid_ems                 => "domain-c871",
       :name                    => "Testing/Production Cluster",
       :ha_enabled              => false,
@@ -340,7 +340,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     @default_rp = @cluster.default_resource_pool
     expect(@default_rp).to have_attributes(
       :ems_ref               => "resgroup-872",
-      :ems_ref_obj           => VimString.new("resgroup-872", :ResourcePool, :ManagedObjectReference),
+      :ems_ref_type          => "ResourcePool",
       :uid_ems               => "resgroup-872",
       :name                  => "Default for Cluster / Deployment Role Testing/Production Cluster",
       :type                  => "ManageIQ::Providers::Vmware::InfraManager::ResourcePool",
@@ -361,7 +361,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     @rp = ResourcePool.find_by_ems_ref("resgroup-11340")
     expect(@rp).to have_attributes(
       :ems_ref               => "resgroup-11340",
-      :ems_ref_obj           => VimString.new("resgroup-11340", :ResourcePool, :ManagedObjectReference),
+      :ems_ref_type          => "ResourcePool",
       :uid_ems               => "resgroup-11340",
       :name                  => "Joe",
       :memory_reserve        => 0,
@@ -389,7 +389,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     @storage = Storage.find_by(:name => "StarM1-Prod1 (1)")
     expect(@storage).to have_attributes(
       :ems_ref                       => "datastore-953",
-      :ems_ref_obj                   => VimString.new("datastore-953", :Datastore, :ManagedObjectReference),
+      :ems_ref_type                  => "Datastore",
       :name                          => "StarM1-Prod1 (1)",
       :store_type                    => "VMFS",
       :total_space                   => 524254445568,
@@ -406,11 +406,11 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
   def assert_specific_storage_cluster
     @storage_cluster = StorageCluster.find_by(:name => "TestDatastoreCluster")
     expect(@storage_cluster).to have_attributes(
-      :ems_ref     => "group-p81",
-      :ems_ref_obj => VimString.new("group-p81", :StorageCluster, :ManagedObjectReference),
-      :uid_ems     => "group-p81",
-      :name        => "TestDatastoreCluster",
-      :type        => "StorageCluster",
+      :ems_ref      => "group-p81",
+      :ems_ref_type => "StorageCluster",
+      :uid_ems      => "group-p81",
+      :name         => "TestDatastoreCluster",
+      :type         => "StorageCluster",
     )
 
     @child_storage = Storage.find_by_ems_ref("datastore-12281")
@@ -441,7 +441,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     @host = ManageIQ::Providers::Vmware::InfraManager::Host.find_by(:name => "VI4ESXM1.manageiq.com")
     expect(@host).to have_attributes(
       :ems_ref          => "host-9",
-      :ems_ref_obj      => VimString.new("host-9", :HostSystem, :ManagedObjectReference),
+      :ems_ref_type     => "HostSystem",
       :name             => "VI4ESXM1.manageiq.com",
       :hostname         => "VI4ESXM1.manageiq.com",
       :ipaddress        => "192.168.252.13",
@@ -675,7 +675,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     expect(v).to have_attributes(
       :template              => false,
       :ems_ref               => "vm-11342",
-      :ems_ref_obj           => VimString.new("vm-11342", :VirtualMachine, :ManagedObjectReference),
+      :ems_ref_type          => "VirtualMachine",
       :uid_ems               => "422f5d16-c048-19e6-3212-e588fbebf7e0",
       :vendor                => "vmware",
       :power_state           => "off",
@@ -775,33 +775,30 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     expect(nic.network).to eq(network)
 
     expect(v.parent_datacenter).to have_attributes(
-      :ems_ref     => "datacenter-2",
-      :ems_ref_obj => VimString.new("datacenter-2", :Datacenter, :ManagedObjectReference),
-      :uid_ems     => "datacenter-2",
-      :name        => "Prod",
-      :type        => "Datacenter",
-
-      :folder_path => "Datacenters/Prod"
+      :ems_ref      => "datacenter-2",
+      :ems_ref_type => "Datacenter",
+      :uid_ems      => "datacenter-2",
+      :name         => "Prod",
+      :type         => "Datacenter",
+      :folder_path  => "Datacenters/Prod"
     )
 
     expect(v.parent_folder).to have_attributes(
-      :ems_ref     => "group-d1",
-      :ems_ref_obj => VimString.new("group-d1", :Folder, :ManagedObjectReference),
-      :uid_ems     => "group-d1",
-      :name        => "Datacenters",
-      :type        => nil,
-
-      :folder_path => "Datacenters"
+      :ems_ref      => "group-d1",
+      :ems_ref_type => "Folder",
+      :uid_ems      => "group-d1",
+      :name         => "Datacenters",
+      :type         => nil,
+      :folder_path  => "Datacenters"
     )
 
     expect(v.parent_blue_folder).to have_attributes(
-      :ems_ref     => "group-v11341",
-      :ems_ref_obj => VimString.new("group-v11341", :Folder, :ManagedObjectReference),
-      :uid_ems     => "group-v11341",
-      :name        => "JFitzgerald",
-      :type        => nil,
-
-      :folder_path => "Datacenters/Prod/vm/JFitzgerald"
+      :ems_ref      => "group-v11341",
+      :ems_ref_type => "Folder",
+      :uid_ems      => "group-v11341",
+      :name         => "JFitzgerald",
+      :type         => nil,
+      :folder_path  => "Datacenters/Prod/vm/JFitzgerald"
     )
   end
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -407,7 +407,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     @storage_cluster = StorageCluster.find_by(:name => "TestDatastoreCluster")
     expect(@storage_cluster).to have_attributes(
       :ems_ref      => "group-p81",
-      :ems_ref_type => "StorageCluster",
+      :ems_ref_type => "StoragePod",
       :uid_ems      => "group-p81",
       :name         => "TestDatastoreCluster",
       :type         => "StorageCluster",

--- a/spec/models/miq_vim_broker_worker/runner_spec.rb
+++ b/spec/models/miq_vim_broker_worker/runner_spec.rb
@@ -218,7 +218,7 @@ describe MiqVimBrokerWorker::Runner do
             :username     => @ems.authentication_userid,
             :objType      => "HostSystem",
             :op           => "update",
-            :mor          => host.ems_ref_obj,
+            :mor          => host.ems_ref,
             :key          => "testkey",
             :changedProps => ["summary.runtime.connectionState"],
             :changeSet    => [{"name" => "summary.runtime.connectionState", "op" => "assign", "val" => "connected"}]
@@ -249,10 +249,10 @@ describe MiqVimBrokerWorker::Runner do
           expected_folder_hash = {
             :folders => [
               {
-                :type        => klass,
-                :ems_ref     => mor,
-                :ems_ref_obj => mor,
-                :uid_ems     => mor
+                :type         => klass,
+                :ems_ref      => mor,
+                :ems_ref_type => "Folder",
+                :uid_ems      => mor
               }
             ]
           }

--- a/spec/tools/vim_data/miq_vim_inventory/storagePodsByMor.yml
+++ b/spec/tools/vim_data/miq_vim_inventory/storagePodsByMor.yml
@@ -15,7 +15,7 @@
       xsiType: :ManagedObjectReference
     MOR: !ruby/string:VimString
       str: group-p81
-      vimType: :Datacenter
+      vimType: :StoragePod
       xsiType: :ManagedObjectReference
     summary: !ruby/hash:VimHash
       name: !ruby/string:VimString


### PR DESCRIPTION
Instead of having an ems_ref_obj which is a serialized `VimString(ManagedObjectReference)` we can build a VimString from ems_ref and the VIM class name stored in ems_ref_type.

https://github.com/ManageIQ/manageiq/pull/19430