### PR TITLE
Updates for VMwareWebService v3.0 with kwargs

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/event_catcher/runner.rb
@@ -2,12 +2,12 @@ class ManageIQ::Providers::Vmware::InfraManager::EventCatcher::Runner < ManageIQ
   def event_monitor_handle
     require 'VMwareWebService/MiqVimEventMonitor'
     @event_monitor_handle ||= MiqVimEventMonitor.new(
-      @ems.hostname,
-      @ems.authentication_userid,
-      @ems.authentication_password,
-      nil,
-      worker_settings[:ems_event_page_size],
-      worker_settings[:ems_event_max_wait])
+      :server    => @ems.hostname,
+      :username  => @ems.authentication_userid,
+      :password  => @ems.authentication_password,
+      :page_size => worker_settings[:ems_event_page_size],
+      :max_wait  => worker_settings[:ems_event_max_wait]
+    )
   end
 
   def reset_event_monitor_handle

--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fog-vcloud-director",    "~> 0.3.0"
   spec.add_dependency "ffi-vix_disk_lib",       "~>1.1"
   spec.add_dependency "rbvmomi",                "~>3.0"
-  spec.add_dependency "vmware_web_service",     "~>2.1.0"
+  spec.add_dependency "vmware_web_service",     "~>3.0"
   spec.add_dependency "vsphere-automation-sdk", "~>0.4.7"
 
   spec.add_development_dependency "manageiq-style"

--- a/spec/models/manageiq/providers/vmware/infra_manager/operations_worker/runner_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/operations_worker/runner_spec.rb
@@ -27,7 +27,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::OperationsWorker::Runner do
       require "VMwareWebService/MiqVim"
       expect(MiqVim)
         .to receive(:new)
-        .with(ems.hostname, ems.auth_user_pwd.first, ems.auth_user_pwd.last, nil, nil, nil)
+        .with(hash_including(:server => ems.hostname, :username => ems.auth_user_pwd.first, :password => ems.auth_user_pwd.last))
         .and_return(nil)
     end
 

--- a/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
@@ -218,7 +218,7 @@ describe ManageIQ::Providers::Vmware::InfraManager do
 
         vim = mock_miq_vim_connection
 
-        expect(MiqVim).to receive(:new).with(ems.hostname, "readonly", "1234", nil, nil, nil).and_return(vim)
+        expect(MiqVim).to receive(:new).with(hash_including(:server => ems.hostname, :username => "readonly", :password => "1234")).and_return(vim)
         expect(vim).to receive(:acquireCloneTicket)
 
         ems.remote_console_vmrc_acquire_ticket


### PR DESCRIPTION
VMwareWebService v3.0 uses kwargs for MiqVim*.new()

https://github.com/ManageIQ/vmware_web_service/releases/tag/v3.0.0

Cross-Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/450

Depends:
* https://github.com/ManageIQ/manageiq-smartstate/pull/159 and release

Merge Together With:
* https://github.com/ManageIQ/manageiq/pull/21334