### PR TITLE
Requeue autostart_destination if Vm not in cache

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb
@@ -56,20 +56,16 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::StateMachine
   end
 
   def autostart_destination
-    if get_option(:vm_auto_start)
-      message = "Starting"
-      _log.info("#{message} #{for_destination}")
-      update_and_notify_parent(:message => message)
-      begin
-        destination.start
-        signal :post_create_destination
-      rescue MiqException::MiqVimResourceNotFound
-        _log.info("Unable to start #{for_destination}.  Retrying...")
-        requeue_phase
-      end
-    else
-      signal :post_create_destination
-    end
+    return signal :post_create_destination unless get_option(:vm_auto_start)
+
+    _log.info("Starting #{for_destination}")
+    update_and_notify_parent(:message => "Starting")
+
+    destination.raw_start
+    signal :post_create_destination
+  rescue MiqException::MiqVimResourceNotFound
+    _log.info("Unable to start #{for_destination}.  Retrying...")
+    requeue_phase
   end
 
   def customize_destination

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb
@@ -55,6 +55,23 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::StateMachine
     end
   end
 
+  def autostart_destination
+    if get_option(:vm_auto_start)
+      message = "Starting"
+      _log.info("#{message} #{for_destination}")
+      update_and_notify_parent(:message => message)
+      begin
+        destination.start
+        signal :post_create_destination
+      rescue MiqException::MiqVimResourceNotFound
+        _log.info("Unable to start #{for_destination}.  Retrying...")
+        requeue_phase
+      end
+    else
+      signal :post_create_destination
+    end
+  end
+
   def customize_destination
     _log.info("Post-processing #{destination_type} id: [#{destination.id}], name: [#{dest_name}]")
     update_and_notify_parent(:message => "Starting New #{destination_type} Customization")

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
@@ -169,6 +169,14 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
           @vm_prov.signal :autostart_destination
         end
 
+        it "autostart_destination with a vm cache error requeues the phase" do
+          @vm_prov.options[:vm_auto_start] = true
+          allow(@vm_prov.destination).to receive(:start).and_raise(MiqException::MiqVimResourceNotFound)
+          expect(@vm_prov).not_to receive(:post_create_destination)
+          expect(@vm_prov).to receive(:requeue_phase)
+          @vm_prov.signal :autostart_destination
+        end
+
         it "autostart_destination with error" do
           @vm_prov.options[:vm_auto_start] = true
           allow(@vm_prov.destination).to receive(:start).and_raise

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
@@ -157,21 +157,21 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
         end
 
         it "autostart_destination, vm_auto_start disabled" do
-          expect(@vm_prov.destination).not_to receive(:start)
+          expect(@vm_prov.destination).not_to receive(:raw_start)
           expect(@vm_prov).to receive(:post_create_destination)
           @vm_prov.signal :autostart_destination
         end
 
         it "autostart_destination" do
           @vm_prov.options[:vm_auto_start] = true
-          expect(@vm_prov.destination).to receive(:start)
+          expect(@vm_prov.destination).to receive(:raw_start)
           expect(@vm_prov).to receive(:post_create_destination)
           @vm_prov.signal :autostart_destination
         end
 
         it "autostart_destination with a vm cache error requeues the phase" do
           @vm_prov.options[:vm_auto_start] = true
-          allow(@vm_prov.destination).to receive(:start).and_raise(MiqException::MiqVimResourceNotFound)
+          allow(@vm_prov.destination).to receive(:raw_start).and_raise(MiqException::MiqVimResourceNotFound)
           expect(@vm_prov).not_to receive(:post_create_destination)
           expect(@vm_prov).to receive(:requeue_phase)
           @vm_prov.signal :autostart_destination
@@ -179,8 +179,8 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
 
         it "autostart_destination with error" do
           @vm_prov.options[:vm_auto_start] = true
-          allow(@vm_prov.destination).to receive(:start).and_raise
-          expect(@vm_prov.destination).to receive(:start).once
+          allow(@vm_prov.destination).to receive(:raw_start).and_raise
+          expect(@vm_prov.destination).to receive(:raw_start).once
           @vm_prov.signal :autostart_destination
         end
       end


### PR DESCRIPTION
If the newly provisioned VM is not yet in the operations worker's cache yet requeue the phase and try again

Fixes https://github.com/ManageIQ/manageiq-providers-vmware/issues/651