### PR TITLE
Clarified ambiguous error message for Hot-Adding memory past the memory_hot_add_limit

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
@@ -65,9 +65,9 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure
       if options[:vm_memory]
         vm_memory = options[:vm_memory].to_i
 
-        raise MiqException::MiqVmError, "Memory Hot-Add not enabled"                                if vm_memory > ram_size && !memory_hot_add_enabled
-        raise MiqException::MiqVmError, "Cannot add more than #{memory_hot_add_limit}MB to this VM" if vm_memory > ram_size && vm_memory > memory_hot_add_limit
-        raise MiqException::MiqVmError, "Cannot remove memory from a running VM"                    if vm_memory < ram_size
+        raise MiqException::MiqVmError, "Memory Hot-Add not enabled"                                                    if vm_memory > ram_size && !memory_hot_add_enabled
+        raise MiqException::MiqVmError, "Cannot add more than #{memory_hot_add_limit}MB to this VM while it is running" if vm_memory > ram_size && vm_memory > memory_hot_add_limit
+        raise MiqException::MiqVmError, "Cannot remove memory from a running VM"                                        if vm_memory < ram_size
       end
     end
   end

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
@@ -173,7 +173,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
         it "raises an exception if adding more than the memory limit" do
           options[:vm_memory] = '4096'
 
-          expect { subject }.to raise_error(MiqException::MiqVmError, "Cannot add more than 2048MB to this VM")
+          expect { subject }.to raise_error(MiqException::MiqVmError, "Cannot add more than 2048MB to this VM while it is running")
         end
 
         it "sets memoryMB correctly" do


### PR DESCRIPTION
The current message is somewhat unclear for users (and gets passed through verbatim to ManageIQ users/tenants). All other similar hot-add related messages clearly indicate that the running state of the machine is part of the reason why the change failed except for this one.