### PR TITLE
Replace MiqFaultTolerantVim with MiqVim

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -112,7 +112,7 @@ module ManageIQ::Providers
       default_endpoint = args.dig("endpoints", "default")
       username, password, server = default_endpoint&.values_at("username", "password", "server")
 
-      !!raw_connect(:ip => server, :user => username, :pass => password, :use_broker => false)
+      !!raw_connect(:ip => server, :user => username, :pass => password)
     end
 
     def supported_auth_types
@@ -200,7 +200,8 @@ module ManageIQ::Providers
     end
 
     def verify_credentials(auth_type = nil, _options = {})
-      self.class.raw_connect(:use_broker => false, :ems => self)
+      user, pwd = auth_user_pwd(auth_type)
+      self.class.raw_connect(:ip => hostname, :user => user, :pass => pwd)
     end
 
     def get_alarms

--- a/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
@@ -45,13 +45,13 @@ module ManageIQ::Providers::Vmware::InfraManager::VimConnectMixin
   module ClassMethods
     def raw_connect(options)
       require 'handsoap'
-      require 'VMwareWebService/miq_fault_tolerant_vim'
+      require 'VMwareWebService/MiqVim'
 
-      options[:pass] = ManageIQ::Password.try_decrypt(options[:pass])
-      options[:use_broker] = false
+      ip, user = options.values_at(:ip, :user)
+      pass = ManageIQ::Password.try_decrypt(options[:pass])
 
       validate_connection do
-        vim = MiqFaultTolerantVim.new(options)
+        vim = MiqVim.new(ip, user, pass)
         raise MiqException::Error, _("Adding ESX/ESXi Hosts is not supported") unless vim.isVirtualCenter
         true
       ensure

--- a/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/scanning.rb
@@ -67,9 +67,9 @@ module ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared::Scanning
         end
 
         begin
-          require 'VMwareWebService/miq_fault_tolerant_vim'
+          require 'VMwareWebService/MiqVim'
           # TODO: Should this move to the EMS?
-          ost.miqVim = MiqFaultTolerantVim.new(:ip => host_address, :user => miqVimHost[:username], :pass => password_decrypt, :use_broker => use_broker, :vim_broker_drb_uri => ost.scanData['ems'][:vim_broker_drb_uri])
+          ost.miqVim = MiqVim.new(host_address, miqVimHost[:username], password_decrypt)
           # ost.snapId = opts.snapId if opts.snapId
           $log.info "Connection to [#{ems_display_text}] completed for VM:[#{@vmCfgFile}] in [#{Time.now - st}] seconds"
         rescue Timeout::Error => err


### PR DESCRIPTION
Now that we are no longer using the broker for these connections we do not need MiqFaultTolerantVim anymore (whose only use was to seamlessly handle broker/DRb specific issues).

https://github.com/ManageIQ/manageiq-providers-vmware/issues/520