### PR TITLE
Fix the MetricsCaptureSpec now that startTime isn't nil

### DIFF
--- a/spec/models/manageiq/providers/vmware/infra_manager/metric_capture_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/metric_capture_spec.rb
@@ -5,7 +5,11 @@ describe ManageIQ::Providers::Vmware::InfraManager::MetricsCapture do
     MiqRegion.seed
 
     guid, server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+
+    Timecop.freeze(Time.parse("2011-08-12T23:33:00Z").utc)
   end
+
+  after { Timecop.return }
 
   context "#perf_capture_object" do
     it "returns the correct class" do
@@ -31,8 +35,10 @@ describe ManageIQ::Providers::Vmware::InfraManager::MetricsCapture do
         end
 
         context "collecting vm realtime data" do
+          let(:start_time) { Time.parse("2011-08-12T00:00:00Z").utc }
+
           before(:each) do
-            @counters_by_mor, @counter_values_by_mor_and_ts = @vm.perf_collect_metrics('realtime')
+            @counters_by_mor, @counter_values_by_mor_and_ts = @vm.perf_collect_metrics('realtime', start_time)
           end
 
           it "should have collected counters and values" do

--- a/spec/tools/vim_data/miq_vim_perf_history/queryPerfMulti.yml
+++ b/spec/tools/vim_data/miq_vim_perf_history/queryPerfMulti.yml
@@ -4,7 +4,7 @@
   vimType: :VirtualMachine
   xsiType: :ManagedObjectReference
 : '20':
-    ! '':
+    '2011-08-12T00:00:00Z':
       ! '': !ruby/array:VimArray
       - !ruby/hash-with-ivars:VimHash
         elements:


### PR DESCRIPTION
After https://github.com/ManageIQ/manageiq/pull/19838 (specifically https://github.com/ManageIQ/manageiq/pull/19838/files#diff-98e67a56bb0805013a9953cc93e47389R52) there is always a start_time set which was causing no metrics data to be found in our saved `spec/tools/vim_data/miq_vim_perf_history/queryPerfMulti.yml` file.

To fix this we can timecop freeze to a specific point (so that 4.hours.ago.beginning_of_day is consistent) and update the queryPerfMulti hash to have a startTime.