### PR TITLE
Rely on the default implementation of .ems_class

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/event_catcher.rb
@@ -1,10 +1,6 @@
 class ManageIQ::Providers::Vmware::CloudManager::EventCatcher < ::MiqEventCatcher
   require_nested :Runner
 
-  def self.ems_class
-    ManageIQ::Providers::Vmware::CloudManager
-  end
-
   def self.settings_name
     :event_catcher_vmware_cloud
   end

--- a/app/models/manageiq/providers/vmware/network_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/vmware/network_manager/refresh_worker.rb
@@ -1,10 +1,6 @@
 class ManageIQ::Providers::Vmware::NetworkManager::RefreshWorker < ::MiqEmsRefreshWorker
   require_nested :Runner
 
-  def self.ems_class
-    ManageIQ::Providers::Vmware::NetworkManager
-  end
-
   def self.settings_name
     :ems_refresh_worker_vmware_cloud
   end

--- a/spec/models/miq_ems_refresh_core_worker_spec.rb
+++ b/spec/models/miq_ems_refresh_core_worker_spec.rb
@@ -7,6 +7,12 @@ describe MiqEmsRefreshCoreWorker do
     my_server.activate_roles("ems_inventory")
   end
 
+  context ".ems_class" do
+    it "is the infra manager" do
+      expect(described_class.ems_class).to eq(ManageIQ::Providers::Vmware::InfraManager)
+    end
+  end
+
   context ".has_required_role?" do
     context "with update_driven_refresh" do
       before do


### PR DESCRIPTION
Also add a spec for the ems refresh core worker because
it is an exception to the rule