### PR TITLE
Fix Notifications created with VimStrings

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm/operations/snapshot.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/operations/snapshot.rb
@@ -8,8 +8,9 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations::Snapshot
   def raw_create_snapshot(name, desc = nil, memory)
     run_command_via_parent(:vm_create_snapshot, :name => name, :desc => desc, :memory => memory)
   rescue => err
-    create_notification(:vm_snapshot_failure, :error => err.to_s, :snapshot_op => "create")
-    raise MiqException::MiqVmSnapshotError, err.to_s
+    error = err.message.to_s
+    create_notification(:vm_snapshot_failure, :error => error, :snapshot_op => "create")
+    raise MiqException::MiqVmSnapshotError, error
   end
 
   def raw_remove_snapshot(snapshot_id)
@@ -26,9 +27,10 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations::Snapshot
 
       run_command_via_parent(:vm_remove_snapshot, :snMor => snapshot.uid_ems)
     rescue => err
-      create_notification(:vm_snapshot_failure, :error => err.to_s, :snapshot_op => "remove")
-      if err.to_s.include?('not found')
-        raise MiqException::MiqVmSnapshotError, err.to_s
+      error = err.message.to_s
+      create_notification(:vm_snapshot_failure, :error => error, :snapshot_op => "remove")
+      if error.include?('not found')
+        raise MiqException::MiqVmSnapshotError, error
       else
         raise
       end

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/operations/snapshot.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/operations/snapshot.rb
@@ -8,7 +8,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations::Snapshot
   def raw_create_snapshot(name, desc = nil, memory)
     run_command_via_parent(:vm_create_snapshot, :name => name, :desc => desc, :memory => memory)
   rescue => err
-    error = err.message.to_s
+    error = String.new(err.message)
     create_notification(:vm_snapshot_failure, :error => error, :snapshot_op => "create")
     raise MiqException::MiqVmSnapshotError, error
   end
@@ -27,8 +27,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations::Snapshot
 
       run_command_via_parent(:vm_remove_snapshot, :snMor => snapshot.uid_ems)
     rescue => err
-      # If the exception is a VimFault then err.message is a VimString
-      error = err.message.to_s
+      error = String.new(err.message)
 
       create_notification(:vm_snapshot_failure, :error => error, :snapshot_op => "remove")
       if err.kind_of?(VimFault)

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/operations/snapshot.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/operations/snapshot.rb
@@ -27,9 +27,11 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations::Snapshot
 
       run_command_via_parent(:vm_remove_snapshot, :snMor => snapshot.uid_ems)
     rescue => err
+      # If the exception is a VimFault then err.message is a VimString
       error = err.message.to_s
+
       create_notification(:vm_snapshot_failure, :error => error, :snapshot_op => "remove")
-      if error.include?('not found')
+      if err.kind_of?(VimFault)
         raise MiqException::MiqVmSnapshotError, error
       else
         raise


### PR DESCRIPTION
If the exception raised is a VimFault then .to_s is a VimString, not a String.  We have to .to_s the err.message in order to not return VimStrings outside the vmware provider code.

```
(byebug) err
#<VimFault: The object 'vim.vm.Snapshot:snapshot-2022' has already been deleted or has not been completely created>
(byebug) err.message
"The object 'vim.vm.Snapshot:snapshot-2022' has already been deleted or has not been completely created"
(byebug) err.to_s
"The object 'vim.vm.Snapshot:snapshot-2022' has already been deleted or has not been completely created"
(byebug) err.to_s.class
VimString
(byebug) err.message.to_s.class
String
```