### PR TITLE
Remove zanata from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![Security](https://hakiri.io/github/ManageIQ/manageiq-providers-vmware/master.svg)](https://hakiri.io/github/ManageIQ/manageiq-providers-vmware/master)
 
 [![Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ManageIQ/manageiq-providers-vmware?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Translate](https://img.shields.io/badge/translate-zanata-blue.svg)](https://translate.zanata.org/zanata/project/view/manageiq-providers-vmware)
 
 ManageIQ plugin for the Vmware provider.
 


### PR DESCRIPTION
We no longer do per-plugin translations, we don't need to mention zanata in README.

@miq-bot add_label cleanup