### PR TITLE
[WIP] Vmware::NetworkManager belongs to a parent manager

### DIFF
--- a/app/models/manageiq/providers/vmware/network_manager.rb
+++ b/app/models/manageiq/providers/vmware/network_manager.rb
@@ -4,6 +4,7 @@ class ManageIQ::Providers::Vmware::NetworkManager < ManageIQ::Providers::Network
   require_nested :NetworkPort
   require_nested :Refresher
 
+  include BelongsToParentManagerMixin
   include ManageIQ::Providers::Vmware::ManagerAuthMixin
 
   # Auth and endpoints delegations, editing of this type of manager must be disabled


### PR DESCRIPTION
Depends on: https://github.com/ManageIQ/manageiq/pull/20229
Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/136