### PR TITLE
Don't fail the refresh on storage profile faults

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -309,6 +309,8 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
         parser.parse_pbm_placement_hub(persister_storage_profile, placement_hub, "enter", placement_hub.props)
       end
     end
+  rescue RbVmomi::Fault => err
+    _log.warn("#{log_header} Unable to collect storage profiles: #{err}")
   end
 
   def save_inventory(persister)


### PR DESCRIPTION
The classic refresh on ivanchuk didn't fail the refresh if there was an exception collecting storage profiles, for example if using a non-admin user that doesn't have permissions to that endpoint.

```
[RbVmomi::Fault]: SecurityError:   Method:[block (2 levels) in [class:LogProxy]
rbvmomi-2.0.1/lib/rbvmomi/connection.rb:63:in `parse_response'
rbvmomi-2.0.1/lib/rbvmomi/connection.rb:92:in `call'
rbvmomi-2.0.1/lib/rbvmomi/basic_types.rb:213:in `_call'
rbvmomi-2.0.1/lib/rbvmomi/basic_types.rb:76:in `block (2 levels) in init'
manageiq-providers-vmware-2f6b7bcbd086/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb:295:in `parse_storage_profiles'
manageiq-providers-vmware-2f6b7bcbd086/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb:88:in `full_refresh'
manageiq-providers-vmware-2f6b7bcbd086/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb:63:in `vim_collector'
manageiq-providers-vmware-2f6b7bcbd086/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb:53:in `block in vim_collector_thread'
```