### PR TITLE
Require MiqVim before setting cacheScope

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/metrics_collector_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/metrics_collector_worker/runner.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Vmware::InfraManager::MetricsCollectorWorker::Runner < ManageIQ::Providers::BaseManager::MetricsCollectorWorker::Runner
   def do_before_work_loop
+    require "VMwareWebService/MiqVim"
     MiqVim.cacheScope = :cache_scope_core
   end
 

--- a/app/models/manageiq/providers/vmware/infra_manager/operations_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/operations_worker/runner.rb
@@ -1,5 +1,7 @@
 class ManageIQ::Providers::Vmware::InfraManager::OperationsWorker::Runner < ManageIQ::Providers::BaseManager::OperationsWorker::Runner
   def do_before_work_loop
+    require "VMwareWebService/MiqVim"
+
     # Set the cache_scope to minimal for ems_operations
     MiqVim.cacheScope = :cache_scope_core
 


### PR DESCRIPTION
There is the possibility that VMwareWebService/MiqVim might not be
required yet by the time the workers hit the do_before_work_loop.

```
uninitialized constant ManageIQ::Providers::Vmware::InfraManager::MetricsCollectorWorker::Runner::MiqVim (NameError)
	from /var/www/miq/vmdb/app/models/miq_worker/runner.rb:108:in `prepare'
	from /var/www/miq/vmdb/app/models/miq_worker/runner.rb:94:in `start'
	from /var/www/miq/vmdb/lib/workers/bin/run_single_worker.rb:113:in `<main>'
```