### PR TITLE
Various small fixes to VimConnectMixin without the broker

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
@@ -48,10 +48,14 @@ module ManageIQ::Providers::Vmware::InfraManager::VimConnectMixin
       require 'VMwareWebService/miq_fault_tolerant_vim'
 
       options[:pass] = ManageIQ::Password.try_decrypt(options[:pass])
+      options[:use_broker] = false
+
       validate_connection do
         vim = MiqFaultTolerantVim.new(options)
         raise MiqException::Error, _("Adding ESX/ESXi Hosts is not supported") unless vim.isVirtualCenter
         true
+      ensure
+        vim&.disconnect rescue nil
       end
     end
 

--- a/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
@@ -3,6 +3,10 @@ module ManageIQ::Providers::Vmware::InfraManager::VimConnectMixin
 
   def connect(options = {})
     Thread.current[:miq_vim] ||= {}
+
+    # Reconnect if the connection is stale
+    Thread.current[:miq_vim][connection_key(options)] = nil unless Thread.current[:miq_vim][connection_key(options)]&.isAlive?
+
     Thread.current[:miq_vim][connection_key(options)] ||= begin
       options[:auth_type] ||= :ws
       raise _("no console credentials defined") if options[:auth_type] == :console && !authentication_type(options[:auth_type])

--- a/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
@@ -24,12 +24,6 @@ module ManageIQ::Providers::Vmware::InfraManager::VimConnectMixin
     begin
       vim = connect(options)
       yield vim
-    rescue MiqException::MiqVimBrokerUnavailable => err
-      MiqVimBrokerWorker.broker_unavailable(err.class.name, err.to_s)
-      _log.warn("Reported the broker unavailable")
-      raise
-    ensure
-      vim.try(:disconnect) rescue nil
     end
   end
 


### PR DESCRIPTION
1. Make sure to disconnect after raw_connect to verify credentials
2. Clear the connection and reconnect if the conn isn't alive
3. Don't rescue broker exception if we're not using the broker

https://github.com/ManageIQ/manageiq-providers-vmware/issues/484