### PR TITLE
Catch vsphere automation api errors

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -277,6 +277,8 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
         parser.parse_content_library_item(api_items.get(item_id).value)
       end
     end
+  rescue VSphereAutomation::ApiError
+    nil
   end
 
   def parse_storage_profiles(vim, parser)


### PR DESCRIPTION
If the vsphere automation api is unavailable this can cause refreshes to
fail.  Catch the ApiError so that the rest of the refresh can continue.

```
[----] E, [2019-11-05T14:23:51.730433 #15966:3fb6e3cd99f0] ERROR -- : MIQ(ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector#vim_collector) EMS: [dev-v67], id: [2] Refresh failed
[----] E, [2019-11-05T14:23:51.730792 #15966:3fb6e3cd99f0] ERROR -- : [VSphereAutomation::ApiError]: Forbidden  Method:[block (2 levels) in <class:LogProxy>]
[----] E, [2019-11-05T14:23:51.731137 #15966:3fb6e3cd99f0] ERROR -- : /home/agrare/.gem/gems/vsphere-automation-runtime-0.2.2/lib/vsphere-automation-runtime/api_client.rb:63:in `call_api'
/home/agrare/.gem/gems/vsphere-automation-content-0.2.2/lib/vsphere-automation-content/api/library_api.rb:173:in `list_with_http_info'
/home/agrare/.gem/gems/vsphere-automation-content-0.2.2/lib/vsphere-automation-content/api/library_api.rb:144:in `list'
/home/agrare/src/manageiq/manageiq-providers-vmware/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb:275:in `parse_content_libraries'
/home/agrare/src/manageiq/manageiq-providers-vmware/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb:83:in `full_refresh'
/home/agrare/src/manageiq/manageiq-providers-vmware/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb:56:in `vim_collector'
/home/agrare/src/manageiq/manageiq-providers-vmware/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb:46:in `block in vim_collector_thread
```