### PR TITLE
Require manageiq-smartstate in VmOrTemplate::Scanning

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/scanning.rb
@@ -16,6 +16,7 @@ module ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared::Scanning
 
   def perform_metadata_scan(ost)
     require 'MiqVm/MiqVm'
+    require 'manageiq-smartstate'
 
     log_pref = "MIQ(#{self.class.name}##{__method__})"
     vm_name  = ManageIQ::Smartstate::Util.uri_to_local_path(ost.args[0])


### PR DESCRIPTION
We need to require the manageiq-smartstate gem in the scanning class to
prevent MiqServer#scan_metadata from the following error:

`uninitialized constant ManageIQ::Smartstate`