### PR TITLE
Update vmware_web_service for snapshot createTime issue

### DIFF
--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fog-vcloud-director",    "~> 0.3.0"
   spec.add_dependency "ffi-vix_disk_lib",       "~>1.1"
   spec.add_dependency "rbvmomi",                "~>3.0"
-  spec.add_dependency "vmware_web_service",     "~>2.0"
+  spec.add_dependency "vmware_web_service",     "~>2.0.2"
   spec.add_dependency "vsphere-automation-sdk", "~>0.4.7"
 
   spec.add_development_dependency "simplecov"


### PR DESCRIPTION
Update to vmware_web_service 2.0.2 to pull in fix for snapshot createTime/uid_ems mismatch

https://github.com/ManageIQ/vmware_web_service/pull/87
Fixes https://github.com/ManageIQ/manageiq-providers-vmware/issues/631