### PR TITLE
Drop logic required due to old vSphere versions

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -255,13 +255,11 @@ module ManageIQ::Providers
 
     def validate_remote_console_vmrc_support
       raise(MiqException::RemoteConsoleNotSupportedError, "vCenter needs to be refreshed to determine VMRC remote console support.")   unless self.remote_console_vmrc_support_known?
-      raise(MiqException::RemoteConsoleNotSupportedError, "vCenter version #{api_version} does not support VMRC remote console.") unless api_version >= "4.1"
-      raise(MiqException::RemoteConsoleNotSupportedError, "vCenter versions earlier than 5.x are not supported.  Found version #{api_version}.") unless api_version >= "5."
       true
     end
 
     def validate_remote_console_webmks_support
-      raise(MiqException::RemoteConsoleNotSupportedError, "vCenter version #{api_version} does not support WebMKS remote console.") unless api_version >= "6.0"
+      true
     end
 
     def after_update_authentication

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
@@ -66,10 +66,6 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
   end
 
   def dest_storage_profile
-    # Storage Profiles were added in vSphere 5.5 so make sure we
-    # don't send newer api types to an older vCenter
-    return nil if source.ext_management_system.api_version < '5.5'
-
     storage_profile_id = get_option(:placement_storage_profile)
     StorageProfile.find_by(:id => storage_profile_id) unless storage_profile_id.nil?
   end

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/container.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/container.rb
@@ -121,10 +121,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration::Cont
 
       # Only explicitly disable #MemoryReservationLockedToMax if the memory reserve
       # is less than the total vm memory
-      if get_option(:memory_reserve).to_i < get_option(:vm_memory).to_i
-        # memoryReservationLockedToMax was added in vSphere 5.0
-        vmcs.memoryReservationLockedToMax = false if source.ext_management_system.api_version >= '5.0'
-      end
+      vmcs.memoryReservationLockedToMax = false if get_option(:memory_reserve).to_i < get_option(:vm_memory).to_i
     end
 
     _log.info("Calling VM reconfiguration")

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
@@ -83,8 +83,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole
   # HTML5 selects the best available console type (VNC or WebMKS)
   #
   def remote_console_html5_acquire_ticket(userid, originating_server = nil)
-    protocol = 'vnc' if ext_management_system.api_version.to_f < 6.0 # Force VNC protocol for API version lower than 6.0
-    protocol ||= with_provider_object { |v| v.extraConfig["RemoteDisplay.vnc.enabled"] == "true" } ? 'vnc' : 'webmks'
+    protocol = with_provider_object { |v| v.extraConfig["RemoteDisplay.vnc.enabled"] == "true" } ? 'vnc' : 'webmks'
     send("remote_console_#{protocol}_acquire_ticket", userid, originating_server)
   end
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
@@ -279,12 +279,6 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
           expect(@vm_prov.dest_storage_profile).to be_nil
         end
 
-        it "returns nil if ems api_version < 5.5" do
-          @vm_prov.source.ext_management_system.api_version = '5.1'
-          @vm_prov.options[:placement_storage_profile] = [storage_profile.id, storage_profile.name]
-          expect(@vm_prov.dest_storage_profile).to be_nil
-        end
-
         it "returns a storage profile" do
           @vm_prov.options[:placement_storage_profile] = [storage_profile.id, storage_profile.name]
           expect(@vm_prov.dest_storage_profile).to eq(storage_profile)

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/remote_console_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/remote_console_spec.rb
@@ -146,11 +146,6 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
       vm.update_attribute(:raw_power_state, 'poweredOff')
       expect { vm.validate_remote_console_webmks_support }.to raise_error MiqException::RemoteConsoleNotSupportedError
     end
-
-    it 'on VC 5.5' do
-      ems.update_attribute(:api_version, '5.5')
-      expect { vm.validate_remote_console_webmks_support }.to raise_error MiqException::RemoteConsoleNotSupportedError
-    end
   end
 
   context '#remote_console_vmrc_acquire_ticket' do
@@ -200,11 +195,6 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
 
     it 'with vm off' do
       vm.update_attribute(:raw_power_state, 'poweredOff')
-      expect { vm.validate_remote_console_vmrc_support }.to raise_error MiqException::RemoteConsoleNotSupportedError
-    end
-
-    it 'on VC 4.0' do
-      ems.update_attribute(:api_version, '4.0')
       expect { vm.validate_remote_console_vmrc_support }.to raise_error MiqException::RemoteConsoleNotSupportedError
     end
   end

--- a/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
@@ -144,21 +144,6 @@ describe ManageIQ::Providers::Vmware::InfraManager do
       @ems = FactoryBot.create(:ems_vmware)
     end
 
-    it "not raise for api_version == 5.0" do
-      @ems.update(:api_version => "5.0", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
-      expect { @ems.validate_remote_console_vmrc_support }.not_to raise_error
-    end
-
-    it "raise for api_version == 4.0" do
-      @ems.update(:api_version => "4.0", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
-      expect { @ems.validate_remote_console_vmrc_support }.to raise_error MiqException::RemoteConsoleNotSupportedError
-    end
-
-    it "raise for api_version == 4.1" do
-      @ems.update(:api_version => "4.1", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
-      expect { @ems.validate_remote_console_vmrc_support }.to raise_error MiqException::RemoteConsoleNotSupportedError
-    end
-
     it "raise for missing/blank values" do
       @ems.update(:api_version => "", :uid_ems => "2E1C1E82-BD83-4E54-9271-630C6DFAD4D1")
       expect { @ems.validate_remote_console_vmrc_support }.to raise_error MiqException::RemoteConsoleNotSupportedError


### PR DESCRIPTION
Now that we depend on >= 6.0 we can remove some logic which was handling old versions