### PR TITLE
Fetch the ems_ref of a VMware Network

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -224,7 +224,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
     dvs_switches = parse_host_system_distributed_switches(host)
 
     parse_host_system_host_switches(host, switches + dvs_switches)
-    parse_host_system_lans(host, switches, props)
+    parse_host_system_lans(object, host, switches, props)
   end
 
   def parse_license_manager(_object, kind, props)
@@ -415,6 +415,16 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
 
     parent_collection = persister.vim_class_to_collection(managed_object)
     parent_collection.lazy_find(managed_object._ref)
+  end
+
+  def find_parent_datacenter(obj)
+    find_parent_of_type(obj, "Datacenter")
+  end
+
+  def find_parent_of_type(obj, wsdl_name)
+    parent = obj
+    parent = cache.find(parent)&.dig(:parent) until parent.nil? || parent.class.wsdl_name == wsdl_name
+    parent
   end
 
   def rbvmomi_to_basic_types(obj)

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -1199,6 +1199,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       expect(lan).to have_attributes(
         :name                       => "VM Network",
         :uid_ems                    => "VM Network",
+        :ems_ref                    => "network-7",
         :tag                        => "0",
         :allow_promiscuous          => false,
         :forged_transmits           => true,


### PR DESCRIPTION
We model Lans at the host level not at the EMS level.  This results in duplication as well as the lack of an ems_ref.

It is possible to get the ems_ref from the VMware Network object by looking up a Network by name in the same datacenter as the current host.

Long term I think remodeling Lans to be up at the EMS level matches the way most infrastructure providers model networking.