### PR TITLE
Add worker kill priority to workers only used by the vmware provider

### DIFF
--- a/app/models/miq_ems_refresh_core_worker.rb
+++ b/app/models/miq_ems_refresh_core_worker.rb
@@ -14,6 +14,10 @@ class MiqEmsRefreshCoreWorker < MiqWorker
     ManageIQ::Providers::Vmware::InfraManager
   end
 
+  def self.kill_priority
+    MiqWorkerType::KILL_PRIORITY_REFRESH_CORE_WORKERS
+  end
+
   def friendly_name
     @friendly_name ||= begin
       ems = ext_management_system

--- a/app/models/miq_vim_broker_worker.rb
+++ b/app/models/miq_vim_broker_worker.rb
@@ -25,6 +25,10 @@ class MiqVimBrokerWorker < MiqWorker
     true
   end
 
+  def self.kill_priority
+    MiqWorkerType::KILL_PRIORITY_VIM_BROKER_WORKERS
+  end
+
   def self.has_required_role?
     return false if emses_to_monitor.empty?
     super


### PR DESCRIPTION
This is needed in order to seed the MiqWorkerType model