### PR TITLE
Always set a host name, even if there is no dns config

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -174,6 +174,8 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
                          "ManageIQ::Providers::Vmware::InfraManager::HostEsx"
                        end
 
+    host_hash[:name] ||= props[:name]
+
     host = persister.hosts.build(host_hash)
 
     parse_host_system_operating_system(host, props)


### PR DESCRIPTION
If there is no config.network.dnsConfig on a host we do not set the
host.name attribute which fails later on in save_inventory on a
active record validation:
```
Validation failed: ManageIQ::Providers::Vmware::InfraManager::HostEsx: Name can't be blank
```

Fixes https://github.com/ManageIQ/manageiq-providers-vmware/issues/503