### PR TITLE
SmartState snapshots on OperationsWorker

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/scanning/job.rb
@@ -20,11 +20,11 @@ class ManageIQ::Providers::Vmware::InfraManager::Scanning::Job < VmScan
   end
 
   def before_scan
-    signal(:start_snapshot)
+    queue_signal(:start_snapshot, role: "ems_operations", queue_name: vm.queue_name_for_ems_operations)
   end
 
   def after_scan
-    signal(:snapshot_delete)
+    queue_signal(:snapshot_delete, role: "ems_operations", queue_name: vm.queue_name_for_ems_operations)
   end
 
   def call_snapshot_create


### PR DESCRIPTION
The snapshot create and delete operations should be run by the
OperationWorker for the ems_operations role.

Depends on: https://github.com/ManageIQ/manageiq/pull/19764