### PR TITLE
Add the event.key to the EmsEvent#ems_ref

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/event_parser.rb
@@ -69,6 +69,7 @@ module ManageIQ::Providers::Vmware::InfraManager::EventParser
 
       :message    => event['fullFormattedMessage'],
       :timestamp  => event['createdTime'],
+      :ems_ref    => event['key'],
       :full_data  => event
     }
     result[:ems_id] = ems_id unless ems_id.nil?


### PR DESCRIPTION
The VMware event.key is the unique id of a VMware event.  It can be used as the EmsEvent#ems_ref unique attribute.

This EmsEvent#ems_ref attribute was added relatively recently but we never set it in the EventParser here.