### PR TITLE
Bump rbvmomi and vmware_web_service

### DIFF
--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency("fog-vcloud-director", ["~> 0.3.0"])
   s.add_dependency "ffi-vix_disk_lib",        "~>1.1"
-  s.add_dependency "rbvmomi",                 "~>2.3"
-  s.add_dependency "vmware_web_service",      "~>1.0.5"
+  s.add_dependency "rbvmomi",                 "~>3.0"
+  s.add_dependency "vmware_web_service",      "~>2.0"
   s.add_dependency "vsphere-automation-sdk",  "~>0.2.1"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
Update RbVmomi to 3.0 and bump vmware_web_service to 2.0 which dropped their RbVmomi dependency

Depends on:
- [x] https://github.com/ManageIQ/vmware_web_service/pull/85
- [x] https://github.com/ManageIQ/manageiq-smartstate/pull/135

Co-Depends: https://github.com/ManageIQ/manageiq/pull/20413