### PR TITLE
Add explicit require in customization spec

### DIFF
--- a/spec/models/manageiq/providers/vmware/infra_manager/ems_ref_obj_mixin.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/ems_ref_obj_mixin.rb
@@ -1,3 +1,5 @@
+require 'VMwareWebService/VimTypes'
+
 describe ManageIQ::Providers::Vmware::InfraManager::EmsRefObjMixin do
   let(:vm) { FactoryBot.create(:vm_vmware, :ems_ref_type => "VirtualMachine") }
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/miq_request_task/dumping_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/miq_request_task/dumping_spec.rb
@@ -1,3 +1,5 @@
+require 'VMwareWebService/VimTypes'
+
 RSpec.describe MiqRequestTask do
   context "::Dumping" do
     let(:task) { FactoryBot.create(:miq_request_task) }

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision/customization_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision/customization_spec.rb
@@ -1,3 +1,5 @@
+require 'VMwareWebService/VimTypes'
+
 describe ManageIQ::Providers::Vmware::InfraManager::Provision::Customization do
   let(:custom_spec_name) { 'custom_spec_name' }
   let(:target_vm_name)   { 'computerName' }

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
@@ -1,3 +1,5 @@
+require 'VMwareWebService/VimTypes'
+
 describe ManageIQ::Providers::Vmware::InfraManager::Provision do
   context "A new provision request," do
     before(:each) do

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
@@ -1,3 +1,5 @@
+require 'VMwareWebService/VimTypes'
+
 describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
   let(:storage) { FactoryBot.create(:storage_vmware) }
   let(:host) do


### PR DESCRIPTION
Currently if you run the customization specs on their own, they will currently failed with `undefined constant VimHash` because autoloading hasn't happened.

So, similar to the event catcher specs, let's add an explicit require so that doesn't happen.