### PR TITLE
Set the new disk thin and format attributes

### DIFF
--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -917,6 +917,8 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         :mode            => "persistent",
         :size            => 536_870_912,
         :start_connected => true,
+        :thin            => false,
+        :format          => "vmdk"
       )
 
       expect(vm.ems_cluster).not_to be_nil


### PR DESCRIPTION
There are new attributes on a disk tracking a boolean if it is thin or
thick and the format [vmdk, rdm-physical, rdm-virtual]