### PR TITLE
Support sata bus type

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -190,6 +190,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
         controller_type = case controller.class.wsdl_name
                           when /IDE/ then 'ide'
                           when /SIO/ then 'sio'
+                          when /AHCI/, /SATA/ then 'sata'
                           else 'scsi'
                           end
         disk_hash = {

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -1120,6 +1120,7 @@ module ManageIQ::Providers
               case controller.xsiType
               when /IDE/ then 'ide'
               when /SIO/ then 'sio'
+              when /AHCI/, /SATA/ then 'sata'
               else 'scsi'
               end
             else


### PR DESCRIPTION
Drives created as sata drive in vCenter are created as scsi drive in manageiq. This causes conflicts with other scsi drives on subsequent provider refreshes.
 
![afbeelding](https://user-images.githubusercontent.com/61044/74740207-b8d93b80-525a-11ea-8d54-a5a5dec7ab51.png)

In the example the cdrom (sata 0:0) disapears because it conflicts with Hard disk 1 scsi drive on 0:0.

This PR adds sata drive as sata drives

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1804291