### PR TITLE
Fix shadowed exceptions

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/host_esx.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/host_esx.rb
@@ -139,10 +139,10 @@ class ManageIQ::Providers::Vmware::InfraManager::HostEsx < ManageIQ::Providers::
         hashes = sp.parse_data_hostd(vim)
         EventLog.add_elements(self, hashes)
       end
-    rescue => err
-      _log.log_backtrace(err)
     rescue Timeout::Error
       _log.warn "Timeout encountered during log collection for Host [#{name}]"
+    rescue => err
+      _log.log_backtrace(err)
     ensure
       vim.disconnect rescue nil
     end
@@ -172,5 +172,5 @@ class ManageIQ::Providers::Vmware::InfraManager::HostEsx < ManageIQ::Providers::
   def thumbprint_sha1
     require 'VMwareWebService/esx_thumb_print'
     ESXThumbPrint.new(ipaddress, authentication_userid, authentication_password).to_sha1
-  end 
+  end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/scanning/job.rb
@@ -49,10 +49,6 @@ class ManageIQ::Providers::Vmware::InfraManager::Scanning::Job < VmScan
         end
       end
       signal(:snapshot_complete)
-    rescue => err
-      _log.log_backtrace(err)
-      signal(:abort, err.message, "error")
-      return
     rescue Timeout::Error
       msg = case options[:snapshot]
             when :smartProxy, :skipped then "Request to log snapshot user event with EMS timed out."
@@ -60,6 +56,10 @@ class ManageIQ::Providers::Vmware::InfraManager::Scanning::Job < VmScan
             end
       _log.error(msg)
       signal(:abort, msg, "error")
+    rescue => err
+      _log.log_backtrace(err)
+      signal(:abort, err.message, "error")
+      return
     end
   end
 
@@ -132,12 +132,12 @@ class ManageIQ::Providers::Vmware::InfraManager::Scanning::Job < VmScan
         _log.info("Deleting snapshot: reference: [#{mor}]")
         begin
           delete_snapshot(mor)
-        rescue => err
-          _log.error(err.to_s)
-          return
         rescue Timeout::Error
           msg = "Request to delete snapshot timed out"
           _log.error(msg)
+        rescue => err
+          _log.error(err.to_s)
+          return
         end
 
         unless options[:snapshot] == :smartProxy

--- a/app/models/manageiq/providers/vmware/infra_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/scanning/job.rb
@@ -59,7 +59,6 @@ class ManageIQ::Providers::Vmware::InfraManager::Scanning::Job < VmScan
     rescue => err
       _log.log_backtrace(err)
       signal(:abort, err.message, "error")
-      return
     end
   end
 


### PR DESCRIPTION
There's a few shadowed exceptions that the rubocop linter pointed out. Specifically, the code is rescuing `StandardError` before rescuing `Timeout::Error`, but since the latter is a subclass of the former, it would never hit that clause. This simple script demonstrates the issue if you run it:

```
require 'timeout'

begin
  raise Timeout::Error
rescue
  puts "Are we in the first rescue?" # Yep
rescue Timeout::Error
  puts "Or the second one?" # Nope
end
```