### PR TITLE
Fix refresh failure of PbmDefaultCapabilityProfile

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -339,7 +339,8 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
       :profile_type => props[:profileCategory]
     )
   end
-  alias parse_pbm_capability_profile parse_pbm_profile
+  alias parse_pbm_capability_profile         parse_pbm_profile
+  alias parse_pbm_default_capability_profile parse_pbm_profile
 
   def parse_pbm_placement_hub(persister_storage_profile, _object, _kind, props)
     persister_storage = persister.storages.lazy_find(props[:hubId])


### PR DESCRIPTION
The PbmDefaultCapabilityProfile [[ref]](https://vdc-download.vmware.com/vmwb-repository/dcr-public/8e6af87a-b054-416d-8b61-aa9fba096944/617db479-aee6-4717-a94c-8bddd19785b9/pbm.profile.DefaultCapabilityBasedProfile.html) extends the PbmCapabilityProfile [[ref]](https://vdc-download.vmware.com/vmwb-repository/dcr-public/8e6af87a-b054-416d-8b61-aa9fba096944/617db479-aee6-4717-a94c-8bddd19785b9/pbm.profile.CapabilityBasedProfile.html) (which extends the PbmProfile).  This means we need to alias the parser for the base pbm_profile to include the default capability profile.