### PR TITLE
Declared DDF schema for creating snapshots

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm.rb
@@ -27,6 +27,27 @@ class ManageIQ::Providers::Vmware::CloudManager::Vm < ManageIQ::Providers::Cloud
     "suspended" => "suspended"
   }.freeze
 
+  def self.params_for_create_snapshot
+    {
+      :fields => [
+        {
+          :component  => 'text-field',
+          :name       => 'name',
+          :id         => 'name',
+          :label      => _('Name'),
+          :isRequired => true,
+          :validate   => [{:type => 'required'}],
+        },
+        {
+          :component => 'textarea',
+          :name      => 'description',
+          :id        => 'description',
+          :label     => _('Description'),
+        },
+      ],
+    }
+  end
+
   def self.calculate_power_state(raw_power_state)
     # https://github.com/xlab-si/fog-vcloud-director/blob/master/lib/fog/vcloud_director/parsers/compute/vm.rb#L70
     POWER_STATES[raw_power_state.to_s] || "terminated"

--- a/app/models/manageiq/providers/vmware/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm.rb
@@ -41,6 +41,37 @@ class ManageIQ::Providers::Vmware::InfraManager::Vm < ManageIQ::Providers::Infra
   supports :snapshots
   supports :quick_stats
 
+  def params_for_create_snapshot
+    {
+      :fields => [
+        {
+          :component  => 'text-field',
+          :name       => 'name',
+          :id         => 'name',
+          :label      => _('Name'),
+          :isRequired => true,
+          :validate   => [{:type => 'required'}],
+        },
+        {
+          :component => 'textarea',
+          :name      => 'description',
+          :id        => 'description',
+          :label     => _('Description'),
+        },
+        {
+          :component  => 'switch',
+          :name       => 'memory',
+          :id         => 'memory',
+          :label      => _('Snapshot VM memory'),
+          :onText     => _('Yes'),
+          :offText    => _('No'),
+          :isDisabled => current_state != 'on',
+          :helperText => _('Snapshotting the memory is only available if the VM is powered on.'),
+        },
+      ],
+    }
+  end
+
   def self.display_name(number = 1)
     n_('Virtual Machine (VMware)', 'Virtual Machines (VMware)', number)
   end


### PR DESCRIPTION
The snapshot form in ui-classic has too complex provider-specific logic to decide what fields to show, so I'm making this simpler by moving the ovirt-specific form into this repo. The API will be able to [expose](https://github.com/ManageIQ/manageiq-api/pull/943) this schema if asked.

@miq-bot assign @agrare 
@miq-bot add_label enhancement