### PR TITLE
Fix VMware VmScan for new MiqServer capabilities

### DIFF
--- a/spec/models/manageiq/providers/vmware/infra_manager/vm_scan_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm_scan_spec.rb
@@ -1,7 +1,7 @@
 describe VmScan do
   context "A single VM Scan Job," do
     before do
-      @server = EvmSpecHelper.local_miq_server(:capabilities => {:vixDisk => true})
+      @server = EvmSpecHelper.local_miq_server(:has_vix_disk_lib => true)
       assign_smartproxy_role_to_server(@server)
 
       # TODO: stub only settings needed for test instead of all from settings.yml


### PR DESCRIPTION
Now that MiqServer no longer has capabilities but rather a
`:has_vix_disk_lib` column we need to update the VmScan spec.

https://github.com/ManageIQ/manageiq/pull/19552