### PR TITLE
Delay the vcloud_director require until needed

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/orchestration_stack.rb
@@ -44,6 +44,7 @@ class ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack < ManageIQ::
   end
 
   def vapp_or_nil(service, ems_ref)
+    require 'fog/vcloud_director'
     service.vapps.get_single_vapp(ems_ref)
   rescue Fog::VcloudDirector::Compute::Forbidden
     # vCloud returns 403 Forbidden instead 404 Not Found when ems_ref is in

--- a/app/models/manageiq/providers/vmware/inventory/collector/network_manager.rb
+++ b/app/models/manageiq/providers/vmware/inventory/collector/network_manager.rb
@@ -151,6 +151,7 @@ class ManageIQ::Providers::Vmware::Inventory::Collector::NetworkManager < Manage
   # Fetch vapp network configuration via vCD API. This call is implemented in Fog, but it's not
   # managed, therefore we must handle errors by ourselves.
   def fetch_network_configurations_for_vapp(vapp_id)
+    require 'fog/vcloud_director'
     begin
       # fog-vcloud-director now uses a more user-friendly parser that yields vApp instance. However, vapp networking
       # is not parsed there yet so we need to fallback to basic ToHashDocument parser that only converts XML to hash.
@@ -164,6 +165,7 @@ class ManageIQ::Providers::Vmware::Inventory::Collector::NetworkManager < Manage
   end
 
   def fetch_nic_configurations_for_vm(vm_id)
+    require 'fog/vcloud_director'
     begin
       data = @connection.get_network_connection_system_section_vapp(vm_id).body
     rescue Fog::VcloudDirector::Errors::ServiceError => e

--- a/app/models/manageiq/providers/vmware/manager_auth_mixin.rb
+++ b/app/models/manageiq/providers/vmware/manager_auth_mixin.rb
@@ -1,5 +1,3 @@
-require 'fog/vcloud_director'
-
 module ManageIQ::Providers::Vmware::ManagerAuthMixin
   extend ActiveSupport::Concern
 
@@ -39,6 +37,7 @@ module ManageIQ::Providers::Vmware::ManagerAuthMixin
 
   module ClassMethods
     def raw_connect(server, port, username, password, api_version = '5.5', validate = false)
+      require 'fog/vcloud_director'
       params = {
         :vcloud_director_username      => username,
         :vcloud_director_password      => ManageIQ::Password.try_decrypt(password),
@@ -69,6 +68,7 @@ module ManageIQ::Providers::Vmware::ManagerAuthMixin
     end
 
     def translate_exception(err)
+      require 'fog/vcloud_director'
       case err
       when Fog::VcloudDirector::Compute::Unauthorized
         MiqException::MiqInvalidCredentialsError.new "Login failed due to a bad username or password."


### PR DESCRIPTION
Before we would load it when loading ManageIQ::Providers::Vmware::NetworkManager
or ManageIQ::Providers::Vmware::CloudManager.  Just loading the managers,
such as through the manageiq rest-api, shouldn't need these vcloud operations.

This saves about 9 MB and decreases $LOADED_FEATURES by about 340.