### PR TITLE
Remove miq-uuid

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -1,5 +1,3 @@
-require 'miq-uuid'
-
 module ManageIQ::Providers
   module Vmware
     module InfraManager::RefreshParser


### PR DESCRIPTION
This was removed from gems-pending, so we need to remove it here.

Also, as far as I can tell, it wasn't actually being used anyway. Specs still pass, and I see no reference to the MiqUUID module.