### PR TITLE
Allow specifying the datastore/network for OVF deployment.

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/orchestration_template.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/orchestration_template.rb
@@ -1,14 +1,15 @@
 class ManageIQ::Providers::Vmware::InfraManager::OrchestrationTemplate < ::OrchestrationTemplate
   belongs_to :ext_management_system, :foreign_key => "ems_id", :class_name => "ManageIQ::Providers::Vmware::InfraManager", :inverse_of => false
 
-  delegate :allowed_resource_pools, :allowed_folders, :allowed_hosts, :to => :workflow_helper
+  delegate :allowed_resource_pools, :allowed_folders, :allowed_hosts, :allowed_storages, :to => :workflow_helper
 
   include ProviderObjectMixin
 
   SPEC_KEY_MAPPING = {
-    "resource_pool" => "resource_pool_id",
     "ems_folder"    => "folder_id",
-    "host"          => "host_id"
+    "host"          => "host_id",
+    "storage"       => "default_datastore_id",
+    "resource_pool" => "resource_pool_id"
   }.freeze
 
   def deploy(options = {})
@@ -28,11 +29,22 @@ class ManageIQ::Providers::Vmware::InfraManager::OrchestrationTemplate < ::Orche
 
     spec = {"accept_all_EULA" => opts[:accept_all_eula]}
     spec["name"] = opts[:vm_name] if opts[:vm_name].present?
+    spec["storage_provisioning"] = opts[:disk_format] if opts[:disk_format].present?
+
+    if opts[:network_id].present?
+      network = Lan.find_by(:id => opts[:network_id])
+      spec["network_mappings"] = [{"key" => network.name, "value" => network.ems_ref}] if network.present?
+    end
+
+    if opts[:storage_id].present?
+      resource = spec_resource("storage", opts)
+      spec[SPEC_KEY_MAPPING["storage"]] = resource.ems_ref if resource.present?
+    end
 
     target = {}
     %w[resource_pool ems_folder host].each do |r|
-      options_key = "#{r}_id"
-      target[SPEC_KEY_MAPPING[r]] = r.camelize.constantize.find_by(:id => opts[options_key]).ems_ref if opts[options_key].present?
+      resource = spec_resource(r, opts)
+      target[SPEC_KEY_MAPPING[r]] = resource.ems_ref if resource.present?
     end
 
     deploy_options = {"deployment_spec" => spec, "target" => target}
@@ -41,8 +53,20 @@ class ManageIQ::Providers::Vmware::InfraManager::OrchestrationTemplate < ::Orche
     deploy_options
   end
 
+  def spec_resource(klass_name, opts)
+    key = "#{klass_name}_id"
+    return if opts[key].blank?
+
+    klass_name.camelize.constantize.find_by(:id => opts[key])
+  end
+
   def workflow_helper
     @workflow_helper ||= MiqProvisionOrchWorkflow.new({:src_vm_id => [id]}, User.current_user, :skip_dialog_load => true, :initial_pass => true)
+  end
+
+  def allowed_vlans
+    # workflow_helper.allowed_vlans returns back host level networks which have no ems_ref
+    Lan.where(:name => [workflow_helper.allowed_vlans.keys]).where.not(:ems_ref => nil).uniq(&:name).pluck(:id, :name)
   end
 
   def target_name_valid?(name, ems_folder_id = nil)

--- a/app/models/manageiq/providers/vmware/infra_manager/ovf_service.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/ovf_service.rb
@@ -3,9 +3,12 @@ class ManageIQ::Providers::Vmware::InfraManager::OvfService < ServiceGeneric
 
   CONFIG_OPTIONS_WHITELIST = %i[
     accept_all_eula
+    disk_format
     ems_folder_id
     host_id
+    network_id
     resource_pool_id
+    storage_id
     vm_name
   ].freeze
 
@@ -138,7 +141,7 @@ class ManageIQ::Providers::Vmware::InfraManager::OvfService < ServiceGeneric
     dialog_options = options[:dialog] || {}
     options = {}
 
-    %w[vm_name resource_pool_id ems_folder_id host_id].each do |r|
+    CONFIG_OPTIONS_WHITELIST.each do |r|
       options[r] = dialog_options["dialog_#{r}"] if dialog_options["dialog_#{r}"].present?
     end
     options

--- a/spec/models/manageiq/providers/vmware/infra_manager/ovf_service_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/ovf_service_spec.rb
@@ -31,6 +31,7 @@ describe(ManageIQ::Providers::Vmware::InfraManager::OvfService) do
         "dialog_vm_name"          => "dialog_vm_name",
         "dialog_resource_pool_id" => "5",
         "dialog_ems_folder_id"    => "30",
+        "dialog_storage_id"       => "3",
       }
     }
   end
@@ -45,7 +46,8 @@ describe(ManageIQ::Providers::Vmware::InfraManager::OvfService) do
           :accept_all_eula  => true,
           :resource_pool_id => "2",
           :ems_folder_id    => "3",
-          :host_id          => "1"
+          :host_id          => "1",
+          :storage_id       => "1"
         }
       }
     }
@@ -58,6 +60,7 @@ describe(ManageIQ::Providers::Vmware::InfraManager::OvfService) do
       "vm_name"          => "dialog_vm_name",
       "accept_all_eula"  => true,
       "host_id"          => "1",
+      "storage_id"       => "3",
       "resource_pool_id" => "5",
       "ems_folder_id"    => "30"
     }
@@ -65,7 +68,7 @@ describe(ManageIQ::Providers::Vmware::InfraManager::OvfService) do
 
   let(:failed_response) { {:value => {:succeeded => false, :error => {:errors => [{:category => "SERVER", :error => {:@class => "com.vmware.vapi.std.errors.already_exists", :messages => [{:args => ["VirtualMachine", "lucy-api-vm-2"], :default_message => "An object of type \"VirtualMachine\" named \"lucy-api-vm-2\" already exists.", :id => "com.vmware.vdcs.util.duplicate_name"}]}}], :warnings => [], :information => []}}} }
 
-  let(:deploy_task) { FactoryBot.create(:miq_task, :state => "Active")}
+  let(:deploy_task) { FactoryBot.create(:miq_task, :state => "Active") }
 
   describe '#preprocess' do
     it 'prepares job options from dialog' do


### PR DESCRIPTION
Allow the user to specify the datastore/network for the OVF deployment when creating the service template or through the service dialog.

Depends on https://github.com/ManageIQ/manageiq-ui-classic/pull/7521.
Depends on https://github.com/ManageIQ/manageiq-providers-vmware/pull/671.

@miq-bot add_label enhancement