### PR TITLE
Fix log_object_update in Inventory Refresh

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -328,6 +328,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
 
       s =  "#{log_header} Object: [#{object_str}] Kind: [#{object_update.kind}]"
       s << " Props: [#{prop_changes}]" if object_update.kind == "modify"
+      s
     end
   end
 


### PR DESCRIPTION
The log_object_update block wasn't returning a string so it wouldn't log anything