### PR TITLE
Collect and parse Storage#maintenance

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/datastore.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/datastore.rb
@@ -11,6 +11,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
       storage_hash[:free_space] = summary[:freeSpace]
       storage_hash[:uncommitted] = summary[:uncommitted]
       storage_hash[:multiplehostaccess] = summary[:multipleHostAccess].to_s.downcase == "true"
+      storage_hash[:maintenance] = summary[:maintenanceMode] != "normal" if summary[:maintenanceMode]
     end
 
     def parse_datastore_location(props)

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -134,6 +134,7 @@ module ManageIQ::Providers
           capability = storage_inv["capability"]
 
           loc = uid = normalize_storage_uid(storage_inv)
+          maintenance = summary["maintenanceMode"] != "normal" if summary["maintenanceMode"]
 
           new_result = {
             :ems_ref            => mor,
@@ -145,6 +146,7 @@ module ManageIQ::Providers
             :uncommitted        => summary["uncommitted"],
             :multiplehostaccess => summary["multipleHostAccess"].to_s.downcase == "true",
             :location           => loc,
+            :maintenance        => maintenance,
           }
 
           unless capability.nil?

--- a/app/models/manageiq/providers/vmware/infra_manager/selector_spec.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/selector_spec.rb
@@ -166,6 +166,7 @@ module ManageIQ::Providers::Vmware::InfraManager::SelectorSpec
       "summary.capacity",
       "summary.datastore",
       "summary.freeSpace",
+      "summary.maintenanceMode",
       "summary.multipleHostAccess",
       "summary.name",
       "summary.type",

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -630,6 +630,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         :store_type                    => "VMFS",
         :total_space                   => 1_099_511_627_776,
         :free_space                    => 824_633_720_832,
+        :maintenance                   => false,
         :multiplehostaccess            => 1,
         :directory_hierarchy_supported => true,
         :thin_provisioning_supported   => true,

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -395,6 +395,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :total_space                   => 524254445568,
       :free_space                    => 85162196992,
       :uncommitted                   => 338640414720,
+      :maintenance                   => false,
       :multiplehostaccess            => 1, # TODO: Should this be a boolean column?
       :location                      => "4d3f9f09-38b9b7dc-365d-0010187f00da",
       :directory_hierarchy_supported => true,

--- a/spec/tools/vim_data/miq_vim_inventory/dataStoresByMor.yml
+++ b/spec/tools/vim_data/miq_vim_inventory/dataStoresByMor.yml
@@ -105,6 +105,7 @@
           str: '1048508891136'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -213,6 +214,7 @@
           str: '0'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -303,6 +305,7 @@
           str: '536602476544'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -389,6 +392,7 @@
           str: '104689827840'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -479,6 +483,7 @@
           str: '15837691904'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -587,6 +592,7 @@
           str: '2830920318976'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -673,6 +679,7 @@
           str: '42949672960'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -759,6 +766,7 @@
           str: '107105746944'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -871,6 +879,7 @@
           str: '524254445568'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -961,6 +970,7 @@
           str: '0'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -1047,6 +1057,7 @@
           str: '524254445568'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -1155,6 +1166,7 @@
           str: '104689827840'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -1241,6 +1253,7 @@
           str: '209648091136'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -1349,6 +1362,7 @@
           str: '104689827840'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -1439,6 +1453,7 @@
           str: '1048508891136'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -1525,6 +1540,7 @@
           str: '1048508891136'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -1633,6 +1649,7 @@
           str: '0'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -1719,6 +1736,7 @@
           str: '104689827840'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -1827,6 +1845,7 @@
           str: '104689827840'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -1939,6 +1958,7 @@
           str: '524254445568'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -2025,6 +2045,7 @@
           str: '524254445568'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -2111,6 +2132,7 @@
           str: '2830920318976'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -2223,6 +2245,7 @@
           str: '107374182400'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -2309,6 +2332,7 @@
           str: '244544700416'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -2395,6 +2419,7 @@
           str: '314337918976'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -2503,6 +2528,7 @@
           str: '104689827840'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -2589,6 +2615,7 @@
           str: '0'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -2701,6 +2728,7 @@
           str: '3832184569856'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -2791,6 +2819,7 @@
           str: '2095675604992'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -2877,6 +2906,7 @@
           str: '104689827840'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -2989,6 +3019,7 @@
           str: '209648091136'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -3075,6 +3106,7 @@
           str: '244544700416'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -3187,6 +3219,7 @@
           str: '2095675604992'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -3299,6 +3332,7 @@
           str: '354334801920'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -3385,6 +3419,7 @@
           str: '104689827840'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -3497,6 +3532,7 @@
           str: '314337918976'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -3605,6 +3641,7 @@
           str: '104689827840'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -3713,6 +3750,7 @@
           str: '8589934592'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -3781,6 +3819,7 @@
           str: '0'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -3867,6 +3906,7 @@
           str: '244544700416'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -3975,6 +4015,7 @@
           str: '107105746944'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -4061,6 +4102,7 @@
           str: '104689827840'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -4147,6 +4189,7 @@
           str: '104689827840'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -4255,6 +4298,7 @@
           str: '104689827840'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -4367,6 +4411,7 @@
           str: '1048508891136'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -4431,6 +4476,7 @@
           str: '0'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -4517,6 +4563,7 @@
           str: '104689827840'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -4625,6 +4672,7 @@
           str: '104689827840'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -4711,6 +4759,7 @@
           str: '5368709120'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary
@@ -4823,6 +4872,7 @@
           str: '536602476544'
           vimType: 
           xsiType: :SOAP::SOAPLong
+        maintenanceMode: normal
       ivars:
         :@vimType: 
         :@xsiType: :DatastoreSummary


### PR DESCRIPTION
Parse if a datastore is in maintenance mode or not, this can assist in 
storage selection for the purpose of provisioning.

Depends on:
- [x] https://github.com/ManageIQ/manageiq-schema/pull/442

https://bugzilla.redhat.com/show_bug.cgi?id=1394909