### PR TITLE
Datastores were missing a parent Datastore Cluster

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -80,6 +80,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
     storage_hash = {
       :ems_ref      => object._ref,
       :ems_ref_type => object.class.wsdl_name,
+      :parent       => lazy_find_managed_object(props[:parent])
     }
 
     parse_datastore_summary(storage_hash, props)


### PR DESCRIPTION
The Datastore parser was missing the link to its parent which is what we
use to indicate if a Storage is in a Storage Cluster for display
purposes.