### PR TITLE
Add support for changing the vSphere port

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/cis_connect_mixin.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/cis_connect_mixin.rb
@@ -5,7 +5,7 @@ module ManageIQ::Providers::Vmware::InfraManager::CisConnectMixin
     require 'vsphere-automation-cis'
 
     configuration = VSphereAutomation::Configuration.new.tap do |c|
-      c.host = hostname
+      c.host = "#{hostname}:#{port || 443}"
       c.username = auth_user_pwd.first
       c.password = auth_user_pwd.last
       c.scheme = 'https'

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -124,6 +124,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
 
   def vim_connect
     host = ems.hostname
+    port = ems.port || 443
     username, password = ems.auth_user_pwd
 
     _log.info("#{log_header} Connecting to #{username}@#{host}...")
@@ -134,7 +135,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
       :ssl      => true,
       :insecure => true,
       :path     => '/sdk',
-      :port     => 443,
+      :port     => port,
       :rev      => '6.5',
     }
 
@@ -150,7 +151,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
 
   def pbm_connect(vim)
     require "rbvmomi/pbm"
-    RbVmomi::PBM.connect(vim, :insecure => true)
+    RbVmomi::PBM.connect(vim, :port => vim.http.port, :insecure => true)
   end
 
   def cis_connect(vim)


### PR DESCRIPTION
This makes it simpler to use the govmomi vcsimulator which by default uses port 8989 and which would require running as root to bind to 443 in order for MIQ to use it as is.

This also opens up options for connecting to a vSphere over a port-mapper proxy or other intermediary

Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/736