### PR TITLE
Handle task errors during vm provisioning

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
@@ -13,6 +13,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
           phase_context[:new_vm_ems_ref] = task_info&.result&.to_s
           phase_context[:clone_vm_task_completion_time] = task_info&.completeTime&.to_s
           return true
+        when TaskInfoState::Error
+          raise "VM Clone Failed: #{task_info&.error&.localizedMessage}"
         when TaskInfoState::Running
           progress = task_info&.progress
           return false, progress.nil? ? "beginning" : "#{progress}% complete"


### PR DESCRIPTION
If the CloneVM_Task fails and returns with an error state the provision
state machine continues to loop on the CheckProvision state until it
reaches the retry limit and fails.

Example task failure:
```
[----] E, [2020-08-26T18:49:50.289863 #7722:a168] ERROR -- : [RuntimeError]: VM Clone Failed: Customization of the guest operating system 'debian10_64Guest' is not supported in this configuration. Microsoft Vista (TM) and Linux guests with Logical Volume Manager are supported only for recent ESX host and VMware Tools versions. Refer to vCenter documentation for supported configurations.  Method:[block (2 levels) in <class:LogProxy>]
```