### PR TITLE
Allow Metrics Capture to handle ems or targets

### DIFF
--- a/spec/models/manageiq/providers/vmware/infra_manager/metric_capture_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/metric_capture_spec.rb
@@ -155,5 +155,11 @@ describe ManageIQ::Providers::Vmware::InfraManager::MetricsCapture do
         expect { described_class.new([]) }.to raise_exception(ArgumentError, "At least one target must be passed")
       end
     end
+
+    context "with an ems" do
+      it "passes" do
+        expect { described_class.new(nil, @ems_vmware) }.not_to raise_exception
+      end
+    end
   end
 end


### PR DESCRIPTION
corresponds/depends upon:
- [x] https://github.com/ManageIQ/manageiq/pull/19511

### Before

metrics_capture targets a group of vms, hosts, or storages.

### After

metrics_capture can target a whole ems.
