### PR TITLE
Handle a license manager without a licenses prop

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -201,7 +201,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
   def parse_license_manager(_object, kind, props)
     return if kind == "leave"
 
-    props[:licenses].each do |license|
+    props[:licenses].to_a.each do |license|
       persister.ems_licenses.build(
         :ems_ref         => license.licenseKey,
         :name            => license.name,


### PR DESCRIPTION
If the license manager has no licenses property we were failing on a NoMethodError.

```
[NoMethodError]: undefined method `each' for nil:NilClass  Method:[block (2 levels) in class:LogProxy]
app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb:204:in `parse_license_manager'
app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb:25:in `parse'
app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb:193:in `block in parse_updates'
app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb:189:in `each'
app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb:189:in `parse_updates'
```