### PR TITLE
Collect VM's createDate on VMware >= 6.7

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector/property_collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector/property_collector.rb
@@ -29,8 +29,10 @@ module ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector::Property
     engine_root = ManageIQ::Providers::Vmware::Engine.root
     hash = YAML.load_file(engine_root.join("config", "property_specs", "#{file_name}.yml"))
 
+    major_minor_version = api_version.split(".").take(2).join(".")
+
     prop_set = hash["base"]
-    prop_set = merge_prop_set!(prop_set, hash[api_version]) if hash.key?(api_version)
+    prop_set = merge_prop_set!(prop_set, hash[major_minor_version]) if hash.key?(major_minor_version)
 
     prop_set.collect do |type, props|
       RbVmomi::VIM.PropertySpec(

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector/property_collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector/property_collector.rb
@@ -17,25 +17,32 @@ module ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector::Property
         RbVmomi::VIM.ObjectSpec(:obj => vim.serviceContent.rootFolder, :selectSet => root_folder_select_set),
         RbVmomi::VIM.ObjectSpec(:obj => vim.serviceContent.licenseManager),
       ],
-      :propSet   => ems_inventory_prop_set
+      :propSet   => ems_inventory_prop_set(vim.rev)
     )
   end
 
-  def ems_inventory_prop_set
-    property_set_from_file("ems_inventory")
+  def ems_inventory_prop_set(api_version)
+    property_set_from_file("ems_inventory", api_version)
   end
 
-  def property_set_from_file(file_name)
+  def property_set_from_file(file_name, api_version)
     engine_root = ManageIQ::Providers::Vmware::Engine.root
     hash = YAML.load_file(engine_root.join("config", "property_specs", "#{file_name}.yml"))
 
-    hash.collect do |type, props|
+    prop_set = hash["base"]
+    prop_set = merge_prop_set!(prop_set, hash[api_version]) if hash.key?(api_version)
+
+    prop_set.collect do |type, props|
       RbVmomi::VIM.PropertySpec(
         :type    => type,
         :all     => props.nil?,
         :pathSet => props
       )
     end
+  end
+
+  def merge_prop_set!(base, extra)
+    base.deep_merge!(extra) { |_k, v1, v2| v1 + v2 }
   end
 
   def root_folder_select_set

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -18,6 +18,8 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
       config = props[:config]
       return if config.nil?
 
+      vm_hash[:ems_created_on] = config[:createDate]
+
       affinity_set = config.fetch_path(:cpuAffinity, :affinitySet)
 
       cpu_affinity = nil

--- a/config/property_specs/ems_inventory.yml
+++ b/config/property_specs/ems_inventory.yml
@@ -1,166 +1,170 @@
 ---
-:ManagedEntity:
-- name
-- parent
-:VirtualMachine:
-- availableField
-- config.cpuAffinity.affinitySet
-- config.cpuHotAddEnabled
-- config.cpuHotRemoveEnabled
-- config.defaultPowerOps.standbyAction
-- config.firmware
-- config.hardware.device
-- config.hardware.numCoresPerSocket
-- config.hotPlugMemoryIncrementSize
-- config.hotPlugMemoryLimit
-- config.memoryHotAddEnabled
-- config.version
-- datastore
-- guest.ipStack
-- guest.net
-- resourceConfig.cpuAllocation.expandableReservation
-- resourceConfig.cpuAllocation.limit
-- resourceConfig.cpuAllocation.reservation
-- resourceConfig.cpuAllocation.shares.level
-- resourceConfig.cpuAllocation.shares.shares
-- resourceConfig.memoryAllocation.expandableReservation
-- resourceConfig.memoryAllocation.limit
-- resourceConfig.memoryAllocation.reservation
-- resourceConfig.memoryAllocation.shares.level
-- resourceConfig.memoryAllocation.shares.shares
-- resourcePool
-- snapshot
-- summary.vm
-- summary.config.annotation
-- summary.config.ftInfo.instanceUuids
-- summary.config.guestFullName
-- summary.config.guestId
-- summary.config.memorySizeMB
-- summary.config.name
-- summary.config.numCpu
-- summary.config.template
-- summary.config.uuid
-- summary.config.vmPathName
-- summary.customValue
-- summary.guest.hostName
-- summary.guest.ipAddress
-- summary.guest.toolsStatus
-- summary.runtime.bootTime
-- summary.runtime.connectionState
-- summary.runtime.host
-- summary.runtime.powerState
-- summary.storage.unshared
-- summary.storage.committed
-:ComputeResource:
-- host
-- resourcePool
-:ClusterComputeResource:
-- configuration.dasConfig.admissionControlPolicy
-- configuration.dasConfig.admissionControlEnabled
-- configuration.dasConfig.enabled
-- configuration.dasConfig.failoverLevel
-- configuration.drsConfig.defaultVmBehavior
-- configuration.drsConfig.enabled
-- configuration.drsConfig.vmotionRate
-- summary.effectiveCpu
-- summary.effectiveMemory
-- host
-- resourcePool
-:ResourcePool:
-- resourcePool
-- summary.config.cpuAllocation.expandableReservation
-- summary.config.cpuAllocation.limit
-- summary.config.cpuAllocation.reservation
-- summary.config.cpuAllocation.shares.level
-- summary.config.cpuAllocation.shares.shares
-- summary.config.memoryAllocation.expandableReservation
-- summary.config.memoryAllocation.limit
-- summary.config.memoryAllocation.reservation
-- summary.config.memoryAllocation.shares.level
-- summary.config.memoryAllocation.shares.shares
-- vm
-:Folder: []
-:Datacenter:
-- datastoreFolder
-- hostFolder
-- networkFolder
-- vmFolder
-:HostSystem:
-- config.adminDisabled
-- config.consoleReservation.serviceConsoleReserved
-- config.hyperThread.active
-- config.network.consoleVnic
-- config.network.dnsConfig.domainName
-- config.network.dnsConfig.hostName
-- config.network.ipRouteConfig.defaultGateway
-- config.network.opaqueNetwork
-- config.network.opaqueSwitch
-- config.network.pnic
-- config.network.portgroup
-- config.network.vnic
-- config.network.vswitch
-- config.service.service
-- datastore
-- hardware.systemInfo.otherIdentifyingInfo
-- summary.host
-- summary.config.name
-- summary.config.product.build
-- summary.config.product.name
-- summary.config.product.osType
-- summary.config.product.vendor
-- summary.config.product.version
-- summary.config.vmotionEnabled
-- summary.hardware.cpuMhz
-- summary.hardware.cpuModel
-- summary.hardware.memorySize
-- summary.hardware.model
-- summary.hardware.numCpuCores
-- summary.hardware.numCpuPkgs
-- summary.hardware.numNics
-- summary.hardware.vendor
-- summary.quickStats.overallCpuUsage
-- summary.quickStats.overallMemoryUsage
-- summary.runtime.connectionState
-- summary.runtime.inMaintenanceMode
-:Datastore:
-- info
-- host
-- capability.directoryHierarchySupported
-- capability.perFileThinProvisioningSupported
-- capability.rawDiskMappingsSupported
-- summary.accessible
-- summary.capacity
-- summary.datastore
-- summary.freeSpace
-- summary.maintenanceMode
-- summary.multipleHostAccess
-- summary.name
-- summary.type
-- summary.uncommitted
-- summary.url
-:StoragePod:
-- summary.capacity
-- summary.freeSpace
-- summary.name
-:DistributedVirtualPortgroup:
-- summary.name
-- config.key
-- config.defaultPortConfig
-- config.distributedVirtualSwitch
-- config.name
-- host
-- tag
-:DistributedVirtualSwitch:
-- config.uplinkPortgroup
-- config.defaultPortConfig
-- config.numPorts
-- summary.name
-- summary.uuid
-- summary.host
-- summary.hostMember
-:LicenseManager:
-- licenses
-:ExtensionManager:
-- extensionList
-:CustomizationSpecManager:
-- info
+base: &base
+  :ManagedEntity:
+  - name
+  - parent
+  :VirtualMachine:
+  - availableField
+  - config.cpuAffinity.affinitySet
+  - config.cpuHotAddEnabled
+  - config.cpuHotRemoveEnabled
+  - config.defaultPowerOps.standbyAction
+  - config.firmware
+  - config.hardware.device
+  - config.hardware.numCoresPerSocket
+  - config.hotPlugMemoryIncrementSize
+  - config.hotPlugMemoryLimit
+  - config.memoryHotAddEnabled
+  - config.version
+  - datastore
+  - guest.ipStack
+  - guest.net
+  - resourceConfig.cpuAllocation.expandableReservation
+  - resourceConfig.cpuAllocation.limit
+  - resourceConfig.cpuAllocation.reservation
+  - resourceConfig.cpuAllocation.shares.level
+  - resourceConfig.cpuAllocation.shares.shares
+  - resourceConfig.memoryAllocation.expandableReservation
+  - resourceConfig.memoryAllocation.limit
+  - resourceConfig.memoryAllocation.reservation
+  - resourceConfig.memoryAllocation.shares.level
+  - resourceConfig.memoryAllocation.shares.shares
+  - resourcePool
+  - snapshot
+  - summary.vm
+  - summary.config.annotation
+  - summary.config.ftInfo.instanceUuids
+  - summary.config.guestFullName
+  - summary.config.guestId
+  - summary.config.memorySizeMB
+  - summary.config.name
+  - summary.config.numCpu
+  - summary.config.template
+  - summary.config.uuid
+  - summary.config.vmPathName
+  - summary.customValue
+  - summary.guest.hostName
+  - summary.guest.ipAddress
+  - summary.guest.toolsStatus
+  - summary.runtime.bootTime
+  - summary.runtime.connectionState
+  - summary.runtime.host
+  - summary.runtime.powerState
+  - summary.storage.unshared
+  - summary.storage.committed
+  :ComputeResource:
+  - host
+  - resourcePool
+  :ClusterComputeResource:
+  - configuration.dasConfig.admissionControlPolicy
+  - configuration.dasConfig.admissionControlEnabled
+  - configuration.dasConfig.enabled
+  - configuration.dasConfig.failoverLevel
+  - configuration.drsConfig.defaultVmBehavior
+  - configuration.drsConfig.enabled
+  - configuration.drsConfig.vmotionRate
+  - summary.effectiveCpu
+  - summary.effectiveMemory
+  - host
+  - resourcePool
+  :ResourcePool:
+  - resourcePool
+  - summary.config.cpuAllocation.expandableReservation
+  - summary.config.cpuAllocation.limit
+  - summary.config.cpuAllocation.reservation
+  - summary.config.cpuAllocation.shares.level
+  - summary.config.cpuAllocation.shares.shares
+  - summary.config.memoryAllocation.expandableReservation
+  - summary.config.memoryAllocation.limit
+  - summary.config.memoryAllocation.reservation
+  - summary.config.memoryAllocation.shares.level
+  - summary.config.memoryAllocation.shares.shares
+  - vm
+  :Folder: []
+  :Datacenter:
+  - datastoreFolder
+  - hostFolder
+  - networkFolder
+  - vmFolder
+  :HostSystem:
+  - config.adminDisabled
+  - config.consoleReservation.serviceConsoleReserved
+  - config.hyperThread.active
+  - config.network.consoleVnic
+  - config.network.dnsConfig.domainName
+  - config.network.dnsConfig.hostName
+  - config.network.ipRouteConfig.defaultGateway
+  - config.network.opaqueNetwork
+  - config.network.opaqueSwitch
+  - config.network.pnic
+  - config.network.portgroup
+  - config.network.vnic
+  - config.network.vswitch
+  - config.service.service
+  - datastore
+  - hardware.systemInfo.otherIdentifyingInfo
+  - summary.host
+  - summary.config.name
+  - summary.config.product.build
+  - summary.config.product.name
+  - summary.config.product.osType
+  - summary.config.product.vendor
+  - summary.config.product.version
+  - summary.config.vmotionEnabled
+  - summary.hardware.cpuMhz
+  - summary.hardware.cpuModel
+  - summary.hardware.memorySize
+  - summary.hardware.model
+  - summary.hardware.numCpuCores
+  - summary.hardware.numCpuPkgs
+  - summary.hardware.numNics
+  - summary.hardware.vendor
+  - summary.quickStats.overallCpuUsage
+  - summary.quickStats.overallMemoryUsage
+  - summary.runtime.connectionState
+  - summary.runtime.inMaintenanceMode
+  :Datastore:
+  - info
+  - host
+  - capability.directoryHierarchySupported
+  - capability.perFileThinProvisioningSupported
+  - capability.rawDiskMappingsSupported
+  - summary.accessible
+  - summary.capacity
+  - summary.datastore
+  - summary.freeSpace
+  - summary.maintenanceMode
+  - summary.multipleHostAccess
+  - summary.name
+  - summary.type
+  - summary.uncommitted
+  - summary.url
+  :StoragePod:
+  - summary.capacity
+  - summary.freeSpace
+  - summary.name
+  :DistributedVirtualPortgroup:
+  - summary.name
+  - config.key
+  - config.defaultPortConfig
+  - config.distributedVirtualSwitch
+  - config.name
+  - host
+  - tag
+  :DistributedVirtualSwitch:
+  - config.uplinkPortgroup
+  - config.defaultPortConfig
+  - config.numPorts
+  - summary.name
+  - summary.uuid
+  - summary.host
+  - summary.hostMember
+  :LicenseManager:
+  - licenses
+  :ExtensionManager:
+  - extensionList
+  :CustomizationSpecManager:
+  - info
+"6.7":
+  :VirtualMachine:
+  - config.createDate


### PR DESCRIPTION
We have an ems_created_on column on VMs which we can use to store the config.createDate which was added in vSphere 6.7