### PR TITLE
 remove last of inventory object refresh from managers

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -147,10 +147,6 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
     %w(vmware)
   end
 
-  def inventory_object_refresh?
-    true
-  end
-
   def self.display_name(number = 1)
     n_('Cloud Provider (VMware vCloud)', 'Cloud Providers (VMware vCloud)', number)
   end

--- a/app/models/manageiq/providers/vmware/network_manager.rb
+++ b/app/models/manageiq/providers/vmware/network_manager.rb
@@ -41,8 +41,4 @@ class ManageIQ::Providers::Vmware::NetworkManager < ManageIQ::Providers::Network
   def description
     @description ||= "VMware Cloud Network".freeze
   end
-
-  def inventory_object_refresh?
-    true
-  end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,7 +10,6 @@
           :critical:
 :ems_refresh:
   :vmware_cloud:
-    :inventory_object_refresh: false
     :get_public_images: false
 :http_proxy:
   :vmware_cloud:


### PR DESCRIPTION
inventory_object_refresh can be 86ed 

i bet it can also be a goner from
```
:ems_refresh:
  :vmware_cloud:
    :inventory_object_refresh: false
```

the settings too 