### PR TITLE
[IVANCHUK] Bump vmware_web_service for bios firmware_type

### DIFF
--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*"]
 
   s.add_dependency("fog-vcloud-director", ["~> 0.3.0"])
-  s.add_dependency "vmware_web_service",      "~>0.4.3"
+  s.add_dependency "vmware_web_service",      "~>0.4.7"
   s.add_dependency "rbvmomi",                 "~>2.0.0"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
https://github.com/ManageIQ/vmware_web_service/pull/65 is required for https://github.com/ManageIQ/manageiq-providers-vmware/pull/459  which was released in v0.4.7