### PR TITLE
Skip any disconnected VMs

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -191,6 +191,10 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
       props          = uncached_props.present? ? cached_props.deep_merge(uncached_props) : cached_props
 
       parser.parse(managed_object, update_kind, props)
+    rescue => err
+      _log.warn("Failed to parse #{managed_object.class.wsdl_name}:#{managed_object._ref}: #{err}")
+      _log.log_backtrace(err)
+      raise
     end
   end
 

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -168,14 +168,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
     persister.hosts.targeted_scope << object._ref
     return if kind == "leave"
 
-    invalid, err = if props.fetch_path(:config).nil? || props.fetch_path(:summary, :config, :product).nil? || props.fetch_path(:summary).nil?
-      [true, "Missing configuration for Host [#{object._ref}]"]
-    elsif props.fetch_path(:config, :network, :dnsConfig, :hostName).blank?
-      [true, "Missing hostname information for Host [#{object._ref}]"]
-    else
-      false
-    end
-
+    invalid, err = validate_host_system_props(object, props)
     if invalid
       _log.warn("#{err} Skipping.")
 
@@ -356,16 +349,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
     persister.vms_and_templates.targeted_scope << object._ref
     return if kind == "leave"
 
-    invalid, err = if props.fetch_path(:summary, :config).nil? || props.fetch_path(:config).nil?
-      [true, "Missing configuration for VM [#{object._ref}]"]
-    elsif props.fetch_path(:summary, :config, :uuid).blank? && props.fetch_path(:config, :uuid).blank?
-      [true, "Missing UUID for VM [#{object._ref}]"]
-    elsif props.fetch_path(:summary, :config, :vmPathName).blank?
-      [true, "Missing pathname location for VM [#{object._ref}]"]
-    else
-      false
-    end
-
+    invalid, err = validate_virtual_machine_props(object, props)
     if invalid
       _log.warn("#{err} Skipping.")
 

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/host_system.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/host_system.rb
@@ -1,5 +1,15 @@
 class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
   module HostSystem
+    def validate_host_system_props(object, props)
+      if props.fetch_path(:config).nil? || props.fetch_path(:summary).nil? || props.fetch_path(:summary, :config, :product).nil?
+        [true, "Missing configuration for Host [#{object._ref}]"]
+      elsif props.fetch_path(:config, :network, :dnsConfig, :hostName).blank?
+        [true, "Missing hostname information for Host [#{object._ref}]"]
+      else
+        false
+      end
+    end
+
     def parse_host_system_summary(host_hash, props)
       summary = props[:summary]
       return if summary.nil?

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -2,6 +2,18 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
   UUID_REGEX_FORMAT = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.freeze
 
   module VirtualMachine
+    def validate_virtual_machine_props(object, props)
+      if props.fetch_path(:summary, :config).nil? || props.fetch_path(:config).nil?
+        [true, "Missing configuration for VM [#{object._ref}]"]
+      elsif props.fetch_path(:summary, :config, :uuid).blank? && props.fetch_path(:config, :uuid).blank?
+        [true, "Missing UUID for VM [#{object._ref}]"]
+      elsif props.fetch_path(:summary, :config, :vmPathName).blank?
+        [true, "Missing pathname location for VM [#{object._ref}]"]
+      else
+        false
+      end
+    end
+
     def parse_virtual_machine_config(vm_hash, props)
       config = props[:config]
       return if config.nil?

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -167,7 +167,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
         # cast numCoresPerSocket to an integer so that we can check for nil and 0
         cpu_cores_per_socket                 = config.dig(:hardware, :numCoresPerSocket).to_i
         hardware_hash[:cpu_cores_per_socket] = cpu_cores_per_socket.zero? ? 1 : cpu_cores_per_socket
-        hardware_hash[:cpu_sockets]          = hardware_hash[:cpu_total_cores] / hardware_hash[:cpu_cores_per_socket]
+        hardware_hash[:cpu_sockets]          = hardware_hash[:cpu_total_cores] / hardware_hash[:cpu_cores_per_socket] if hardware_hash[:cpu_total_cores]
         hardware_hash[:virtual_hw_version]   = config[:version].to_s.split('-').last if config[:version].present?
         hardware_hash[:firmware_type]        = config[:firmware].to_s.downcase == "efi" ? "EFI" : "BIOS"
       end

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -144,6 +144,10 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
         expect(prev_respool.reload.children).not_to include(vm)
       end
 
+      it "skip disconnected vms" do
+        run_targeted_refresh(targeted_update_set(vm_disconnected_object_updates))
+      end
+
       it "creating and deleting a snapshot" do
         vm = ems.vms.find_by(:ems_ref => "vm-107")
 
@@ -301,6 +305,33 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
                 :name => "summary.effectiveMemory",
                 :op   => "assign",
                 :val  => 59_871
+              ),
+            ],
+            :missingSet => []
+          ),
+        ]
+      end
+
+      def vm_disconnected_object_updates
+        [
+          RbVmomi::VIM.ObjectUpdate(
+            :kind       => "enter",
+            :obj        => RbVmomi::VIM.VirtualMachine(vim, "vm-999"),
+            :changeSet  => [
+              RbVmomi::VIM.PropertyChange(
+                :name => "name",
+                :op   => "assign",
+                :val  => "disconnected-vm"
+              ),
+              RbVmomi::VIM.PropertyChange(
+                :name => "config.version",
+                :op   => "assign",
+                :val  => "7"
+              ),
+              RbVmomi::VIM.PropertyChange(
+                :name => "runtime.connectionState",
+                :op   => "assign",
+                :val  => "disconnected"
               ),
             ],
             :missingSet => []

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -146,6 +146,8 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
 
       it "skip disconnected vms" do
         run_targeted_refresh(targeted_update_set(vm_disconnected_object_updates))
+
+        expect(ems.vms.pluck(:ems_ref)).not_to include("vm-999")
       end
 
       it "creating and deleting a snapshot" do


### PR DESCRIPTION
If VMs don't have sufficient information to continue to parse (e.g. they are disconnected) then we should skip them completely

This was handled in the previous version of refresh [here](https://github.com/ManageIQ/manageiq-providers-vmware/blob/ivanchuk/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb#L230-L244) for hosts and [here](https://github.com/ManageIQ/manageiq-providers-vmware/blob/ivanchuk/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb#L867-L877) for vms.

Having a config section but no summary.config was causing `[NoMethodError]: undefined method '/' for nil:NilClass` when parsing the cpu values [here](https://github.com/ManageIQ/manageiq-providers-vmware/blob/0ec4c0ff52461c41f0e2f654f9664bf50459b57c/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb#L158)

TODO
- [x] Add specs for disconnected vms