### PR TITLE
Fix strict partial failures in specs

### DIFF
--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
@@ -245,7 +245,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
 
         it "returns a resource_pool if one is passed in" do
           expect(ResourcePool).to receive(:find_by).and_return(:resource_pool)
-          expect(@vm_prov).to receive(:default_resource_pool).never
+          expect(cluster).to receive(:default_resource_pool).never
           @vm_prov.dest_resource_pool
         end
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
@@ -407,7 +407,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
           disks[1].merge(:controller_key => 1000, :unit_number => 15)
         ]
 
-        expect(vm).not_to receive(:add_scsi_controllers)
+        expect(vm).not_to receive(:add_scsi_controller)
         expect(vm).to receive(:add_disk_config_spec).with(vmcs, expected_disks[0]).once
         expect(vm).to receive(:add_disk_config_spec).with(vmcs, expected_disks[1]).once
 
@@ -423,7 +423,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
           disks[1].merge(:controller_key => 1000, :unit_number => 3)
         ]
 
-        expect(vm).not_to receive(:add_scsi_controllers)
+        expect(vm).not_to receive(:add_scsi_controller)
         expect(vm).to receive(:add_disk_config_spec).with(vmcs, expected_disks[0]).once
         expect(vm).to receive(:add_disk_config_spec).with(vmcs, expected_disks[1]).once
 


### PR DESCRIPTION
A few minor updates to the specs that revealed themselves once strict partials were enabled. Two of the three fixes are simply correcting a typo in the check for `add_scsi_controller` (there should be no "s"). The third is a check for `default_resource_pool` which is implemented on a cluster, not a vm.