### PR TITLE
Clear cached tags after finishing a full refresh

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -102,6 +102,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
     save_inventory(persister)
 
     self.last_full_refresh = Time.now.utc
+    clear_cis_taggings
 
     version
   end
@@ -342,6 +343,12 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
         tag_ids_by_attached_object[obj.type][obj.id] << tag.id
       end
     end
+  end
+
+  # These are only collected for full refreshes, after a full they can be cleared
+  # to free up memory and prevent targeted refreshes from trying to map labels
+  def clear_cis_taggings
+    self.categories_by_id = self.tags_by_id = self.tag_ids_by_attached_object = nil
   end
 
   def parse_storage_profiles(vim, parser)

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -359,7 +359,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
           :section  => "custom_field",
           :name     => key_to_name[cv.key],
           :value    => cv.value,
-          :source   => "VC",
+          :source   => "VC"
         )
       end
     end
@@ -386,7 +386,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
         )
       end.compact
 
-      persister.tag_mapper.map_labels("VmVmware", persister_labels).each do |tag|
+      persister.tag_mapper&.map_labels("VmVmware", persister_labels)&.each do |tag|
         persister.vm_and_template_taggings.build(:taggable => vm, :tag => tag)
       end
     end

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -66,14 +66,14 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
         let!(:env_tag_mapping)         { FactoryBot.create(:tag_mapping_with_category, :label_name => "Category1") }
         let(:env_tag_mapping_category) { env_tag_mapping.tag.classification }
 
-        before do
-          collector.categories_by_id           = {category.id => category}
-          collector.tags_by_id                 = {tag.id => tag}
-          collector.tag_ids_by_attached_object = {"VirtualMachine" => {"vm-21" => [tag.id]}}
-        end
-
         it "saves vm labels" do
-          2.times { with_vcr { collector.refresh } }
+          2.times do
+            collector.categories_by_id           = {category.id => category}
+            collector.tags_by_id                 = {tag.id => tag}
+            collector.tag_ids_by_attached_object = {"VirtualMachine" => {"vm-21" => [tag.id]}}
+
+            with_vcr { collector.refresh }
+          end
 
           ems.reload
 


### PR DESCRIPTION
Due to the fact that we can't WaitForUpdates on VMware Tags (thus we have to collect _all_ categories and tags) we only map tags to labels during full refreshes.

Because VMware shares a Collector object between full and targeted refreshes the collected tags were leaking to the targeted refreshes.  Any VMs which had tags and had an update would fail when referencing the persister.tag_mapper because it wasn't initialized.

Fixes https://github.com/ManageIQ/manageiq-providers-vmware/issues/694