### PR TITLE
Set the opaqueNetwork ems_ref and uid_ems and link VMs to opaqueNetworks

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -215,6 +215,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
 
   def parse_network(object, kind, props)
   end
+  alias parse_opaque_networks parse_network
 
   def parse_distributed_virtual_portgroup(object, kind, props)
     return if kind == "leave"

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/host_system.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/host_system.rb
@@ -459,8 +459,8 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
         nsx_network_uuid = extra_config["com.vmware.opaquenetwork.segment.path"]&.split("/")&.last
 
         name    = opaque_network.opaqueNetworkName
-        uid_ems = nsx_network_uuid || name
-        ems_ref = opaque_network.opaqueNetworkId
+        ems_ref = nsx_network_uuid || name
+        uid_ems = opaque_network.opaqueNetworkId
         switch  = persister.host_virtual_switches.lazy_find(:host => host, :uid_ems => switch_key)
 
         persister.host_virtual_lans.build(

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/host_system.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/host_system.rb
@@ -467,7 +467,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
           :switch  => switch,
           :ems_ref => ems_ref,
           :uid_ems => uid_ems,
-          :name    => name,
+          :name    => name
         )
       end
     end

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/host_system.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/host_system.rb
@@ -452,7 +452,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
       end
 
       network[:opaqueNetwork].to_a.each do |opaque_network|
-        switch_key = cache["HostSystem"][host.ems_ref]&.dig(:config, :network, :opaqueSwitch)&.pluck(:key)&.sort
+        switch_key = cache["HostSystem"][host.ems_ref]&.dig(:config, :network, :opaqueSwitch)&.pluck(:key)&.sort&.first
         next if switch_key.nil?
 
         extra_config     = Hash[opaque_network.extraConfig.to_a.map { |ec| [ec.key, ec.value] }]

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -360,7 +360,11 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
         persister_switch = persister.distributed_virtual_switches.lazy_find({:switch_uuid => backing.port.switchUuid}, :ref => :by_switch_uuid)
       else
         collection = :host_virtual_lans
-        lan_uid = backing.deviceName
+        lan_uid = if backing.kind_of?(RbVmomi::VIM::VirtualEthernetCardOpaqueNetworkBackingInfo)
+          backing.opaqueNetworkId
+        else
+          backing.deviceName
+        end
 
         host_ref = find_vm_host_ref(vm)
         return if host_ref.nil?


### PR DESCRIPTION
Use the opaqueNetworkId as the uid_ems and the nsx network uuid as the ems_ref.  This will allow cross-referencing vSphere Networks to NSX-T Networks.

We also weren't properly linking up vms to OpaqueNetworks because were were looking for the switch_uid in the config.network.portgroups instead of config.network.opaqueNetworks.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1816278