### PR TITLE
The snapshot uid_ems should be the ISO 8601 format

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -356,20 +356,22 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
       snap = snapshot[:snapshot]
       return if snap.nil?
 
-      create_time = snapshot[:createTime]
+      create_time     = snapshot[:createTime]
+      create_time_ems = create_time.iso8601(6)
+
       parent = persister.snapshots.lazy_find(:vm_or_template => vm, :uid => Time.parse(parent_uid).iso8601(6)) if parent_uid
 
       snapshot_hash = {
         :vm_or_template => vm,
         :ems_ref        => snap._ref,
         :ems_ref_type   => snap.class.wsdl_name,
-        :uid_ems        => create_time.to_s,
-        :uid            => create_time.iso8601(6),
+        :uid_ems        => create_time_ems,
+        :uid            => create_time_ems,
         :parent_uid     => parent_uid,
         :parent         => parent,
         :name           => CGI.unescape(snapshot[:name]),
         :description    => snapshot[:description],
-        :create_time    => create_time.to_s,
+        :create_time    => create_time.utc.to_s,
         :current        => snap._ref == current._ref,
       }
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -155,6 +155,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
 
         expect(vm.snapshots.count).to eq(1)
         expect(vm.snapshots.first).to have_attributes(
+          :uid_ems     => "2018-05-19T06:47:56.000000Z",
           :uid         => "2018-05-19T06:47:56.000000Z",
           :parent_uid  => nil,
           :name        => "VM Snapshot 5%2f19%2f2018, 6:47:56 AM",
@@ -162,7 +163,6 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
           :current     => 1,
           :create_time => Time.parse("2018-05-19 06:47:56 UTC").utc,
           :parent_id   => nil,
-          :uid_ems     => "2018-05-19 06:47:56 UTC",
           :ems_ref     => "snapshot-1100"
         )
 


### PR DESCRIPTION
RbVmomi treats `xsd:dateTime` as `Time` objects where Handsoap just returns the raw string.  This is leading to the `:uid_ems` not being equal to the `:uid` like it used to be which causes the snapshot lookup by timestamp not to find anything.

Handsoap:
```
>> snapshot = inv['rootSnapshotList'].first
>> snapshot['createTime']
=> "2020-07-14T18:06:56.887059Z"
>> Time.parse(snapshot['createTime']).getutc
=> 2020-07-14 18:06:56.887059 UTC
```

RbVmomi:
```
(byebug) snapshot[:createTime]
2019-07-08 21:25:00.689297 UTC
(byebug) snapshot[:createTime].iso8601(6)
"2019-07-08T21:25:00.689297Z"
```

Using the `#iso8601` converted time matches the string that Handsoap has for the createTime

Fixes https://github.com/ManageIQ/manageiq-providers-vmware/issues/600