### PR TITLE
Remove unused worker OPTIONS_PARSER_SETTINGS

### DIFF
--- a/app/models/miq_ems_refresh_core_worker/runner.rb
+++ b/app/models/miq_ems_refresh_core_worker/runner.rb
@@ -1,10 +1,6 @@
 require 'thread'
 
 class MiqEmsRefreshCoreWorker::Runner < MiqWorker::Runner
-  OPTIONS_PARSER_SETTINGS = MiqWorker::Runner::OPTIONS_PARSER_SETTINGS + [
-    [:ems_id, 'EMS Instance ID', String],
-  ]
-
   def after_initialize
     @ems = ExtManagementSystem.find(@cfg[:ems_id])
     do_exit("Unable to find instance for EMS id [#{@cfg[:ems_id]}].", 1) if @ems.nil?


### PR DESCRIPTION
We last used this constant before we switched from spawn to fork in
https://github.com/ManageIQ/manageiq/commit/98745799d17600ba07.

We've subsequently moved to use run_single_worker for launching workers and that handles
options parsing.

https://github.com/ManageIQ/manageiq/pull/19580
