### PR TITLE
Fix an exception when VMs don't have cpu_allocation

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -104,6 +104,8 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
 
     def parse_virtual_machine_cpu_allocation(vm_hash, props)
       cpu_allocation = props.fetch_path(:resourceConfig, :cpuAllocation)
+      return if cpu_allocation.nil?
+
       vm_hash[:cpu_reserve] = cpu_allocation[:reservation]
       vm_hash[:cpu_reserve_expand] = cpu_allocation[:expandableReservation].to_s.downcase == "true"
       vm_hash[:cpu_limit] = cpu_allocation[:limit]


### PR DESCRIPTION
Fix a missing guard clause when VMs don't have cpu_allocation causing a NoMethodError exception

```
[NoMethodError]: undefined method `[]' for nil:NilClass
manageiq-providers-vmware-d0217cccff5b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb:105:in`parse_virtual_machine_cpu_allocation'
manageiq-providers-vmware-d0217cccff5b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb:113:in `parse_virtual_machine_resource_config'
manageiq-providers-vmware-d0217cccff5b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb:344:in`parse_virtual_machine'
```
