### PR TITLE
Fix the tag mapper category on VMware VMs

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -384,7 +384,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
         )
       end.compact
 
-      persister.tag_mapper.map_labels("VmOrTemplate", persister_labels).each do |tag|
+      persister.tag_mapper.map_labels("VmVmware", persister_labels).each do |tag|
         persister.vm_and_template_taggings.build(:taggable => vm, :tag => tag)
       end
     end


### PR DESCRIPTION
The tag mapper category should be VmVmware not VmOrTemplate.  I was going off of the Amazon implementation and they use "Vm" so I falsely believed this was the base-class name.