### PR TITLE
Fix IP Address Regex Matching IPv6 as IPv4

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
+  require "more_core_extensions/core_ext/string/formats"
+
   UUID_REGEX_FORMAT = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.freeze
 
   module VirtualMachine
@@ -302,7 +304,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
         props.fetch_path(:guest, :net).to_a.each do |net|
           ip_config_by_ip_addr = net.ipConfig&.ipAddress&.index_by(&:ipAddress) || {}
 
-          ipv4, ipv6 = net[:ipAddress].to_a.compact.collect(&:to_s).sort.partition { |ip| ip =~ /^([0-9]{1,3}\.){3}[0-9]{1,3}/ }
+          ipv4, ipv6 = net[:ipAddress].to_a.compact.collect(&:to_s).select(&:ipaddress?).sort.partition(&:ipv4?)
           ipv4 << nil if ipv4.empty?
           ipaddresses = ipv4.zip_stretched(ipv6)
 

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -302,7 +302,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
         props.fetch_path(:guest, :net).to_a.each do |net|
           ip_config_by_ip_addr = net.ipConfig&.ipAddress&.index_by(&:ipAddress) || {}
 
-          ipv4, ipv6 = net[:ipAddress].to_a.compact.collect(&:to_s).sort.partition { |ip| ip =~ /([0-9]{1,3}\.){3}[0-9]{1,3}/ }
+          ipv4, ipv6 = net[:ipAddress].to_a.compact.collect(&:to_s).sort.partition { |ip| ip =~ /^([0-9]{1,3}\.){3}[0-9]{1,3}/ }
           ipv4 << nil if ipv4.empty?
           ipaddresses = ipv4.zip_stretched(ipv6)
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/parser_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/parser_spec.rb
@@ -1,0 +1,60 @@
+describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser do
+  let(:ems)       { FactoryBot.create(:ems_vmware) }
+  let(:collector) { ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector.new(ems) }
+  let(:persister) { ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister::Targeted.new(ems) }
+  let(:parser)    { described_class.new(collector, persister) }
+
+  context "#parse_virtual_machine" do
+    let(:rbvmomi_vm) do
+      require "rbvmomi"
+      RbVmomi::VIM::VirtualMachine(nil, "vm-1")
+    end
+    let(:vm_name)      { "my-vm" }
+    let(:vm_uuid)      { "eaa1c3e0-e3b4-4811-8929-2fe40929051b" }
+    let(:ipv4_address) { "127.0.1.1" }
+    let(:ipv6_address) { "::ffff:127.0.0.1" }
+    let(:vm_props) do
+      {
+        :config  => {},
+        :guest   => {
+          :ipStack => [],
+          :net     => [
+            RbVmomi::VIM::GuestNicInfo(
+              :ipAddress => [ipv4_address, ipv6_address].compact,
+              :ipConfig  => RbVmomi::VIM::NetIpConfigInfo(
+                :ipAddress => [].tap do |addrs|
+                  addrs << RbVmomi::VIM::NetIpConfigInfoIpAddress(:ipAddress => ipv4_address, :prefixLength => 22) if ipv4_address
+                  addrs << RbVmomi::VIM::NetIpConfigInfoIpAddress(:ipAddress => ipv6_address, :prefixLength => 64) if ipv6_address
+                end
+              )
+            )
+          ]
+        },
+        :name    => vm_name,
+        :summary => {
+          :config => {
+            :uuid       => vm_uuid,
+            :vmPathName => "[Datastore] #{vm_name}/#{vm_name}.vmx"
+          },
+          :guest  => {
+            :ipAddress => ipv4_address || ipv6_address
+          }
+        },
+      }
+    end
+
+    context "with an ipv4 embedded ipv6 address" do
+      let(:ipv4_address) { nil }
+
+      it "sets the subnet_mask" do
+        parser.parse_virtual_machine(rbvmomi_vm, "enter", vm_props)
+
+        expect(persister.networks.data.first.data).to include(
+          :ipaddress   => ipv4_address,
+          :ipv6address => ipv6_address,
+          :subnet_mask => "ffff:ffff:ffff:ffff::"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Some ipv6 addresses can match the previous Regex testing for ipv4 addresses because there was no start of string anchor.  This meant that `"::ffff:127.0.1.1"` would match which was causing the subnet mask calculation to fail because the prefix length was >32.

```
[IPAddr::InvalidPrefixError]: invalid length
[----] E, [2020-12-09T17:18:51.415341 #182226:2b1548fb2e84] ERROR -- : /usr/share/ruby/ipaddr.rb:520:in `mask!'
/usr/share/ruby/ipaddr.rb:161:in `mask'
```

The subnet mask calculation was added in https://github.com/ManageIQ/manageiq-providers-vmware/pull/591 but the regex for partitioning ipv4/ipv6 goes way back to the old legacy refresh parser.

Fixes https://github.com/ManageIQ/manageiq-providers-vmware/issues/676