### PR TITLE
Hash the license_key for a license ems_ref

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -230,11 +230,13 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
   def parse_license_manager(_object, kind, props)
     return if kind == "leave"
 
+    require "digest"
     props[:licenses].to_a.each do |license|
+      uid = Digest::SHA1.hexdigest(license.licenseKey)
+
       persister.ems_licenses.build(
-        :ems_ref         => license.licenseKey,
+        :ems_ref         => uid,
         :name            => license.name,
-        :license_key     => license.licenseKey,
         :license_edition => license.editionKey,
         :total_licenses  => license.total,
         :used_licenses   => license.used


### PR DESCRIPTION
We don't need the content of the license_key for the purposes of uniqueness

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1889355