### PR TITLE
DVPortGroup deletion event doesn't remove the Lan record

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -232,14 +232,12 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
   alias parse_opaque_network parse_network
 
   def parse_distributed_virtual_portgroup(_object, kind, props)
-    return if kind == "leave"
-
     dvs = props.fetch_path(:config, :distributedVirtualSwitch)
     parse_distributed_virtual_switch(dvs, kind, cache.find(dvs))
   end
 
   def parse_portgroups_internal(object, props)
-    return if props[:tag].detect { |tag| tag.key == "SYSTEM/DVS.UPLINKPG" }
+    return if Array.wrap(props[:tag]).detect { |tag| tag.key == "SYSTEM/DVS.UPLINKPG" }
 
     ref  = object._ref
     uid  = props.fetch_path(:config, :key)

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -204,6 +204,21 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
         expect(lan.reload.name).to eq("DC0_DVPG1_RENAMED")
       end
 
+      it "adding a new distributed virtual portgroup" do
+        run_targeted_refresh(targeted_update_set([dvpg_create_object_update]))
+
+        new_dvpg = ems.distributed_virtual_lans.find_by(:name => "New DVPG")
+        expect(new_dvpg).not_to be_nil
+        expect(new_dvpg.ems_ref).to eq("dvportgroup-99")
+        expect(new_dvpg.switch.uid_ems).to eq("dvs-8")
+      end
+
+      it "deleting a distributed virtual portgroup" do
+        run_targeted_refresh(targeted_update_set([dvpg_delete_object_update]))
+
+        expect(ems.distributed_virtual_lans.find_by(:name => "DC0_DVPG1")).to be_nil
+      end
+
       it "adding a customValue to a VM" do
         vm = ems.vms.find_by(:ems_ref => "vm-107")
         expect(vm.ems_custom_attributes).to be_empty
@@ -591,6 +606,30 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
           RbVmomi::VIM.PropertyChange(:name => "name", :op => "assign", :val => "DC0_DVPG1_RENAMED"),
           RbVmomi::VIM.PropertyChange(:name => "summary.name", :op => "assign", :val => "DC0_DVPG1_RENAMED")
         ]
+      )
+    end
+
+    def dvpg_create_object_update
+      RbVmomi::VIM.ObjectUpdate(
+        :kind      => "enter",
+        :obj       => RbVmomi::VIM.DistributedVirtualPortgroup(vim, "dvportgroup-99"),
+        :changeSet => [
+          RbVmomi::VIM.PropertyChange(:name => "config.distributedVirtualSwitch", :op => "assign", :val => RbVmomi::VIM.VmwareDistributedVirtualSwitch(vim, "dvs-8")),
+          RbVmomi::VIM.PropertyChange(:name => "config.key",                      :op => "assign", :val => "dvportgroup-99"),
+          RbVmomi::VIM.PropertyChange(:name => "config.name",                     :op => "assign", :val => "New DVPG"),
+          RbVmomi::VIM.PropertyChange(:name => "host",                            :op => "assign", :val => []),
+          RbVmomi::VIM.PropertyChange(:name => "parent",                          :op => "assign", :val => RbVmomi::VIM.Folder(vim, "group-n6")),
+          RbVmomi::VIM.PropertyChange(:name => "name",                            :op => "assign", :val => "New DVPG"),
+          RbVmomi::VIM.PropertyChange(:name => "summary.name",                    :op => "assign", :val => "New DVPG"),
+          RbVmomi::VIM.PropertyChange(:name => "tag",                             :op => "assign", :val => [])
+        ]
+      )
+    end
+
+    def dvpg_delete_object_update
+      RbVmomi::VIM.ObjectUpdate(
+        :kind => "leave",
+        :obj  => RbVmomi::VIM.DistributedVirtualPortgroup(vim, "dvportgroup-11")
       )
     end
 


### PR DESCRIPTION
Since DVPortGroups aren't able to be saved by themselves we have to handle deletions differently

Fixes https://github.com/ManageIQ/manageiq-providers-vmware/pull/620