### PR TITLE
[JANSA] Update vmware_web_service to 1.0.8 to fix snapshot uid_ems

### DIFF
--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency("fog-vcloud-director", ["~> 0.3.0"])
   s.add_dependency "ffi-vix_disk_lib",        "~>1.1"
   s.add_dependency "rbvmomi",                 "~>2.0.0"
-  s.add_dependency "vmware_web_service",      "~>1.0.5"
+  s.add_dependency "vmware_web_service",      "~>1.0.8"
   s.add_dependency "vsphere-automation-sdk",  "~>0.2.1"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
Jansa backport of https://github.com/ManageIQ/manageiq-providers-vmware/pull/633 with https://github.com/ManageIQ/vmware_web_service/pull/88