### PR TITLE
Run post_refresh after save_inventory completes

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/saver.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/saver.rb
@@ -76,8 +76,10 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Saver
   end
 
   def save_inventory(persister)
+    save_inventory_start_time = Time.now.utc
     persister.persist!
     update_ems_refresh_stats(persister.manager)
+    post_refresh(persister.manager, save_inventory_start_time)
   rescue => err
     log_header = log_header_for_ems(persister.manager)
 
@@ -89,6 +91,22 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Saver
 
   def update_ems_refresh_stats(ems, error: nil)
     ems.update(:last_refresh_error => error, :last_refresh_date => Time.now.utc)
+  end
+
+  def post_refresh(ems, save_inventory_start_time)
+    log_header = log_header_for_ems(ems)
+
+    # Do any post-operations for this EMS
+    post_process_refresh_classes.each do |klass|
+      next unless klass.respond_to?(:post_refresh_ems)
+      _log.info("#{log_header} Performing post-refresh operations for #{klass} instances...")
+      klass.post_refresh_ems(ems.id, save_inventory_start_time)
+      _log.info("#{log_header} Performing post-refresh operations for #{klass} instances...Complete")
+    end
+  end
+
+  def post_process_refresh_classes
+    [VmOrTemplate]
   end
 
   def log_header_for_ems(ems)


### PR DESCRIPTION
There are some operations which are run after the refresh completes such as connecting newly saved vms to ems_events that were caught prior to the VM being saved.

After moving to streaming refresh only and the refresh no longer being run in the context of the Refresher this functionality was lost.