### PR TITLE
Add to Inventory Refresh of Distrubutes Virtual Lan the vlanId as Tag

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -234,6 +234,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
 
     default_port_config = props.fetch_path(:config, :defaultPortConfig)
     security_policy = default_port_config&.securityPolicy
+    vlanId = default_port_config&.vlan&.try(:vlanId)
 
     if security_policy
       allow_promiscuous = security_policy.allowPromiscuous&.value
@@ -252,6 +253,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
       :allow_promiscuous => allow_promiscuous,
       :forged_transmits  => forged_transmits,
       :mac_changes       => mac_changes,
+      :tag               => vlanId
     }
 
     persister.distributed_virtual_lans.find_or_build_by(lan_hash)

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -234,7 +234,6 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
 
     default_port_config = props.fetch_path(:config, :defaultPortConfig)
     security_policy = default_port_config&.securityPolicy
-    vlanId = default_port_config&.vlan&.try(:vlanId)
 
     if security_policy
       allow_promiscuous = security_policy.allowPromiscuous&.value
@@ -253,7 +252,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
       :allow_promiscuous => allow_promiscuous,
       :forged_transmits  => forged_transmits,
       :mac_changes       => mac_changes,
-      :tag               => vlanId
+      :tag               => default_port_config&.vlan&.try(:vlanId)
     }
 
     persister.distributed_virtual_lans.find_or_build_by(lan_hash)

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -234,6 +234,8 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
 
     default_port_config = props.fetch_path(:config, :defaultPortConfig)
     security_policy = default_port_config&.securityPolicy
+    vlan_spec = default_port_config&.vlan
+    tag = vlan_spec.vlanId if vlan_spec&.kind_of?(RbVmomi::VIM::VmwareDistributedVirtualSwitchVlanIdSpec)
 
     if security_policy
       allow_promiscuous = security_policy.allowPromiscuous&.value
@@ -252,7 +254,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
       :allow_promiscuous => allow_promiscuous,
       :forged_transmits  => forged_transmits,
       :mac_changes       => mac_changes,
-      :tag               => default_port_config&.vlan&.try(:vlanId)
+      :tag               => tag
     }
 
     persister.distributed_virtual_lans.find_or_build_by(lan_hash)

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -890,7 +890,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
         :allow_promiscuous => false,
         :forged_transmits  => false,
         :mac_changes       => false,
-        :tag               => nil
+        :tag               => "1"
       )
 
       expect(lan.switch.uid_ems).to eq("dvs-8")


### PR DESCRIPTION
Add to Inventory Refresh of Distrubutes Virtual Lan the vlanId as Tag

![image](https://user-images.githubusercontent.com/57907607/86584798-c2eba480-bf85-11ea-9e11-da36aa1eb970.png)


