### PR TITLE
Follow-up fixes for the updated storage parsing

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -74,7 +74,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
   end
 
   def parse_datastore(object, kind, props)
-    persister.storages.targeted_scope << parse_datastore_location(props)
+    persister.storages.targeted_scope << object._ref
     return if kind == "leave"
 
     storage_hash = {
@@ -280,10 +280,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
   alias parse_pbm_capability_profile parse_pbm_profile
 
   def parse_pbm_placement_hub(persister_storage_profile, _object, _kind, props)
-    datastore = cache["Datastore"][props[:hubId]]
-    return if datastore.nil?
-
-    persister_storage = persister.storages.lazy_find(parse_datastore_location(datastore))
+    persister_storage = persister.storages.lazy_find(props[:hubId])
     persister.storage_profile_storages.build(
       :storage_profile => persister_storage_profile,
       :storage         => persister_storage

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -71,7 +71,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
         cache.find(ds)&.dig(:summary, :name) == datastore_name
       end
 
-      vm_hash[:storage] = persister.storages.lazy_find(datastore._ref)
+      vm_hash[:storage] = persister.storages.lazy_find(datastore._ref) if datastore
     end
 
     def parse_virtual_machine_summary_runtime(vm_hash, props)


### PR DESCRIPTION
There was one instance where datastore could be nil really early on in a
VM's lifecycle, and one where we were still looking up a datastore by
location not ems_ref.