### PR TITLE
[Podification] Add an operations worker that doesn't need the VimBroker

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -131,6 +131,10 @@ module ManageIQ::Providers
       Settings.ems_refresh.vmwarews.streaming_refresh
     end
 
+    def queue_name_for_ems_operations
+      queue_name
+    end
+
     def remote_console_vmrc_acquire_ticket
       vim = connect(:auth_type => :console)
       ticket = vim.acquireCloneTicket

--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -13,6 +13,7 @@ module ManageIQ::Providers
     require_nested :MetricsCapture
     require_nested :MetricsCollectorWorker
     require_nested :OpaqueSwitch
+    require_nested :OperationsWorker
     require_nested :OrchestrationTemplate
     require_nested :Provision
     require_nested :ProvisionViaPxe

--- a/app/models/manageiq/providers/vmware/infra_manager/operations_worker.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/operations_worker.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::Vmware::InfraManager::OperationsWorker < ManageIQ::Providers::BaseManager::OperationsWorker
+  require_nested :Runner
+end

--- a/app/models/manageiq/providers/vmware/infra_manager/operations_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/operations_worker/runner.rb
@@ -1,23 +1,9 @@
 class ManageIQ::Providers::Vmware::InfraManager::OperationsWorker::Runner < ManageIQ::Providers::BaseManager::OperationsWorker::Runner
-  attr_reader :miq_vim
-
   def do_before_work_loop
-    server = ems.hostname
-    username, password = ems.auth_user_pwd
-    cache_scope = :cache_scope_core
+    # Set the cache_scope to minimal for ems_operations
+    MiqVim.cacheScope = :cache_scope_core
 
-    require "VMwareWebService/MiqVim"
-    @miq_vim = MiqVim.new(server, username, password, cache_scope)
-  end
-
-  def deliver_queue_message(msg)
-    super do |obj, args|
-      if args.first&.kind_of?(Hash)
-        args.first[:vim] = miq_vim
-      else
-        args << miq_vim
-      end
-      obj.send(msg.method_name, *args)
-    end
+    # Prime the cache before starting the do_work loop
+    ems.connect
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/operations_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/operations_worker/runner.rb
@@ -1,0 +1,23 @@
+class ManageIQ::Providers::Vmware::InfraManager::OperationsWorker::Runner < ManageIQ::Providers::BaseManager::OperationsWorker::Runner
+  attr_reader :miq_vim
+
+  def do_before_work_loop
+    server = ems.hostname
+    username, password = ems.auth_user_pwd
+    cache_scope = :cache_scope_core
+
+    require "VMwareWebService/MiqVim"
+    @miq_vim = MiqVim.new(server, username, password, cache_scope)
+  end
+
+  def deliver_queue_message(msg)
+    super do |obj, args|
+      if args.first&.kind_of?(Hash)
+        args.first[:vim] = miq_vim
+      else
+        args << miq_vim
+      end
+      obj.send(msg.method_name, *args)
+    end
+  end
+end

--- a/app/models/manageiq/providers/vmware/infra_manager/operations_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/operations_worker/runner.rb
@@ -6,4 +6,13 @@ class ManageIQ::Providers::Vmware::InfraManager::OperationsWorker::Runner < Mana
     # Prime the cache before starting the do_work loop
     ems.connect
   end
+
+  def before_exit(_message, _exit_code)
+    Thread.current[:miq_vim].each_value do |vim|
+      begin
+        vim.disconnect
+      rescue => err
+      end
+    end
+  end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/operations.rb
@@ -3,4 +3,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations
 
   include_concern 'Guest'
   include_concern 'Snapshot'
+
+  def rename(new_name, vim = nil)
+    provider_object(vim).renameVM(new_name)
+  end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/operations.rb
@@ -3,8 +3,4 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations
 
   include_concern 'Guest'
   include_concern 'Snapshot'
-
-  def rename(new_name, vim = nil)
-    provider_object(vim).renameVM(new_name)
-  end
 end

--- a/app/models/miq_vim_broker_worker.rb
+++ b/app/models/miq_vim_broker_worker.rb
@@ -3,23 +3,9 @@ class MiqVimBrokerWorker < MiqWorker
 
   require_nested :Runner
 
-  self.required_roles         = lambda {
-    %w(
-      ems_metrics_collector
-      ems_operations
-      smartproxy
-      smartstate
-    ).tap do |roles|
-      roles << 'ems_inventory' unless Settings.ems_refresh.vmwarews.streaming_refresh
-    end
-  }
-
+  self.required_roles         = []
   self.check_for_minimal_role = false
-  self.workers                = lambda {
-    return 0 unless ManageIQ::Providers::Vmware::InfraManager.use_vim_broker?
-    return self.has_minimal_env_option? ? 1 : 0 if MiqServer.minimal_env?
-    return 1
-  }
+  self.workers                = 0
 
   def self.supports_container?
     true
@@ -30,8 +16,7 @@ class MiqVimBrokerWorker < MiqWorker
   end
 
   def self.has_required_role?
-    return false if emses_to_monitor.empty?
-    super
+    false
   end
 
   def self.emses_to_monitor

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -46,6 +46,8 @@
     :queue_worker_base:
       :ems_metrics_collector_worker:
         :ems_metrics_collector_worker_vmware: {}
+      :ems_operations_worker:
+        :ems_operations_worker_vmware: {}
       :ems_refresh_worker:
         :ems_refresh_worker_vmware: {}
         :ems_refresh_worker_vmware_cloud: {}

--- a/spec/models/miq_vim_broker_worker_spec.rb
+++ b/spec/models/miq_vim_broker_worker_spec.rb
@@ -20,7 +20,7 @@ describe MiqVimBrokerWorker do
     end
 
     it ".required_roles" do
-      expect(described_class.required_roles.call).not_to include('ems_inventory')
+      expect(described_class.required_roles).to be_empty
     end
   end
 
@@ -36,7 +36,7 @@ describe MiqVimBrokerWorker do
     end
 
     it ".required_roles" do
-      expect(described_class.required_roles.call).to include('ems_inventory')
+      expect(described_class.required_roles).to be_empty
     end
   end
 end


### PR DESCRIPTION
Remove the requirement for the MiqVimBroker for performing ems_operations over DRb by adding an operations worker that has a MiqVim object in the Runner context so connecting to DMiqVim over DRb isn't required.

Depends:
- [x] https://github.com/ManageIQ/manageiq/pull/19464
- [x] https://github.com/ManageIQ/manageiq/pull/19476