### PR TITLE
Fix uninitialized constant RefreshParser::Filter

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -17,8 +17,8 @@ module ManageIQ::Providers
     require_nested :Provision
     require_nested :ProvisionViaPxe
     require_nested :ProvisionWorkflow
+    require_nested :RefreshParser # This has to be before Refresher because that includes RefreshParser::Filter
     require_nested :Refresher
-    require_nested :RefreshParser
     require_nested :RefreshWorker
     require_nested :ResourcePool
     require_nested :SelectorSpec


### PR DESCRIPTION
The Refresher includes the RefreshParser::Filter so the require_nested
RefreshParser has to be before the Refresher

Fixes this error in the UI
```
Data {"error":{"kind":"internal_server_error","message":"uninitialized constant ManageIQ::Providers::InfraManager::RefreshParser::Filter","klass":"NameError"}} 
```
