### PR TITLE
Pull in fix for EventCatcher on ruby >= 2.6

### DIFF
--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency("fog-vcloud-director", ["~> 0.3.0"])
   s.add_dependency "ffi-vix_disk_lib",        "~>1.1"
   s.add_dependency "rbvmomi",                 "~>2.3"
-  s.add_dependency "vmware_web_service",      "~>1.0.3"
+  s.add_dependency "vmware_web_service",      "~>1.0.4"
   s.add_dependency "vsphere-automation-sdk",  "~>0.2.1"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
There was an issue with the MiqVimEventMonitor not being able to catch events due to a conflict on attributes in the PropertyFilterUpdate object and the underlying Hash class.  This was causing no events to ever be raised by the Vmware EventCatcher worker.

https://github.com/ManageIQ/vmware_web_service/pull/78