### PR TITLE
Support for VMware content library item deployment.

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/orchestration_template.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/orchestration_template.rb
@@ -1,4 +1,65 @@
-class ManageIQ::Providers::Vmware::InfraManager::OrchestrationTemplate < OrchestrationTemplate
+class ManageIQ::Providers::Vmware::InfraManager::OrchestrationTemplate < ::OrchestrationTemplate
+  belongs_to :ext_management_system, :foreign_key => "ems_id", :class_name => "ManageIQ::Providers::Vmware::InfraManager", :inverse_of => false
+
+  SPEC_KEY_MAPPING = {
+    "resource_pool" => "resource_pool_id",
+    "ems_folder"    => "folder_id",
+    "host"          => "host_id"
+  }.freeze
+
+  def connect
+    require 'vsphere-automation-cis'
+
+    configuration = VSphereAutomation::Configuration.new.tap do |c|
+      c.host = ext_management_system.hostname
+      c.username = ext_management_system.auth_user_pwd.first
+      c.password = ext_management_system.auth_user_pwd.last
+      c.verify_ssl = false
+      c.verify_ssl_host = false
+    end
+
+    api_client = VSphereAutomation::ApiClient.new(configuration)
+    VSphereAutomation::CIS::SessionApi.new(api_client).create('')
+    api_client
+  end
+
+  def with_provider_connection
+    raise _("no block given") unless block_given?
+
+    _log.info("Connecting through #{ext_management_system.class.name}: [#{ext_management_system.name}]")
+    yield connect
+  end
+
+  def deploy(options = {})
+    require 'vsphere-automation-vcenter'
+
+    with_provider_connection do |api_client|
+      request_body = VSphereAutomation::VCenter::VcenterOvfLibraryItemDeploy.new(deployment_spec(options))
+      api_instance = VSphereAutomation::VCenter::OvfLibraryItemApi.new(api_client)
+      api_instance.deploy(ems_ref, request_body)
+    end
+  end
+
+  def deployment_spec(opts)
+    opts = opts.with_indifferent_access
+    raise _("Resource pool is required for content library item deployment.") if opts[:resource_pool_id].blank?
+    raise _("accept_all_EULA is required for content library item deployment.") if opts[:accept_all_EULA].nil?
+
+    spec = {"accept_all_EULA" => opts[:accept_all_EULA]}
+    spec["name"] = opts[:vm_name] if opts[:vm_name].present?
+
+    target = {}
+    %w[resource_pool ems_folder host].each do |r|
+      options_key = "#{r}_id"
+      target[SPEC_KEY_MAPPING[r]] = r.camelize.constantize.find_by(:id => opts[options_key]).ems_ref if opts[options_key].present?
+    end
+
+    deploy_options = {"deployment_spec" => spec, "target" => target}
+    _log.info("Content Library deployment request body: #{deploy_options}")
+
+    deploy_options
+  end
+
   def unique_md5?
     false
   end

--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ffi-vix_disk_lib",        "~>1.1"
   s.add_dependency "rbvmomi",                 "~>3.0"
   s.add_dependency "vmware_web_service",      "~>2.0"
-  s.add_dependency "vsphere-automation-sdk",  "~>0.2.1"
+  s.add_dependency "vsphere-automation-sdk",  "~>0.4.7"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"

--- a/spec/factories/orchestration_template.rb
+++ b/spec/factories/orchestration_template.rb
@@ -4,4 +4,8 @@ FactoryBot.define do
           :class  => "ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate" do
     content { File.read(ManageIQ::Providers::Vmware::Engine.root.join(*%w(spec fixtures orchestration_templates vmware_parameters_ovf.xml))) }
   end
+
+  factory :orchestration_template_vmware_infra,
+          :parent => :orchestration_template,
+          :class  => "ManageIQ::Providers::Vmware::InfraManager::OrchestrationTemplate"
 end

--- a/spec/models/manageiq/providers/vmware/infra_manager/orchestration_template_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/orchestration_template_spec.rb
@@ -1,0 +1,28 @@
+describe ManageIQ::Providers::Vmware::InfraManager::OrchestrationTemplate do
+  subject { FactoryBot.create(:orchestration_template_vmware_infra) }
+
+  context "#deployment_spec" do
+    describe "required fields" do
+      let(:resource_pool) { FactoryBot.create(:resource_pool, :ems_ref => 'obj-103') }
+      let(:options) { {:accept_all_EULA => false, :resource_pool_id => resource_pool.id} }
+
+      it "raises an error if accept_all_EULA is absent" do
+        options.delete(:accept_all_EULA)
+        expect { subject.deployment_spec(options) }.to raise_error(/accept_all_EULA is required for content library item deployment./)
+      end
+
+      it "raises an error if resource pool is absent" do
+        options.delete(:resource_pool_id)
+        expect { subject.deployment_spec(options) }.to raise_error(/Resource pool is required for content library item deployment./)
+      end
+
+      it "works with keys in string format" do
+        options["vm_name"] = "new VM"
+        result = subject.deployment_spec(options)
+        expect(result.dig("target", "resource_pool_id")).to eq(resource_pool.ems_ref)
+        expect(result.dig("deployment_spec", "accept_all_EULA")).to be false
+        expect(result.dig("deployment_spec", "name")).to eq(options["vm_name"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add support to deploy a `ManageIQ::Providers::Vmware::InfraManager::OrchestrationTemplate`.

Blocks ManageIQ/manageiq#20555.
Related to #627.

https://github.com/ManageIQ/manageiq/issues/19718

@miq-bot add_label enhancement