### PR TITLE
Excluding archived vms from reconfigurable? method.

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm/reconfigure.rb
@@ -1,7 +1,7 @@
 module ManageIQ::Providers::Vmware::CloudManager::Vm::Reconfigure
   # Show Reconfigure VM task
   def reconfigurable?
-    true
+    active?
   end
 
   def max_cpu_cores_per_socket(_total_vcpus = nil)

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
@@ -1,7 +1,7 @@
 module ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure
   # Show Reconfigure VM task
   def reconfigurable?
-    true
+    active?
   end
 
   def max_total_vcpus

--- a/spec/models/manageiq/providers/vmware/cloud_manager/vm/reconfigure_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/vm/reconfigure_spec.rb
@@ -27,8 +27,29 @@ describe ManageIQ::Providers::Vmware::CloudManager::Vm::Reconfigure do
     stack
   end
 
-  it '#reconfigurable?' do
-    expect(vm.reconfigurable?).to be_truthy
+  describe "#reconfigurable?" do
+    let(:storage)     { FactoryBot.create(:storage_vmware) }
+    let(:ems)         { FactoryBot.create(:ext_management_system) }
+    let(:vm_active)   { FactoryBot.create(:vm_vmware_cloud, :storage => storage, :ext_management_system => ems) }
+    let(:vm_retired)  { FactoryBot.create(:vm_vmware_cloud, :retired => true, :storage => storage, :ext_management_system => ems) }
+    let(:vm_orphaned) { FactoryBot.create(:vm_vmware_cloud, :storage => storage) }
+    let(:vm_archived) { FactoryBot.create(:vm_vmware_cloud) }
+
+    it 'returns true for active vm' do
+      expect(vm_active.reconfigurable?).to be_truthy
+    end
+
+    it 'returns false for orphaned vm' do
+      expect(vm_orphaned.reconfigurable?).to be_falsey
+    end
+
+    it 'returns false for retired vm' do
+      expect(vm_retired.reconfigurable?).to be_falsey
+    end
+
+    it 'returns false for archived vm' do
+      expect(vm_archived.reconfigurable?).to be_falsey
+    end
   end
 
   it '.max_cpu_cores_per_socket' do

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
@@ -16,8 +16,28 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
     )
   end
 
-  it "#reconfigurable?" do
-    expect(vm.reconfigurable?).to be_truthy
+  describe "#reconfigurable?" do
+    let(:ems)         { FactoryBot.create(:ext_management_system) }
+    let(:vm_active)   { FactoryBot.create(:vm_vmware, :storage => storage, :ext_management_system => ems) }
+    let(:vm_retired)  { FactoryBot.create(:vm_vmware, :retired => true, :storage => storage, :ext_management_system => ems) }
+    let(:vm_orphaned) { FactoryBot.create(:vm_vmware, :storage => storage) }
+    let(:vm_archived) { FactoryBot.create(:vm_vmware) }
+
+    it 'returns true for active vm' do
+      expect(vm_active.reconfigurable?).to be_truthy
+    end
+
+    it 'returns false for orphaned vm' do
+      expect(vm_orphaned.reconfigurable?).to be_falsey
+    end
+
+    it 'returns false for retired vm' do
+      expect(vm_retired.reconfigurable?).to be_falsey
+    end
+
+    it 'returns false for archived vm' do
+      expect(vm_archived.reconfigurable?).to be_falsey
+    end
   end
 
   context "#max_total_vcpus" do


### PR DESCRIPTION
As a result of request from related BZ below we are excluding archived vms from being able to be reconfigurable. Similar change is being made in 1 more repository(https://github.com/ManageIQ/manageiq-providers-ovirt/pull/421). 

https://bugzilla.redhat.com/show_bug.cgi?id=1743533