### PR TITLE
Don't save clone_task_mor VimString to phase_context

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
@@ -160,6 +160,10 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
 
     source.with_provider_object do |vim_vm|
       task_mor = vim_vm.cloneVM_raw(vim_clone_options[:folder], vim_clone_options[:name], cspec, vim_clone_options[:wait])
+
+      # task_mor is a VimString xsiType: ManagedObjectReference vimType: Task but
+      # we have to serialize just the String to the phase_context
+      task_mor = task_mor.to_s if task_mor
     end
 
     task_mor

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb
@@ -25,7 +25,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::StateMachine
   end
 
   def poll_clone_complete
-    clone_status, status_message = do_clone_task_check(phase_context[:clone_task_mor])
+    task_mor = VimString.new(phase_context[:clone_task_mor], "Task", :ManagedObjectReference)
+    clone_status, status_message = do_clone_task_check(task_mor)
 
     status_message = "completed; post provision work queued" if clone_status
     message = "Clone of #{clone_direction} is #{status_message}"


### PR DESCRIPTION
The `phase_context[:clone_task_mor]` must be converted to a standard String before saving it to the `MiqProvisionTask#phase_context`

The `clone_task_mor` is deleted out of the `phase_context` once the task completes, but if the clone task fails it is left there and can cause exceptions for anyone yaml loading the phase_context

Similar issue to https://github.com/ManageIQ/manageiq-providers-vmware/pull/597