### PR TITLE
metrics: Allow a storage with no ems_id

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/metrics_capture.rb
@@ -243,7 +243,7 @@ class ManageIQ::Providers::Vmware::InfraManager::MetricsCapture < ManageIQ::Prov
 
     raise ArgumentError, "At least one target must be passed"      if self.ems.nil? && targets.empty?
     raise ArgumentError, "All targets must be connected to an EMS" if self.ems.nil?
-    raise ArgumentError, "All targets must be on the same EMS"     if targets.map(&:ems_id).any? { |ems_id| ems_id != self.ems.id }
+    raise ArgumentError, "All targets must be on the same EMS"     if targets.select { |t| !t.kind_of?(Storage) }.map(&:ems_id).any? { |ems_id| ems_id != self.ems.id }
   end
 
   #


### PR DESCRIPTION
Storages have multiple ems references. the ems_id tends to be nil.

This allows a storage record to have no ems_id
This check is of less interest since we are not collecting by ems
rather than by zone

related to https://github.com/ManageIQ/manageiq/pull/19741