### PR TITLE
Ensure all OperationsWorker connections create monitor_updates thread

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/operations_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/operations_worker/runner.rb
@@ -4,9 +4,11 @@ class ManageIQ::Providers::Vmware::InfraManager::OperationsWorker::Runner < Mana
 
     # Set the cache_scope to minimal for ems_operations
     MiqVim.cacheScope = :cache_scope_core
+    MiqVim.monitor_updates = true
+    MiqVim.pre_load = true
 
     # Prime the cache before starting the do_work loop
-    ems.connect(:monitor_updates => true, :pre_load => true)
+    ems.connect
   end
 
   def before_exit(_message, _exit_code)

--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fog-vcloud-director",    "~> 0.3.0"
   spec.add_dependency "ffi-vix_disk_lib",       "~>1.1"
   spec.add_dependency "rbvmomi",                "~>3.0"
-  spec.add_dependency "vmware_web_service",     "~>2.0.2"
+  spec.add_dependency "vmware_web_service",     "~>2.1.0"
   spec.add_dependency "vsphere-automation-sdk", "~>0.4.7"
 
   spec.add_development_dependency "manageiq-style"

--- a/spec/models/manageiq/providers/vmware/infra_manager/operations_worker/runner_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/operations_worker/runner_spec.rb
@@ -1,0 +1,41 @@
+describe ManageIQ::Providers::Vmware::InfraManager::OperationsWorker::Runner do
+  let(:ems)    { FactoryBot.create(:ems_vmware_with_authentication, :hostname => "hostname") }
+  let(:runner) { ManageIQ::Providers::Vmware::InfraManager::OperationsWorker::Runner.new(:ems_id => ems.id) }
+
+  # TODO: need a better way to create a runner for testing without the following mocks
+  # And the runner can be reloaded between tests
+  before do
+    allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive(:authentication_check).and_return([true, ""])
+    allow_any_instance_of(MiqWorker::Runner).to receive(:worker_initialization)
+  end
+
+  describe "#do_before_work_loop" do
+    # The operations worker changes the class-level setting of monitor_updates,
+    # we have to put back the previous values so as to not break other tests
+    around do |example|
+      require "VMwareWebService/MiqVim"
+      saved_monitor_updates = MiqVim.monitor_updates
+      saved_pre_load = MiqVim.pre_load
+
+      example.run
+    ensure
+      MiqVim.monitor_updates = saved_monitor_updates
+      MiqVim.pre_load = saved_pre_load
+    end
+
+    before do
+      require "VMwareWebService/MiqVim"
+      expect(MiqVim)
+        .to receive(:new)
+        .with(ems.hostname, ems.auth_user_pwd.first, ems.auth_user_pwd.last, nil, nil, nil)
+        .and_return(nil)
+    end
+
+    it "preloads the cache" do
+      runner.do_before_work_loop
+
+      expect(MiqVim.pre_load).to be_truthy
+      expect(MiqVim.monitor_updates).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
If the cached connection dies and has to be re-created we have to ensure that the new connection also creates a monitor_updates thread.

Depends:
- [x] https://github.com/ManageIQ/vmware_web_service/pull/93