### PR TITLE
CustomValues weren't being parsed correctly

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector/property_collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector/property_collector.rb
@@ -94,8 +94,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector::Property
       end
     when "assign"
       if key
-        # TODO
-        raise "Array properties aren't supported yet"
+        a, i = get_array_entry(h[tag], key)
+        a[i] = prop_change.val
       else
         h[tag] = prop_change.val
       end

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -299,14 +299,14 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
       custom_values = props.fetch_path(:summary, :customValue)
 
       key_to_name = {}
-      available_field.to_a.each { |af| key_to_name[af["key"]] = af["name"] }
+      available_field.to_a.each { |af| key_to_name[af.key] = af.name }
 
       custom_values.to_a.each do |cv|
         persister.ems_custom_attributes.build(
           :resource => vm,
           :section  => "custom_field",
-          :name     => key_to_name[cv["key"]],
-          :value    => cv["value"],
+          :name     => key_to_name[cv.key],
+          :value    => cv.value,
           :source   => "VC",
         )
       end

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -209,6 +209,21 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         expect(custom_attrs.first).to have_attributes(:name => "foo", :value => "bar", :source => "VC")
       end
 
+      it "changing a customValue" do
+        vm = ems.vms.find_by(:ems_ref => "vm-107")
+        expect(vm.ems_custom_attributes).to be_empty
+
+        run_targeted_refresh(
+          targeted_update_set(
+            [vm_add_new_custom_value_update, vm_edit_custom_value_update]
+          )
+        )
+
+        custom_attrs = vm.reload.ems_custom_attributes
+        expect(custom_attrs.count).to eq(1)
+        expect(custom_attrs.first).to have_attributes(:name => "foo", :value => "baz", :source => "VC")
+      end
+
       def run_targeted_refresh(update_set)
         persister       = ems.class::Inventory::Persister::Targeted.new(ems)
         parser          = ems.class::Inventory::Parser.new(cache, persister)
@@ -553,6 +568,16 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         :changeSet  => [
           RbVmomi::VIM.PropertyChange(:name => "availableField", :op => "assign", :val => [RbVmomi::VIM.CustomFieldDef(:key => 300, :managedObjectType => "VirtualMachine", :name => "foo", :type => "string")]),
           RbVmomi::VIM.PropertyChange(:name => "summary.customValue[300]", :op => "add", :val => RbVmomi::VIM.CustomFieldStringValue(:key => 300, :value => "bar"))
+        ]
+      )
+    end
+
+    def vm_edit_custom_value_update
+      RbVmomi::VIM.ObjectUpdate(
+        :kind       => "modify",
+        :obj        => RbVmomi::VIM.VirtualMachine(vim, "vm-107"),
+        :changeSet  => [
+          RbVmomi::VIM.PropertyChange(:name => "summary.customValue[300]", :op => "assign", :val => RbVmomi::VIM.CustomFieldStringValue(:key => 300, :value => "baz"))
         ]
       )
     end

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/collector_spec.rb
@@ -198,6 +198,17 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
         expect(lan.reload.name).to eq("DC0_DVPG1_RENAMED")
       end
 
+      it "adding a customValue to a VM" do
+        vm = ems.vms.find_by(:ems_ref => "vm-107")
+        expect(vm.ems_custom_attributes).to be_empty
+
+        run_targeted_refresh(targeted_update_set([vm_add_new_custom_value_update]))
+
+        custom_attrs = vm.reload.ems_custom_attributes
+        expect(custom_attrs.count).to eq(1)
+        expect(custom_attrs.first).to have_attributes(:name => "foo", :value => "bar", :source => "VC")
+      end
+
       def run_targeted_refresh(update_set)
         persister       = ems.class::Inventory::Persister::Targeted.new(ems)
         parser          = ems.class::Inventory::Parser.new(cache, persister)
@@ -531,6 +542,17 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector do
           RbVmomi::VIM.PropertyChange(:name => "config.name", :op => "assign", :val => "DC0_DVPG1_RENAMED"),
           RbVmomi::VIM.PropertyChange(:name => "name", :op => "assign", :val => "DC0_DVPG1_RENAMED"),
           RbVmomi::VIM.PropertyChange(:name => "summary.name", :op => "assign", :val => "DC0_DVPG1_RENAMED")
+        ]
+      )
+    end
+
+    def vm_add_new_custom_value_update
+      RbVmomi::VIM.ObjectUpdate(
+        :kind       => "modify",
+        :obj        => RbVmomi::VIM.VirtualMachine(vim, "vm-107"),
+        :changeSet  => [
+          RbVmomi::VIM.PropertyChange(:name => "availableField", :op => "assign", :val => [RbVmomi::VIM.CustomFieldDef(:key => 300, :managedObjectType => "VirtualMachine", :name => "foo", :type => "string")]),
+          RbVmomi::VIM.PropertyChange(:name => "summary.customValue[300]", :op => "add", :val => RbVmomi::VIM.CustomFieldStringValue(:key => 300, :value => "bar"))
         ]
       )
     end


### PR DESCRIPTION
VM Custom Values weren't being parsed and saved correctly because they were being treated like hashes (cv["name"] instead of cv.name) which was returning nil.

Also editing an existing custom value was triggering an exception in the property cache as it was a condition that we didn't think was used anymore thus left TODO.