### PR TITLE
Make the credentials required in the provider DDF

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -80,6 +80,7 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
                     :id                     => 'endpoints.default.valid',
                     :name                   => 'endpoints.default.valid',
                     :skipSubmit             => true,
+                    :isRequired             => true,
                     :validationDependencies => %w[type zone_id api_version],
                     :fields                 => [
                       {
@@ -151,6 +152,7 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
                     :id                     => 'endpoints.amqp.valid',
                     :name                   => 'endpoints.amqp.valid',
                     :skipSubmit             => true,
+                    :isRequired             => true,
                     :validationDependencies => %w[type event_stream_selection],
                     :condition              => {
                       :when => 'event_stream_selection',

--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -97,6 +97,7 @@ module ManageIQ::Providers
                       :id                     => 'endpoints.default.valid',
                       :name                   => 'endpoints.default.valid',
                       :skipSubmit             => true,
+                      :isRequired             => true,
                       :validationDependencies => %w[type zone_id],
                       :fields                 => [
                         {
@@ -158,6 +159,7 @@ module ManageIQ::Providers
                       :id                     => 'endpoints.console.valid',
                       :name                   => 'endpoints.console.valid',
                       :skipSubmit             => true,
+                      :isRequired             => true,
                       :validationDependencies => %w[type endpoints.default.hostname],
                       :condition              => {
                         :when => 'vmrc_console',


### PR DESCRIPTION
The default behavior for the `async-credentials` component is [changing to be optional](https://github.com/ManageIQ/manageiq-ui-classic/pull/7347), so it has to be explicitly marked as required here. This is a little different from any other provider, not just the default credentials are required as all the other components are only rendered when the user selects the right protocol from the dropdown.