### PR TITLE
Use hostname instead of address to avoid deprecation warning

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/cluster.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/cluster.rb
@@ -14,7 +14,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Cluster < ManageIQ::Providers::
     raise _("Host cannot be nil") if host.nil?
 
     userid, password = host.auth_user_pwd(:default)
-    network_address  = host.address
+    network_address  = host.hostname
 
     with_provider_object do |vim_cluster|
       begin


### PR DESCRIPTION
Currently the code emits a warning because it's calling `address`:

`DEPRECATION WARNING: address is deprecated and will be removed from ManageIQ L-release (hostname) (called from register_host at /Users/dberger/Dev/manageiq-providers-vmware-djberg96/app/models/manageiq/providers/vmware/infra_manager/cluster.rb:17)`

This PR updates the code to use the `hostname` method as well, which is now preferred:

https://github.com/ManageIQ/manageiq/blob/master/app/models/host.rb#L98