### PR TITLE
Adjusted DDF schema for infra provider creation + validation

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -61,7 +61,7 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
         },
         {
           :component => 'sub-form',
-          :name      => 'endpoints',
+          :name      => 'endpoints-subform',
           :title     => _("Endpoints"),
           :fields    => [
             :component => 'tabs',
@@ -69,7 +69,7 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
             :fields    => [
               {
                 :component => 'tab-item',
-                :name      => 'default',
+                :name      => 'default-tab',
                 :title     => _('Default'),
                 :fields    => [
                   {
@@ -95,15 +95,19 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
                         :initialValue => 443,
                       },
                       {
-                        :component => "text-field",
-                        :name      => "authentications.default.userid",
-                        :label     => _("Username")
+                        :component  => "text-field",
+                        :name       => "authentications.default.userid",
+                        :label      => _("Username"),
+                        :isRequired => true,
+                        :validate   => [{:type => "required-validator"}],
                       },
                       {
-                        :component => "password-field",
-                        :name      => "authentications.default.password",
-                        :label     => _("Password"),
-                        :type      => "password"
+                        :component  => "password-field",
+                        :name       => "authentications.default.password",
+                        :label      => _("Password"),
+                        :type       => "password",
+                        :isRequired => true,
+                        :validate   => [{:type => "required-validator"}],
                       },
                     ],
                   },
@@ -111,7 +115,7 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
               },
               {
                 :component => 'tab-item',
-                :name      => 'events',
+                :name      => 'events-tab',
                 :title     => _('Events'),
                 :fields    => [
                   {

--- a/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
@@ -23,7 +23,7 @@ describe ManageIQ::Providers::Vmware::InfraManager do
   end
 
   context ".verify_credentials" do
-    let(:verify_params) { {"endpoints" => {"default" => {"server" => "vcenter", "username" => "root", "password" => "vmware"}}} }
+    let(:verify_params) { {"endpoints" => {"default" => {"hostname" => "vcenter"}}, "authentications" => {"default" => {"username" => "root", "password" => "vmware"}}} }
     before do
       miq_vim = double("VMwareWebService/MiqVim")
       allow(miq_vim).to receive(:isVirtualCenter).and_return(is_virtual_center)


### PR DESCRIPTION
Adjusting the DDF forms to provide the same experience as the old ones.

**Before:**
![Screenshot from 2020-07-03 10-27-04](https://user-images.githubusercontent.com/649130/86449056-e6111c80-bd17-11ea-9ae0-e206825432d0.png)
![Screenshot from 2020-07-03 10-27-45](https://user-images.githubusercontent.com/649130/86449076-ef01ee00-bd17-11ea-976a-9c6076aa0115.png)

**After:**
![Screenshot from 2020-07-03 10-27-18](https://user-images.githubusercontent.com/649130/86449093-f45f3880-bd17-11ea-811c-386fdb9e341f.png)

There's a slight change on the *VMRC Console* tab, I added a protocol-selector component to enable/disable the console support. This allows the username/password fields to be required and obsoletes the additional info field.

![Screenshot from 2020-07-03 10-27-51](https://user-images.githubusercontent.com/649130/86449108-f88b5600-bd17-11ea-9360-0dc51e47f289.png)
![Screenshot from 2020-07-03 10-27-58](https://user-images.githubusercontent.com/649130/86449125-fb864680-bd17-11ea-82b8-ec47267241f5.png)

@miq-bot add_label enhancement
@miq-bot assign @agrare 
Parent issue: https://github.com/ManageIQ/manageiq/issues/18818