### PR TITLE
Defer requirement of securerandom, use regular require

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm/remote_console.rb
@@ -1,6 +1,4 @@
 module ManageIQ::Providers::Vmware::CloudManager::Vm::RemoteConsole
-  require_dependency 'securerandom'
-
   def console_supported?(type)
     %w(WEBMKS).include?(type.upcase)
   end
@@ -39,11 +37,15 @@ module ManageIQ::Providers::Vmware::CloudManager::Vm::RemoteConsole
   #
 
   def remote_console_webmks_acquire_ticket(userid, originating_server = nil)
+    require 'securerandom'
+
     validate_remote_console_webmks_support
     ticket = nil
+
     ext_management_system.with_provider_connection do |service|
       ticket = service.post_acquire_mks_ticket(ems_ref).body
     end
+
     raise(MiqException::RemoteConsoleNotSupportedError, 'Could not obtain WebMKS ticket') unless ticket && ticket[:Ticket]
 
     SystemConsole.force_vm_invalid_token(id)

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
@@ -1,6 +1,4 @@
 module ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole
-  require_dependency 'securerandom'
-
   def console_supported?(type)
     %w(VMRC VNC WEBMKS).include?(type.upcase)
   end
@@ -93,6 +91,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole
   # VNC
   #
   def remote_console_vnc_acquire_ticket(userid, originating_server)
+    require 'securerandom'
+
     validate_remote_console_acquire_ticket("vnc")
 
     password     = SecureRandom.base64[0, 8] # Random password from the Base64 character set


### PR DESCRIPTION
Since https://github.com/ManageIQ/manageiq-providers-vmware/pull/218 we've been seeing this warning in the console and/or rails logs:

```
securerandom.rb:275: warning: already initialized constant Random::Formatter::ALPHANUMERIC
securerandom.rb:275: warning: previous definition of ALPHANUMERIC was here
```
This appears to be caused by `load`-ing securerandom after it's already been `require`'d somewhere else.

I'm not sure why it was written this way since securerandom should already be loaded (via rails, in active_support.rb, among other places). Since it's only used within a single method, I've moved it into that method so that it's deferred until needed, and changed it to a regular `require`. The specs still seem to pass.