### PR TITLE
Reconnect VMs based on uid_ems

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
@@ -96,6 +96,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister < ManageIQ
         relation.where(:uid_ems => vm_uids).order(:id => :asc).each do |record|
           inventory_object = vms_by_uid_ems[record.uid_ems].shift
           hash             = attributes_index.delete(inventory_object.ems_ref)
+          inventory_objects_index.delete(inventory_object.ems_ref)
 
           # Skip if hash is blank, which can happen when having several archived entities with the same ref
           next unless hash

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -184,23 +184,26 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
 
       context "reconnecting a virtual machine" do
         let!(:vm)     { FactoryBot.create(:vm_vmware, :ems_ref => ems_ref, :uid_ems => uid_ems) }
-        let(:ems_ref) { "vm-999" }
+        let(:ems_ref) { "vm-456" }
         let(:uid_ems) { "7cb139af-20fb-4fc7-9195-0d3fbd32fe73" }
 
         context "with the same ems_ref" do
-          it "reconnects the virtual machine" do
+          let(:ems_ref) { "vm-999" }
+
+          it "reconnects the virtual machine and doesn't creating a new one" do
+            num_vms = VmOrTemplate.count
+
             run_targeted_refresh(targeted_update_set([vm_create_object_update(:uuid => uid_ems)]))
 
             vm.reload
 
             expect(vm.archived?).to be_falsy
             expect(vm.ext_management_system).to eq(ems)
+            expect(VmOrTemplate.count).to eq(num_vms)
           end
         end
 
         context "with a different ems_ref" do
-          let(:ems_ref) { "vm-456" }
-
           it "reconnects the virtual machine" do
             run_targeted_refresh(targeted_update_set([vm_create_object_update(:uuid => uid_ems)]))
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -211,6 +211,16 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
           end
         end
 
+        context "with a vm with the same uuid in a different active ems" do
+          let(:other_ems) { FactoryBot.create(:ems_vmware) }
+          let!(:other_vm) { FactoryBot.create(:vm_vmware, :ext_management_system => other_ems, :ems_ref => ems_ref, :uid_ems => uid_ems) }
+
+          it "creates a new record and doesn't steal the other vm" do
+            run_targeted_refresh(targeted_update_set([vm_create_object_update(:uuid => uid_ems)]))
+            expect(other_vm.reload.ext_management_system).to eq(other_ems)
+          end
+        end
+
         context "two vms with duplicate uuids" do
           let!(:other_vm) { FactoryBot.create(:vm_vmware, :ems_ref => "vm-789", :uid_ems => uid_ems) }
 


### PR DESCRIPTION
At some point the core infra_manager vms collection manager_ref was changed to be the ems_ref not the uid_ems, and either case it didn't handle duplicate uid_ems's well.

TODO:
- [x] Expand test coverage of the different reconnect cases (e.g. multiple duplicate uuids)