### PR TITLE
Convert VimString/VimHash to standard String/Hash

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/event_parser.rb
@@ -2,6 +2,8 @@ module ManageIQ::Providers::Vmware::InfraManager::EventParser
   def self.event_to_hash(event, ems_id = nil)
     log_header = "ems_id: [#{ems_id}] " unless ems_id.nil?
 
+    event = vim_types_to_basic_types(event)
+
     _log.debug { "#{log_header}event: [#{event.inspect}]" }
     event_type = event['eventType']
     if event_type.nil?
@@ -149,5 +151,19 @@ module ManageIQ::Providers::Vmware::InfraManager::EventParser
     }
 
     return hash, klass, :uid_ems => mor
+  end
+
+  def self.vim_types_to_basic_types(obj)
+    case obj
+    when VimString
+      obj = obj.to_s
+    when VimHash
+      obj = obj.to_h
+      obj.each { |key, val| obj[key] = vim_types_to_basic_types(val) }
+    when VimArray
+      obj = obj.map { |v| vim_types_to_basic_types(v) }
+    end
+
+    obj
   end
 end

--- a/spec/models/manageiq/providers/vmware/infra_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/event_parser_spec.rb
@@ -1,3 +1,5 @@
+require 'VMwareWebService/VimTypes'
+
 describe ManageIQ::Providers::Vmware::InfraManager::EventParser do
   EPV_DATA_DIR = File.expand_path(File.join(File.dirname(__FILE__), "event_data"))
 
@@ -24,7 +26,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::EventParser do
       )
 
       expect(data[:full_data]).to    eq(event)
-      expect(data[:full_data]).to    be_instance_of VimHash
+      expect(data[:full_data]).to    be_instance_of Hash
       expect(data[:vm_ems_ref]).to   be_instance_of String
       expect(data[:host_ems_ref]).to be_instance_of String
     end
@@ -64,7 +66,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::EventParser do
         )
 
         expect(data[:full_data]).to    eq(event)
-        expect(data[:full_data]).to    be_instance_of VimHash
+        expect(data[:full_data]).to    be_instance_of Hash
         expect(data[:host_ems_ref]).to be_instance_of String
       end
     end


### PR DESCRIPTION
The EventParser was adding VimStrings and VimHashes to the serialized
event payload