### PR TITLE
Set :hidden on ems_clusters for "singular" clusters

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -41,12 +41,17 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
     persister.clusters.targeted_scope << object._ref
     return if kind == "leave"
 
+    # If a host isn't in a cluster VMware still puts it in a ComputeResource
+    # parent object but this isn't shown on their UI
+    hidden = object.class.wsdl_name == "ComputeResource"
+
     cluster_hash = {
       :ems_ref      => object._ref,
       :ems_ref_type => object.class.wsdl_name,
       :uid_ems      => object._ref,
       :name         => CGI.unescape(props[:name]),
       :parent       => lazy_find_managed_object(props[:parent]),
+      :hidden       => hidden
     }
 
     parse_compute_resource_summary(cluster_hash, props)

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -784,7 +784,8 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
         :ha_enabled              => false,
         :ha_max_failures         => 1,
         :name                    => "DC0_C0",
-        :uid_ems                 => "domain-c12"
+        :uid_ems                 => "domain-c12",
+        :hidden                  => false
       )
 
       expect(cluster.parent).not_to be_nil


### PR DESCRIPTION
If a host isn't in a "real" cluster (wsdl_class ClusterComputeResource) e.g. it is shown directly under a datacenter or it is a standalone host (no vCenter) then VMware has the host in a "singular" or "fake" cluster where there can only be a single host child (wsdl_class ComputeResource).

We can simplify the parent/child logic by relying on all hosts being in an ems_cluster and only showing the ones that aren't "hidden" on the UI similar to what is done for ems_folders.