### PR TITLE
Collect VM Disk Latency Metrics

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/metrics_capture.rb
@@ -98,6 +98,10 @@ class ManageIQ::Providers::Vmware::InfraManager::MetricsCapture < ManageIQ::Prov
       stats    = c['statsType'].to_s.downcase
       unit_key = c.fetch_path('unitInfo', 'key').to_s.downcase
 
+      # VM disk info is primarily in the "virtualdisk" group where hosts use the
+      # "disk" group.
+      group = "disk" if group == "virtualdisk"
+
       counter_key = "#{group}_#{name}_#{stats}_#{rollup}"
 
       # Filter the metrics for only the cols we will use


### PR DESCRIPTION
VM disk latency is in the "virtualdisk" group not the "disk" group like we are expecting.

In addition the latency metrics have been split up between read and write so we are currently only requesting "disk_devicelatency_absolute_average" where the actual disk latency metrics are called "virtualdisk_totalwritelatency_absolute_average" and "virtualdisk_totalreadlatency_absolute_average"

Depends:
- [x] https://github.com/ManageIQ/manageiq-schema/pull/563

Fixes https://github.com/ManageIQ/manageiq-providers-vmware/issues/688