### PR TITLE
Move save_inventory thread out of the inventory collector

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -16,7 +16,6 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
   end
 
   def start
-    self.exit_requested = false
     self.vim_thread = vim_collector_thread
   end
 
@@ -26,10 +25,11 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
 
   def stop(join_timeout = 2.minutes)
     _log.info("#{log_header} Monitor updates thread exiting...")
-    self.exit_requested = true
 
     # The WaitOptions for WaitForUpdatesEx call sets maxWaitSeconds to 60 seconds
-    vim_thread&.join(join_timeout) if join_timeout
+    self.exit_requested = true
+    vim_thread&.join(join_timeout)
+    self.exit_requested = false
   end
 
   def restart(join_timeout = 2.minutes)

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -32,7 +32,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
     return if join_timeout.nil?
 
     # The WaitOptions for WaitForUpdatesEx call sets maxWaitSeconds to 60 seconds
-    vim_thread&.join(join_timeout)
+    vim_thread&.join(join_timeout) if vim_thread&.alive?
     saver.stop_thread
   end
 

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/saver.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/saver.rb
@@ -1,11 +1,11 @@
 class ManageIQ::Providers::Vmware::InfraManager::Inventory::Saver
   include Vmdb::Logging
 
-  def initialize
+  def initialize(threaded: true)
     @join_limit  = 30
     @queue       = Queue.new
     @should_exit = Concurrent::AtomicBoolean.new
-    @threaded    = ENV["RAILS_ENV"] != "test"
+    @threaded    = threaded
     @thread      = nil
   end
 

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
@@ -9,7 +9,7 @@ class ManageIQ::Providers::Vmware::InfraManager::RefreshWorker::Runner < ManageI
   end
 
   def do_before_work_loop
-    # No need to queue an initial full refresh if we are streaming
+    start_inventory_collector
   end
 
   def do_work
@@ -34,8 +34,12 @@ class ManageIQ::Providers::Vmware::InfraManager::RefreshWorker::Runner < ManageI
 
   attr_accessor :ems, :collector
 
+  def saver
+    @saver ||= ems.class::Inventory::Saver.new
+  end
+
   def start_inventory_collector
-    self.collector = ems.class::Inventory::Collector.new(ems)
+    self.collector = ems.class::Inventory::Collector.new(ems, saver)
     collector.start
     _log.info("Started inventory collector")
   end
@@ -44,8 +48,7 @@ class ManageIQ::Providers::Vmware::InfraManager::RefreshWorker::Runner < ManageI
     return if collector&.running?
 
     _log.warn("Inventory collector thread not running, restarting...") unless collector.nil?
-    stop_inventory_collector
-    start_inventory_collector
+    restart_inventory_collector
   end
 
   def stop_inventory_collector

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
@@ -44,6 +44,7 @@ class ManageIQ::Providers::Vmware::InfraManager::RefreshWorker::Runner < ManageI
     return if collector&.running?
 
     _log.warn("Inventory collector thread not running, restarting...") unless collector.nil?
+    stop_inventory_collector
     start_inventory_collector
   end
 

--- a/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
@@ -5,10 +5,9 @@ module ManageIQ::Providers
   module Vmware
     class InfraManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
       def refresh
-        collector_klass = ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
-
         ems_by_ems_id.each do |_ems_id, ems|
-          collector = collector_klass.new(ems)
+          saver     = ems.class::Inventory::Saver.new(:threaded => false)
+          collector = ems.class::Inventory::Collector.new(ems, saver)
           collector.refresh
         end
       end

--- a/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
@@ -4,7 +4,17 @@ require 'http-access2' # Required in case it is not already loaded
 module ManageIQ::Providers
   module Vmware
     class InfraManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
+      # This is a helper method to allow for developers to run a full refresh from
+      # a rails console with the typical `EmsRefresh.refresh(ems)` pattern.
+      #
+      # In production this is not used as the RefreshWorker processes full refreshes
+      # directly by restarting the collector thread, not by actually calling #refresh.
+      #
+      # If you need to force a full refresh in production mode you can still queue a full
+      # refresh with `EmsRefresh.queue_refresh(ems)` or `ems.queue_refresh`
       def refresh
+        raise NotImplementedError, "not implemented in production mode" if Rails.env.production?
+
         ems_by_ems_id.each do |_ems_id, ems|
           saver     = ems.class::Inventory::Saver.new(:threaded => false)
           collector = ems.class::Inventory::Collector.new(ems, saver)

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/parser_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/parser_spec.rb
@@ -1,6 +1,7 @@
 describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser do
   let(:ems)       { FactoryBot.create(:ems_vmware) }
-  let(:collector) { ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector.new(ems) }
+  let(:saver)     { ManageIQ::Providers::Vmware::InfraManager::Inventory::Saver.new(:threaded => false) }
+  let(:collector) { ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector.new(ems, saver) }
   let(:persister) { ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister::Targeted.new(ems) }
   let(:parser)    { described_class.new(collector, persister) }
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -16,7 +16,8 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       ems.update_authentication(:default => {:userid => username, :password => password})
     end
   end
-  let(:collector) { ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector.new(ems) }
+  let(:saver)     { ManageIQ::Providers::Vmware::InfraManager::Inventory::Saver.new(:threaded => false) }
+  let(:collector) { ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector.new(ems, saver) }
 
   context "#monitor_updates" do
     context "full refresh" do


### PR DESCRIPTION
Noticed this while digging into https://github.com/ManageIQ/manageiq-providers-vmware/pull/695

If the collector thread dies and we restart the collector we have to make sure the old saver_thread is stopped as well otherwise we'll leak a thread and database connection

If the collector thread fails enough times eventually you'll end up with:
```
[----] E, [2021-02-10T13:12:41.821381 #76064:38cfc] ERROR -- : MIQ(ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector#vim_collector) EMS: [dev-vc67], id: [4] Refresh failed
[----] E, [2021-02-10T13:12:41.821751 #76064:38cfc] ERROR -- : [ActiveRecord::ConnectionTimeoutError]: could not obtain a connection from the pool within 5.000 seconds (waited 5.000 seconds); all pooled connections were in use  Method:[block (2 levels) in <class:LogProxy>]
[----] E, [2021-02-10T13:12:41.822180 #76064:38cfc] ERROR -- : /home/grare/adam/.gem/gems/activerecord-6.0.3.4/lib/active_record/connection_adapters/abstract/connection_pool.rb:221:in `block in wait_poll'
```