### PR TITLE
VM#destroyed? is overriding a core active_record method

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/disconnect.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/disconnect.rb
@@ -4,14 +4,14 @@ module ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared::Disconnect
   def disconnect_storage
     # If the VM was unregistered don't clear the storage because the disks
     # are still on the underlying datastore
-    super unless unregistered?
+    super unless vm_unregistered?
   end
 
-  def destroyed?
+  def vm_destroyed?
     disconnect_events.last&.event_type == "DestroyVM_Task_Complete"
   end
 
-  def unregistered?
+  def vm_unregistered?
     disconnect_events.last&.event_type == "UnregisterVM_Complete"
   end
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -171,6 +171,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
 
       it "deleting a virtual machine" do
         vm = ems.vms.find_by(:ems_ref => 'vm-107')
+        vm.ems_events.create!(:event_type => "DestroyVM_Task_Complete")
 
         expect(vm.archived?).to be_falsy
         run_targeted_refresh(targeted_update_set(vm_delete_object_updates))


### PR DESCRIPTION
We have methods called `destroyed?` and `unregistered?` to help us decide if we should disconnect the storage or not (aka archive vs orphan) the vm when disconnecting it.

`destroyed?` is too general of a name and actually overrides a method in the core active_record persistence layer [[ref]](https://github.com/rails/rails/blob/562dd0494a90d9d47849f052e8913f0050f3e494/activerecord/lib/active_record/persistence.rb#L226-L229)

This was "okay" until rails v5.2.0 which added [[ref]](https://github.com/rails/rails/commit/562dd0494a9#diff-11b42664eb9834972953ecd5725c75fd6020af6d4ee5da37ef6d8e0c146f7773R697):
```
    def create_or_update(*args, &block)
      _raise_readonly_record_error if readonly?
      return false if destroyed?
      result = new_record? ? _create_record(&block) : _update_record(*args, &block)
      result != false
    end
```

This caused all updates to Vmware VMs to call our overridden `destroyed?` method instead of checking the `@destroyed` ivar.

If a VM did have a DestroyVM_Task_Complete even it would prevent any updates to the vm, which resulted in the VM never being able to be archived. with:
```
vm.save!
   (0.2ms)  ROLLBACK
Traceback (most recent call last):
        1: from activerecord (5.2.4.4) lib/active_record/persistence.rb:308:in `save!'
ActiveRecord::RecordNotSaved (Failed to save the record
```