### PR TITLE
Fix undefined local variable in host reconnect block

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
@@ -105,7 +105,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister < ManageIQ
           inventory_collection.store_updated_records(record)
         end
 
-        inventory_object.id = record.id
+        obj.id = record.id
       end
     end
   end
@@ -129,7 +129,9 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister < ManageIQ
       vms_by_uid_ems = inventory_objects_index.values.group_by(&:uid_ems).except(nil)
       relation.where(:uid_ems => vms_by_uid_ems.keys).order(:id => :asc).find_each(:batch_size => 100).each do |record|
         inventory_object = vms_by_uid_ems[record.uid_ems].shift
-        hash             = attributes_index.delete(inventory_object.ems_ref)
+        next if inventory_object.nil?
+
+        hash = attributes_index.delete(inventory_object.ems_ref)
         inventory_objects_index.delete(inventory_object.ems_ref)
 
         # Skip if hash is blank, which can happen when having several archived entities with the same ref

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -449,6 +449,8 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
 
         collector.send(:parse_updates, vim, parser, updated_objects)
         collector.send(:save_inventory, persister)
+
+        expect(ems.reload.last_refresh_error).to be_nil
       end
 
       def targeted_update_set(object_updates)
@@ -949,6 +951,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
 
     def run_full_refresh
       collector.refresh
+      expect(ems.reload.last_refresh_error).to be_nil
     end
 
     def assert_ems


### PR DESCRIPTION
This was actually failing in the specs but we had already reconnected the host so the test passed and we weren't checking that the refresh succeeded.

After adding the `expect(ems.reload.last_refresh_error).to be_nil` these specs fail with:
```
  5) ManageIQ::Providers::Vmware::InfraManager::Refresher#monitor_updates targeted refresh reconnecting a host with a hostname reconnects the host
     Failure/Error: expect(ems.reload.last_refresh_error).to be_nil
     
       expected: nil
            got: "undefined local variable or method `inventory_object' for #<ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister::Targeted:0x0000562d4a71b538>\nDid you mean?  inventory_collections"
```

This also fixes a vm reconnect bug with multiple duplicate uuids found by checking last_refresh_error:
```
  1) ManageIQ::Providers::Vmware::InfraManager::Refresher#monitor_updates targeted refresh reconnecting a virtual machine two vms with duplicate uuids reconnects the older vm
     Failure/Error: expect(ems.reload.last_refresh_error).to be_nil
     
       expected: nil
            got: "undefined method `ems_ref' for nil:NilClass"
```

Fixes https://github.com/ManageIQ/manageiq-providers-vmware/issues/678