### PR TITLE
Save only OVF templates into VMDB.

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -397,6 +397,8 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
   end
 
   def parse_content_library_item(library_item)
+    return unless library_item.type == 'ovf'
+
     props = {
       :ems_ref     => library_item.id,
       :name        => library_item.name,


### PR DESCRIPTION
Save only OVF templates into VMDB.

https://github.com/ManageIQ/manageiq/issues/19718