### PR TITLE
Fix provisioning a VM to an Opaque/NSX network

### DIFF
--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency("fog-vcloud-director", ["~> 0.3.0"])
   s.add_dependency "ffi-vix_disk_lib",        "~>1.1"
   s.add_dependency "rbvmomi",                 "~>2.3"
-  s.add_dependency "vmware_web_service",      "~>1.0"
+  s.add_dependency "vmware_web_service",      "~>1.0.3"
   s.add_dependency "vsphere-automation-sdk",  "~>0.2.1"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
We were missing the backing definition for an OpaqueNetworkBacking which
was causing the provision to fail with:

`[RuntimeError]: No arg map for VirtualEthernetCardOpaqueNetworkBackingInfo`

https://github.com/ManageIQ/vmware_web_service/pull/77