### PR TITLE
Customization spec name is "" when not selected

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/customization.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/customization.rb
@@ -12,7 +12,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Customization
     custom_spec_name = nil if custom_spec_name == "__VC__NONE__"
 
     sysprep_spec_override = get_option(:sysprep_spec_override)
-    spec = load_customization_spec(custom_spec_name) if custom_spec_name
+    spec = load_customization_spec(custom_spec_name) if custom_spec_name.present?
 
     _log.info "Loaded custom spec [#{custom_spec_name}].  Override flag: [#{sysprep_spec_override}]"
     if spec && sysprep_spec_override == false

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision/customization_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision/customization_spec.rb
@@ -115,11 +115,18 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision::Customization do
       expect(prov_vm.build_customization_spec).to(eq(spec_for_compare))
     end
 
-    it 'creates a new spec' do
-      custom_spec.spec = nil
+    it 'creates a new spec when the saved spec is nil' do
       options[:sysprep_full_name] = 'sysprep_full_name_value'
       options[:sysprep_organization] = 'sysprep_organization_value'
       expect(prov_vm).to receive(:load_customization_spec).and_return(nil)
+      expect(prov_vm.build_customization_spec).to(eq(new_spec))
+    end
+
+    it 'creates a new spec when the name is blank' do
+      options[:sysprep_custom_spec] = ''
+      options[:sysprep_full_name] = 'sysprep_full_name_value'
+      options[:sysprep_organization] = 'sysprep_organization_value'
+      expect(prov_vm).not_to receive(:load_customization_spec)
       expect(prov_vm.build_customization_spec).to(eq(new_spec))
     end
   end


### PR DESCRIPTION
When a customization spec isn't selected the customization_spec name is "" not nil.

This was broken because of a subtle change where it was checking for `blank?` [here](https://github.com/ManageIQ/manageiq-providers-vmware/pull/614/files#diff-84d2e88c39771dd23c0154b19f5c1254f18ab9d931a1013cbf7287acf3ddcc9aL201) to checking for `nil?` [here](https://github.com/ManageIQ/manageiq-providers-vmware/pull/614/files#diff-84d2e88c39771dd23c0154b19f5c1254f18ab9d931a1013cbf7287acf3ddcc9aR15)

Fixes http://talk.manageiq.org/t/miqexception-miqprovisionerror-customization-specification-does-not-exist/5197/4