### PR TITLE
Don't delete VCB snapshots or ConsolidateHelper snapshots

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm/operations/snapshot.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/operations/snapshot.rb
@@ -16,6 +16,9 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations::Snapshot
     raise MiqException::MiqVmError, unsupported_reason(:remove_snapshot) unless supports_remove_snapshot?
     snapshot = snapshots.find_by(:id => snapshot_id)
     raise _("Requested VM snapshot not found, unable to remove snapshot") unless snapshot
+    raise _("Refusing to delete a VCB Snapshot") if snapshot.name == MiqVimVm::VCB_SNAPSHOT_NAME
+    raise _("Refusing to delete snapshot when there is a Consolidate Helper snapshot") if snapshots.any? { |s| MiqVimVm::CH_SNAPSHOT_NAME =~ s.name }
+
     begin
       _log.info("removing snapshot ID: [#{snapshot.id}] uid_ems: [#{snapshot.uid_ems}] ems_ref: [#{snapshot.ems_ref}] name: [#{snapshot.name}] description [#{snapshot.description}]")
 

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/operations/snapshot.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/operations/snapshot.rb
@@ -13,6 +13,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations::Snapshot
   end
 
   def raw_remove_snapshot(snapshot_id)
+    require "VMwareWebService/MiqVimVm"
+
     raise MiqException::MiqVmError, unsupported_reason(:remove_snapshot) unless supports_remove_snapshot?
     snapshot = snapshots.find_by(:id => snapshot_id)
     raise _("Requested VM snapshot not found, unable to remove snapshot") unless snapshot

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/operations/snapshot_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/operations/snapshot_spec.rb
@@ -1,0 +1,47 @@
+describe ManageIQ::Providers::Vmware::InfraManager::Vm::Operations::Snapshot do
+  let(:vm) do
+    _, _, zone = EvmSpecHelper.create_guid_miq_server_zone
+    ems = FactoryBot.create(:ems_vmware, :zone => zone)
+    host = FactoryBot.create(:host_vmware, :ext_management_system => ems)
+    FactoryBot.create(:vm_vmware, :ext_management_system => ems, :host => host)
+  end
+
+  describe "#remove_snapshot" do
+    context "with no snapshots" do
+      it "raises an exception" do
+        expect { vm.remove_snapshot(nil) }.to raise_error(MiqException::MiqVmError, "No snapshots available for this VM")
+      end
+    end
+
+    context "with a snapshot" do
+      let!(:snapshot) { FactoryBot.create(:snapshot, :vm_or_template => vm, :uid_ems => Time.now.utc) }
+
+      it "calls to remove the snapshot" do
+        expect(vm).to receive(:run_command_via_parent).with(:vm_remove_snapshot, :snMor => snapshot.uid_ems)
+
+        vm.remove_snapshot(snapshot)
+      end
+
+      it "with an invalid snapshot id raises an exception" do
+        expect { vm.remove_snapshot(nil) }.to raise_error("Requested VM snapshot not found, unable to remove snapshot")
+      end
+
+      context "with a consolidate helper snapshot" do
+        let!(:ch_snapshot) { FactoryBot.create(:snapshot, :name => "Consolidate Helper", :vm_or_template => vm) }
+
+        it "doesn't delete the snapshot" do
+          expect { vm.remove_snapshot(snapshot) }
+            .to raise_error("Refusing to delete snapshot when there is a Consolidate Helper snapshot")
+        end
+      end
+
+      context "with a VCB snapshot" do
+        let(:vcb_snapshot) { FactoryBot.create(:snapshot, :name => "_VCB-BACKUP_", :vm_or_template => vm) }
+
+        it "doesn't delete the snpashot" do
+          expect { vm.remove_snapshot(vcb_snapshot) }.to raise_error("Refusing to delete a VCB Snapshot")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
With a snapshot named `"Consolidate Helper"`
```
RuntimeError (Refusing to delete snapshot when there is a Consolidate Helper snapshot)
```

With a snapshot named `"_VCB-BACKUP_"`
```
RuntimeError (Refusing to delete a VCB Snapshot)
```