### PR TITLE
Move Scanning#start_scan to core

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/scanning/job.rb
@@ -233,11 +233,6 @@ class ManageIQ::Providers::Vmware::InfraManager::Scanning::Job < VmScan
     end
   end
 
-  def start_scan
-    scanning
-    call_scan
-  end
-
   # All other signals
   alias_method :start_snapshot,     :call_snapshot_create
   alias_method :snapshot_delete,    :call_snapshot_delete


### PR DESCRIPTION
The start_scan method is being moved up to the base `VmScan` class so we don't need to override it here.

Depends on: https://github.com/ManageIQ/manageiq/pull/20953