### PR TITLE
Fix targeted refresh of VM with a standard network

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -383,7 +383,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
 
     def find_host_vswitch(host_ref, lan_name)
       portgroups = cache["HostSystem"][host_ref]&.dig(:config, :network, :portgroup) || []
-      portgroups.detect { |portgroup| portgroup.spec.name == lan_name }
+      portgroups.detect { |portgroup| portgroup.spec.name == lan_name }&.spec&.vswitchName
     end
 
     def find_host_opaque_switch(host_ref)

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -99,7 +99,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         assert_inventory_not_changed(inventory_after_full_refresh, serialize_inventory)
       end
 
-      it "power on a virtual machine" do
+      it "power off a virtual machine" do
         vm = ems.vms.find_by(:ems_ref => 'vm-107')
 
         expect(vm.power_state).to eq("on")


### PR DESCRIPTION
The lookup of the host switch uid_ems was returning the whole object rather than the uid_ems so targeted refresh would fail.

Introduced by: https://github.com/ManageIQ/manageiq-providers-vmware/pull/558

Specifically https://github.com/ManageIQ/manageiq-providers-vmware/pull/558/files#diff-d39b41ac99d2226f2096dd017e768889L372 being changed to https://github.com/ManageIQ/manageiq-providers-vmware/pull/558/files#diff-d39b41ac99d2226f2096dd017e768889R386

```
ERROR -- : Error when saving InventoryCollection:<GuestDevice>, strategy: local_db_find_missing_references with strategy: local_db_find_missing_references, saver_strategy: default, targeted: true. Message: can't quote RbVmomi::VIM::HostPortGroup
ERROR -- : MIQ(ManageIQ::Providers::Vmware::InfraManager::Inventory::Saver#save_inventory) EMS: [vSphere 6.7 IMS], id: [2] Save Inventory failed
ERROR -- : [TypeError]: can't quote RbVmomi::VIM::HostPortGroup  Method:[block (2 levels) in <class:LogProxy>]
ERROR -- : /usr/local/lib/ruby/gems/2.6.0/gems/activerecord-5.1.7/lib/active_record/connection_adapters/abstract/quoting.rb:197:in `_quote'
```

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1818976