### PR TITLE
Fix OpaqueNetwork parser

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -215,7 +215,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
 
   def parse_network(object, kind, props)
   end
-  alias parse_opaque_networks parse_network
+  alias parse_opaque_network parse_network
 
   def parse_distributed_virtual_portgroup(_object, kind, props)
     return if kind == "leave"


### PR DESCRIPTION
The parser alias for OpaqueNetworks was incorrectly plural so the refresh was failing with: `Missing parser for OpaqueNetwork`

Fixes https://github.com/ManageIQ/manageiq-providers-vmware/issues/577