### PR TITLE
Allow setting cpu/memory hot add/remove during provision

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/container.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/container.rb
@@ -42,6 +42,10 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration::Cont
         end
       end
 
+      set_spec_option(vmcs, :cpuHotAddEnabled, :cpu_hot_add, nil, :to_s)
+      set_spec_option(vmcs, :cpuHotRemoveEnabled, :cpu_hot_remove, nil, :to_s)
+      set_spec_option(vmcs, :memoryHotAddEnabled, :memory_hot_add, nil, :to_s)
+
       build_config_network_adapters(vmcs)
       build_config_disk_spec(vmcs)
     end

--- a/content/miq_dialogs/miq_provision_vmware_cluster_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_cluster_dialogs_template.yaml
@@ -678,6 +678,33 @@
           :display: :edit
           :data_type: :integer
           :validation_method: :validate_memory_reservation
+        :cpu_hot_add:
+          :values:
+            false: 0
+            true: 1
+          :description: Enable CPU Hot Add
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :cpu_hot_remove:
+          :values:
+            false: 0
+            true: 1
+          :description: Enable CPU Hot Remove
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :memory_hot_add:
+          :values:
+            false: 0
+            true: 1
+          :description: Enable Memory Hot Add
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
         :network_adapters:
           :values:
             1: "1"

--- a/content/miq_dialogs/miq_provision_vmware_dialogs_clone_to_template.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_dialogs_clone_to_template.yaml
@@ -715,6 +715,33 @@
           :display: :edit
           :data_type: :integer
           :validation_method: :validate_memory_reservation
+        :cpu_hot_add:
+          :values:
+            false: 0
+            true: 1
+          :description: Enable CPU Hot Add
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :cpu_hot_remove:
+          :values:
+            false: 0
+            true: 1
+          :description: Enable CPU Hot Remove
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :memory_hot_add:
+          :values:
+            false: 0
+            true: 1
+          :description: Enable Memory Hot Add
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
         :network_adapters:
           :values:
             1: "1"

--- a/content/miq_dialogs/miq_provision_vmware_dialogs_clone_to_vm.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_dialogs_clone_to_vm.yaml
@@ -724,6 +724,33 @@
           :display: :edit
           :data_type: :integer
           :validation_method: :validate_memory_reservation
+        :cpu_hot_add:
+          :values:
+            false: 0
+            true: 1
+          :description: Enable CPU Hot Add
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :cpu_hot_remove:
+          :values:
+            false: 0
+            true: 1
+          :description: Enable CPU Hot Remove
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :memory_hot_add:
+          :values:
+            false: 0
+            true: 1
+          :description: Enable Memory Hot Add
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
         :network_adapters:
           :values:
             1: "1"

--- a/content/miq_dialogs/miq_provision_vmware_dialogs_ovf.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_dialogs_ovf.yaml
@@ -740,6 +740,33 @@
           :display: :edit
           :data_type: :integer
           :validation_method: :validate_memory_reservation
+        :cpu_hot_add:
+          :values:
+            false: 0
+            true: 1
+          :description: Enable CPU Hot Add
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :cpu_hot_remove:
+          :values:
+            false: 0
+            true: 1
+          :description: Enable CPU Hot Remove
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :memory_hot_add:
+          :values:
+            false: 0
+            true: 1
+          :description: Enable Memory Hot Add
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
         :network_adapters:
           :values:
             1: "1"

--- a/content/miq_dialogs/miq_provision_vmware_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_dialogs_template.yaml
@@ -756,6 +756,33 @@
           :display: :edit
           :data_type: :integer
           :validation_method: :validate_memory_reservation
+        :cpu_hot_add:
+          :values:
+            false: 0
+            true: 1
+          :description: Enable CPU Hot Add
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :cpu_hot_remove:
+          :values:
+            false: 0
+            true: 1
+          :description: Enable CPU Hot Remove
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :memory_hot_add:
+          :values:
+            false: 0
+            true: 1
+          :description: Enable Memory Hot Add
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
         :network_adapters:
           :values:
             1: "1"

--- a/content/miq_dialogs/miq_provision_vmware_folder_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_folder_dialogs_template.yaml
@@ -668,6 +668,33 @@
           :display: :edit
           :data_type: :integer
           :validation_method: :validate_memory_reservation
+        :cpu_hot_add:
+          :values:
+            false: 0
+            true: 1
+          :description: Enable CPU Hot Add
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :cpu_hot_remove:
+          :values:
+            false: 0
+            true: 1
+          :description: Enable CPU Hot Remove
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :memory_hot_add:
+          :values:
+            false: 0
+            true: 1
+          :description: Enable Memory Hot Add
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
         :network_adapters:
           :values:
             1: "1"


### PR DESCRIPTION
These settings control if the VM is able to have cpus added/removed and memory added while the vm is running.

These can only be reconfigured while the vm is powered down so setting these during provisioning removes the need for downtime in the future if this has to be enabled.

![Screenshot from 2021-06-09 14-29-35](https://user-images.githubusercontent.com/12851112/121409189-354fcc00-c92f-11eb-848d-fdbc8b5ccbab.png)
