### PR TITLE
Force VNC console for API versions lower than 6.0

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
@@ -83,7 +83,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole
   # HTML5 selects the best available console type (VNC or WebMKS)
   #
   def remote_console_html5_acquire_ticket(userid, originating_server = nil)
-    protocol = with_provider_object { |v| v.extraConfig["RemoteDisplay.vnc.enabled"] == "true" } ? 'vnc' : 'webmks'
+    protocol = 'vnc' if ext_management_system.api_version.to_f < 6.0 # Force VNC protocol for API version lower than 6.0
+    protocol ||= with_provider_object { |v| v.extraConfig["RemoteDisplay.vnc.enabled"] == "true" } ? 'vnc' : 'webmks'
     send("remote_console_#{protocol}_acquire_ticket", userid, originating_server)
   end
 

--- a/spec/models/manageiq/providers/vmware/cloud_manager/vm/remote_console_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/vm/remote_console_spec.rb
@@ -1,6 +1,6 @@
 describe ManageIQ::Providers::Vmware::CloudManager::Vm::RemoteConsole do
   let(:user) { FactoryBot.create(:user) }
-  let(:ems)  { FactoryBot.create(:ems_vmware_cloud, :api_version => 5.5) }
+  let(:ems)  { FactoryBot.create(:ems_vmware_cloud, :api_version => 6.0) }
   let(:vm)   { FactoryBot.create(:vm_vcloud, :ext_management_system => ems, :raw_power_state => 'on') }
 
   context '#remote_console_acquire_ticket' do

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/remote_console_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/remote_console_spec.rb
@@ -4,7 +4,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
     FactoryBot.create(:ems_vmware,
                       :hostname    => '192.168.252.16',
                       :ipaddress   => '192.168.252.16',
-                      :api_version => '5.0',
+                      :api_version => '6.0',
                       :uid_ems     => '2E1C1E82-BD83-4E54-9271-630C6DFAD4D1')
   end
   let(:host) do


### PR DESCRIPTION
API versions lower than 6.0 behave a little differently and only support VNC protocol. I am adding a test against the version in the HTML5 console ticket acquiring process in order to fix the consoles on older versions.

@miq-bot assign @agrare 
@miq-bot add_label bug, ivanchuk/yes, jansa/yes?

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1809114