### PR TITLE
Remove obsolete init_console method

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
@@ -4,11 +4,6 @@ require 'http-access2' # Required in case it is not already loaded
 module ManageIQ::Providers
   module Vmware
     class InfraManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
-      # Development helper method for setting up the selector specs for VC
-      def self.init_console(*_)
-        # TODO remove from core
-      end
-
       def refresh
         collector_klass = ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
 


### PR DESCRIPTION
This can be removed now that https://github.com/ManageIQ/manageiq/pull/19653 is merged