### PR TITLE
[WIP] Replace snapshotting_memory_allowed? with supports :snapshot_memory

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm/operations/snapshot.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/operations/snapshot.rb
@@ -1,8 +1,12 @@
 module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations::Snapshot
   extend ActiveSupport::Concern
 
-  def snapshotting_memory_allowed?
-    current_state == 'on'
+  included do
+    supports :snapshot_memory do
+      unless current_state == 'on'
+        unsupported_reason_add(:snapshot_memory, "Memory can only be included in the snapshot if the VM is running")
+      end
+    end
   end
 
   def raw_create_snapshot(name, desc = nil, memory)

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm_spec.rb
@@ -132,25 +132,6 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm do
     end
   end
 
-  context "snapshotting_memory_allowed?" do
-    context "when powered on" do
-      let(:power_state) {{:raw_power_state => power_state_on}}
-
-      it "is allowed" do
-        vm.update(power_state)
-        expect(vm.snapshotting_memory_allowed?).to be_truthy
-      end
-    end
-
-    context "when powered off" do
-      let(:power_state) {{:raw_power_state => power_state_suspended}}
-      it "is not allowed" do
-        vm.update(power_state)
-        expect(vm.snapshotting_memory_allowed?).to be_falsy
-      end
-    end
-  end
-
   describe "#supports_terminate?" do
     context "when connected to a provider" do
       it "returns true" do


### PR DESCRIPTION
The `snapshotting_memory_allowed?` is exposed in the UI for VM snapshot creation and in order to provide this information via the UI, it needs to be available through the `SupportsFeatureMixin` instead. 

Depends on: https://github.com/ManageIQ/manageiq/pull/20729

@miq-bot add_label technical debt
@miq-bot assign @agrare 