### PR TITLE
Bump the OperationsWorker memory threshold

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -43,7 +43,8 @@
       :ems_metrics_collector_worker:
         :ems_metrics_collector_worker_vmware: {}
       :ems_operations_worker:
-        :ems_operations_worker_vmware: {}
+        :ems_operations_worker_vmware:
+          :memory_threshold: 1.gigabytes
       :ems_refresh_worker:
         :ems_refresh_worker_vmware: {}
         :ems_refresh_worker_vmware_cloud: {}


### PR DESCRIPTION
A 10,000 VM simulator uses about 700MB of memory so 1GB should be
comfortable