### PR TITLE
Subclass require_snapshot_for_scan? method

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/template.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/template.rb
@@ -1,6 +1,8 @@
 class ManageIQ::Providers::Vmware::InfraManager::Template < ManageIQ::Providers::InfraManager::Template
   include_concern 'ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared'
 
+  include_concern 'Scanning'
+
   supports :provisioning do
     if ext_management_system
       unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports_provisioning?

--- a/app/models/manageiq/providers/vmware/infra_manager/template/scanning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/template/scanning.rb
@@ -1,0 +1,7 @@
+module ManageIQ::Providers::Vmware::InfraManager::Template::Scanning
+  extend ActiveSupport::Concern
+
+  def require_snapshot_for_scan?
+    false
+  end
+end

--- a/app/models/manageiq/providers/vmware/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm.rb
@@ -4,6 +4,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Vm < ManageIQ::Providers::Infra
   include_concern 'Operations'
   include_concern 'RemoteConsole'
   include_concern 'Reconfigure'
+  include_concern 'Scanning'
 
   supports :clone do
     unsupported_reason_add(:clone, _('Clone operation is not supported')) if blank? || orphaned? || archived?

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/scanning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/scanning.rb
@@ -1,0 +1,7 @@
+module ManageIQ::Providers::Vmware::InfraManager::Vm::Scanning
+  extend ActiveSupport::Concern
+
+  def require_snapshot_for_scan?
+    true
+  end
+end


### PR DESCRIPTION
Is it enough to just override the Template code and leave the Vm code unchanged?

Would this be the same as the original: `return false unless vm.runnable?`