### PR TITLE
Don't put VimStrings in the miq_request phase_context

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
@@ -10,8 +10,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
 
         case task_state
         when TaskInfoState::Success
-          phase_context[:new_vm_ems_ref] = task_info&.result
-          phase_context[:clone_vm_task_completion_time] = task_info&.completeTime
+          phase_context[:new_vm_ems_ref] = task_info&.result&.to_s
+          phase_context[:clone_vm_task_completion_time] = task_info&.completeTime&.to_s
           return true
         when TaskInfoState::Running
           progress = task_info&.progress


### PR DESCRIPTION
VimStrings in the miq_request phase_context cause loading the record to fail without VMwareWebService/VimTypes required.

```
irb(main):002:0> prov = MiqProvision.find(5)
Traceback (most recent call last):
       16: from psych (3.1.0) lib/psych/visitors/visitor.rb:16:in `visit'
       15: from psych (3.1.0) lib/psych/visitors/to_ruby.rb:162:in `visit_Psych_Nodes_Mapping'
       14: from psych (3.1.0) lib/psych/visitors/to_ruby.rb:336:in `revive_hash'
       13: from psych (3.1.0) lib/psych/visitors/to_ruby.rb:336:in `each_slice'
       12: from psych (3.1.0) lib/psych/visitors/to_ruby.rb:336:in `each'
       11: from psych (3.1.0) lib/psych/visitors/to_ruby.rb:338:in `block in revive_hash'
       10: from psych (3.1.0) lib/psych/visitors/to_ruby.rb:32:in `accept'
        9: from psych (3.1.0) lib/psych/visitors/visitor.rb:6:in `accept'
        8: from psych (3.1.0) lib/psych/visitors/visitor.rb:16:in `visit'
        7: from psych (3.1.0) lib/psych/visitors/to_ruby.rb:213:in `visit_Psych_Nodes_Mapping'
        6: from config/initializers/yaml_autoloader.rb:10:in `resolve_class'
        5: from psych (3.1.0) lib/psych/visitors/to_ruby.rb:391:in `resolve_class'
        4: from psych (3.1.0) lib/psych/class_loader.rb:28:in `load'
        3: from psych (3.1.0) lib/psych/class_loader.rb:46:in `find'
        2: from psych (3.1.0) lib/psych/class_loader.rb:54:in `resolve'
        1: from psych (3.1.0) lib/psych/class_loader.rb:54:in `path2class'
ArgumentError (undefined class/module VimString)
```

```
irb(main):008:0> MiqProvision.find(5).phase_context[:new_vm_ems_ref].class.name
=> "VimString"
```