### PR TITLE
Don't pass kind="leave" to the dvswitch parser when deleting a dvportgroup

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -248,6 +248,10 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
 
   def parse_distributed_virtual_portgroup(_object, kind, props)
     dvs = props.fetch_path(:config, :distributedVirtualSwitch)
+
+    # If the dvportgroup is deleted we don't want to pass kind="leave" to the
+    # switch parser because it will think the switch is being deleted
+    kind = "update" if kind == "leave"
     parse_distributed_virtual_switch(dvs, kind, cache.find(dvs))
   end
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -271,6 +271,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
         run_targeted_refresh(targeted_update_set([dvpg_delete_object_update]))
 
         expect(ems.distributed_virtual_lans.find_by(:name => "DC0_DVPG1")).to be_nil
+        expect(ems.distributed_virtual_switches.count).to eq(2)
       end
 
       it "adding a customValue to a VM" do


### PR DESCRIPTION
When a distributed virtual portgroup is deleted the objectUpdate has kind="leave".  We have to parse portgroup updates at the whole switch level due to our Switch -> Lan modeling but we have to change the objectUpdate kind otherwise the switch parser thinks it is the switch that is being deleted.

Fixes https://github.com/ManageIQ/manageiq-providers-vmware/issues/637