### PR TITLE
[WIP] Lock RbVmomi to 2.3.1 to fix Refresh errors

### DIFF
--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("fog-vcloud-director", ["~> 0.3.0"])
   s.add_dependency "ffi-vix_disk_lib",        "~>1.1"
-  s.add_dependency "rbvmomi",                 "~>2.3"
+  s.add_dependency "rbvmomi",                 "~>2.3.1"
   s.add_dependency "vmware_web_service",      "~>1.0"
   s.add_dependency "vsphere-automation-sdk",  "~>0.2.1"
 


### PR DESCRIPTION
The newer RbVmomi 2.4.0 with vSphere 7.0 support causes errors when
refreshing a vCenter:
`[NoMethodError]: undefined method 'split' for #<RbVmomi::VIM::PhysicalNic:0x000000001154aba8>`

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1823192