### PR TITLE
Renaming a DVPG doesn't rename the Lans in VMDB

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -114,7 +114,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
       dvpg_props.fetch_path(:config, :distributedVirtualSwitch)&._ref == object._ref
     end.each do |mor, dvpg_props|
       portgroup = RbVmomi::VIM::DistributedVirtualPortgroup(object._connection, mor)
-      parse_distributed_virtual_portgroup(portgroup, kind, dvpg_props)
+      parse_portgroups_internal(portgroup, dvpg_props)
     end
   end
   alias parse_vmware_distributed_virtual_switch parse_distributed_virtual_switch
@@ -217,8 +217,14 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
   end
   alias parse_opaque_networks parse_network
 
-  def parse_distributed_virtual_portgroup(object, kind, props)
+  def parse_distributed_virtual_portgroup(_object, kind, props)
     return if kind == "leave"
+
+    dvs = props.fetch_path(:config, :distributedVirtualSwitch)
+    parse_distributed_virtual_switch(dvs, kind, cache.find(dvs))
+  end
+
+  def parse_portgroups_internal(object, props)
     return if props[:tag].detect { |tag| tag.key == "SYSTEM/DVS.UPLINKPG" }
 
     name = props.fetch_path(:summary, :name) || props.fetch_path(:config, :name)

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -189,6 +189,15 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         expect(child_snapshot.parent).to eq(root_snapshot)
       end
 
+      it "renaming a distributed virtual portgroup" do
+        lan = ems.distributed_virtual_lans.first
+        expect(lan.name).to eq("DC0_DVPG1")
+
+        run_targeted_refresh(targeted_update_set([dvpg_rename_object_update]))
+
+        expect(lan.reload.name).to eq("DC0_DVPG1_RENAMED")
+      end
+
       def run_targeted_refresh(update_set)
         persister       = ems.class::Inventory::Persister::Targeted.new(ems)
         parser          = ems.class::Inventory::Parser.new(cache, persister)
@@ -511,6 +520,18 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
           ),
         ],
         :missingSet => []
+      )
+    end
+
+    def dvpg_rename_object_update
+      RbVmomi::VIM.ObjectUpdate(
+        :kind      => "modify",
+        :obj       => RbVmomi::VIM.DistributedVirtualPortgroup(vim, "dvportgroup-11"),
+        :changeSet => [
+          RbVmomi::VIM.PropertyChange(:name => "config.name", :op => "assign", :val => "DC0_DVPG1_RENAMED"),
+          RbVmomi::VIM.PropertyChange(:name => "name", :op => "assign", :val => "DC0_DVPG1_RENAMED"),
+          RbVmomi::VIM.PropertyChange(:name => "summary.name", :op => "assign", :val => "DC0_DVPG1_RENAMED")
+        ]
       )
     end
 


### PR DESCRIPTION
Since a Lan is a child of a Switch, targeting a Lan without including the Switch doesn't actually save anything.  We have to target the whole switch which is fine since we have everything cached, but if we want to drop the cache we'll need to fix the modeling to allow for switches to be top-level objects.