### PR TITLE
Test dumping VimHash and VimArray in MiqRequestTask

### DIFF
--- a/spec/models/manageiq/providers/vmware/infra_manager/miq_request_task/dumping_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/miq_request_task/dumping_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe MiqRequestTask do
+  context "::Dumping" do
+    let(:task) { FactoryBot.create(:miq_request_task) }
+
+    it 'with a VimHash' do
+      data = VimHash.new('VirtualDisk') do |vh|
+        vh.backing = {'diskMode' => 'persistent', 'datastore' => 'datastore-001'}
+        vh.capacityInKB = 100
+      end
+      expect(MiqRequestTask).to receive(:dump_hash)
+      expect(STDOUT).to receive(:puts).with(" (VimHash) xsiType: <VirtualDisk>  vimType: <>")
+      task.dump_obj(data)
+    end
+
+    it 'with a VimArray' do
+      array = VimArray.new("ArrayOfHostInternetScsiHbaStaticTarget") do |ta|
+        ta << VimHash.new("HostInternetScsiHbaStaticTarget") do |st|
+          st.address    = "10.1.1.210"
+          st.iScsiName  = "iqn.1992-08.com.netapp:sn.135107242"
+        end
+        ta << VimHash.new("HostInternetScsiHbaStaticTarget") do |st|
+          st.address    = "10.1.1.100"
+          st.iScsiName  = "iqn.2008-08.com.starwindsoftware:starwindm1-starm1-test1"
+        end
+      end
+      expect(MiqRequestTask).to receive(:dump_array)
+      expect(STDOUT).to receive(:puts).with(" (VimArray) xsiType: <ArrayOfHostInternetScsiHbaStaticTarget>  vimType: <>")
+      task.dump_obj(array)
+    end
+  end
+end


### PR DESCRIPTION
Replace the core test which references VimHash and VimArray types in core with one in the VMware repo.

Replaces the core specs from https://github.com/ManageIQ/manageiq/pull/19833