### PR TITLE
Do we need Dictionary.gettext in the VMware Parser?

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -261,7 +261,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
                    cached_parent = cache.find(parent) if parent
                    parent_model = persister.vim_class_to_collection(parent).base_class_name
 
-                   "Default for #{Dictionary.gettext(parent_model, :type => :model, :notfound => :titleize)} #{cached_parent[:name]}"
+                   "Default for #{parent_model.titleize} #{cached_parent[:name]}"
                  else
                    CGI.unescape(props[:name])
                  end


### PR DESCRIPTION
I'm not sure that this buys us anything, since this runs in the backend it won't translate to the users locale anyway so it always finds "Cluster" in the en.yml right?