### PR TITLE
Handle if the property change target doesn't exist

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector/property_collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector/property_collector.rb
@@ -108,7 +108,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector::Property
       key, array_key = tag_and_key(key)
       if array_key
         array, idx = get_array_entry(h[key], array_key)
-        raise "hashTarget: Could not traverse tree through array element #{k}[#{array_key}] in #{key_string}" unless array
+        raise "hashTarget: Could not traverse tree through array element #{key}[#{array_key}] in #{key_string}" unless array
 
         h = array[idx]
       else
@@ -171,5 +171,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector::Property
         return array, n if entry_key.to_s == key
       end
     end
+
+    return nil, nil
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector/property_collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector/property_collector.rb
@@ -98,6 +98,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector::Property
         h[tag] = prop_change.val
       end
     end
+  rescue => err
+    _log.warn("Failed to process property change #{prop_change.name}: #{err}")
   end
 
   def hash_target(base_hash, key_string)
@@ -108,7 +110,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector::Property
       key, array_key = tag_and_key(key)
       if array_key
         array, idx = get_array_entry(h[key], array_key)
-        raise "hashTarget: Could not traverse tree through array element #{key}[#{array_key}] in #{key_string}" unless array
+        raise "Could not traverse tree through array element #{key}[#{array_key}] in #{key_string}" unless array
 
         h = array[idx]
       else

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/cache_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/cache_spec.rb
@@ -18,21 +18,21 @@ describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Cache do
               :device             => [2000],
               :hotAddRemove       => true,
               :sharedBus          => "noSharing",
-              :scsiCtlrUnitNumber => 7,
+              :scsiCtlrUnitNumber => 7
             ),
             RbVmomi::VIM::VirtualDisk(
-              :key             => 2000,
-              :deviceInfo      => RbVmomi::VIM::Description(:label => "Hard disk 1", :summary => "41,943,040 KB"),
-              :backing         => RbVmomi::VIM::VirtualDiskFlatVer2BackingInfo(
+              :key           => 2000,
+              :deviceInfo    => RbVmomi::VIM::Description(:label => "Hard disk 1", :summary => "41,943,040 KB"),
+              :backing       => RbVmomi::VIM::VirtualDiskFlatVer2BackingInfo(
                 :fileName        => "[datastore] vm1/vm1.vmdk",
                 :datastore       => RbVmomi::VIM::Datastore(nil, "datastore-1"),
                 :diskMode        => "persistent",
                 :thinProvisioned => true,
-                :uuid            => "6000C294-264b-3f91-8e5c-8c2ebac1bfe8",
+                :uuid            => "6000C294-264b-3f91-8e5c-8c2ebac1bfe8"
               ),
-              :controllerKey   => 1000,
-              :unitNumber      => 0,
-              :capacityInKB    => 41_943_040,
+              :controllerKey => 1000,
+              :unitNumber    => 0,
+              :capacityInKB  => 41_943_040
             ),
           ],
         },

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -393,6 +393,21 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
         expect(child_snapshot.parent).to eq(root_snapshot)
       end
 
+      it "datastore mount info with invalid host doesn't fail the refresh" do
+        run_targeted_refresh(
+          targeted_update_set(
+            [
+              RbVmomi::VIM.ObjectUpdate(
+                :kind      => "modify",
+                :obj       => RbVmomi::VIM.Datastore(vim, "datastore-15"),
+                :changeSet => [RbVmomi::VIM.PropertyChange(:name => "host[\"host-garbage\"].mountInfo", :op => "assign", :val => nil)]
+              )
+            ]
+          )
+        )
+        expect(ems.reload.last_refresh_error).to be_nil
+      end
+
       it "renaming a distributed virtual portgroup" do
         lan = ems.distributed_virtual_lans.first
         expect(lan.name).to eq("DC0_DVPG1")


### PR DESCRIPTION
Sometimes vSphere returns a property change for an object that the logged in user doesn't have permission to see.  For example if the user MIQ uses for the refresh is excluded from traversing into a cluster, but a datastore (which exists at the datacenter level, not the cluster level) is mounted to hosts in that cluster then vSphere will return a property change referencing those "non-existent" hosts.

https://github.com/ManageIQ/manageiq-providers-vmware/issues/738