### PR TITLE
Fix missing storages_vms_and_templates records

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -378,6 +378,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
     }
 
     parse_virtual_machine_config(vm_hash, props)
+    parse_virtual_machine_datastore(vm_hash, props)
     parse_virtual_machine_resource_config(vm_hash, props)
     parse_virtual_machine_summary(vm_hash, props)
     parse_virtual_machine_storage(vm_hash, props)

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -34,6 +34,12 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
       vm_hash[:memory_hot_add_increment] = config[:hotPlugMemoryIncrementSize]
     end
 
+    def parse_virtual_machine_datastore(vm_hash, props)
+      vm_hash[:storages] = props[:datastore].to_a.map do |datastore|
+        persister.storages.lazy_find(datastore._ref)
+      end
+    end
+
     def parse_virtual_machine_summary(vm_hash, props)
       summary = props[:summary]
       return if summary.nil?

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -1119,6 +1119,9 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       expect(vm.storage).not_to be_nil
       expect(vm.storage.name).to eq("GlobalDS_0")
 
+      expect(vm.storages.count).to eq(1)
+      expect(vm.storages.first.name).to eq("GlobalDS_0")
+
       expect(vm.parent_blue_folder).not_to be_nil
       expect(vm.parent_blue_folder.ems_ref).to eq("group-v3")
 


### PR DESCRIPTION
There is a join_table connecting a vm_or_template record to all of its storages which wasn't being populated, this is used to find active smartstate proxies [here](https://github.com/ManageIQ/manageiq/blob/master/app/models/vm_or_template.rb#L1024)

I'm not sure how this wasn't picked up by the refresh full database comparison