### PR TITLE
Reconfigure cdrom does not connect the ISO

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
@@ -408,6 +408,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure
       end
 
       device.connectable.startConnected = true
+      device.connectable.connected = true
 
       vdcs.device = device
     end


### PR DESCRIPTION
When using the reconfigure screen to mount the ISO to a VM the cdrom is not in an connected state and not usable for the user.

![afbeelding](https://user-images.githubusercontent.com/61044/71091586-a3398e00-21a5-11ea-8876-cd4dd42e22a6.png)

This PR enables the connected checkbox so the iso is available to the OS in the VM without a reboot (startConnected=true requires a reboot to become connected).