### PR TITLE
Enable monitorUpdates thread in OperationsWorker

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/metrics_collector_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/metrics_collector_worker/runner.rb
@@ -1,3 +1,9 @@
 class ManageIQ::Providers::Vmware::InfraManager::MetricsCollectorWorker::Runner < ManageIQ::Providers::BaseManager::MetricsCollectorWorker::Runner
-  self.require_vim_broker = true
+  def do_before_work_loop
+    MiqVim.cacheScope = :cache_scope_core
+  end
+
+  def before_exit(_message, _exit_code)
+    ManageIQ::Providers::Vmware::InfraManager.disconnect_all
+  end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/operations_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/operations_worker/runner.rb
@@ -8,11 +8,6 @@ class ManageIQ::Providers::Vmware::InfraManager::OperationsWorker::Runner < Mana
   end
 
   def before_exit(_message, _exit_code)
-    Thread.current[:miq_vim].each_value do |vim|
-      begin
-        vim.disconnect
-      rescue => err
-      end
-    end
+    ManageIQ::Providers::Vmware::InfraManager.disconnect_all
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/operations_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/operations_worker/runner.rb
@@ -4,7 +4,7 @@ class ManageIQ::Providers::Vmware::InfraManager::OperationsWorker::Runner < Mana
     MiqVim.cacheScope = :cache_scope_core
 
     # Prime the cache before starting the do_work loop
-    ems.connect
+    ems.connect(:monitor_updates => true, :pre_load => true)
   end
 
   def before_exit(_message, _exit_code)

--- a/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
@@ -13,12 +13,14 @@ module ManageIQ::Providers::Vmware::InfraManager::VimConnectMixin
     options[:user] ||= authentication_userid(options[:auth_type])
     options[:pass] ||= authentication_password(options[:auth_type])
 
-    # Reconnect if the connection is stale
-    Thread.current[:miq_vim][connection_key(options)] = nil unless Thread.current[:miq_vim][connection_key(options)]&.isAlive?
+    conn_key = connection_key(options)
 
-    Thread.current[:miq_vim][connection_key(options)] ||= begin
+    # Reconnect if the connection is stale
+    Thread.current[:miq_vim][conn_key] = nil unless Thread.current[:miq_vim][conn_key]&.isAlive?
+
+    Thread.current[:miq_vim][conn_key] ||= begin
       require 'VMwareWebService/MiqVim'
-      MiqVim.new(options[:ip], options[:user], options[:pass], options[:cache_scope], options[:monitor_updates])
+      MiqVim.new(*options.values_at(*%i[ip user pass cache_scope monitor_updates pre_load]))
     end
   end
 

--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*"]
 
   s.add_dependency("fog-vcloud-director", ["~> 0.3.0"])
-  s.add_dependency "vmware_web_service",      "~>0.4.3"
+  s.add_dependency "vmware_web_service",      "~>1.0.0"
   s.add_dependency "rbvmomi",                 "~>2.0.0"
   s.add_dependency "vsphere-automation-sdk",  "~>0.2.1"
 

--- a/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
@@ -93,7 +93,7 @@ describe ManageIQ::Providers::Vmware::InfraManager do
 
         vim = mock_vim_broker_connection
 
-        expect(MiqVim).to receive(:new).with(ems.hostname, "readonly", "1234").and_return(vim)
+        expect(MiqVim).to receive(:new).with(ems.hostname, "readonly", "1234", nil, nil, nil).and_return(vim)
         expect(vim).to receive(:acquireCloneTicket)
 
         ems.remote_console_vmrc_acquire_ticket


### PR DESCRIPTION
Enable the monitorUpdates thread in the OperationsWorker to keep the inventoryHash up-to-date

Depends on: https://github.com/ManageIQ/vmware_web_service/pull/72
Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/56

https://github.com/ManageIQ/manageiq-providers-vmware/issues/484