### PR TITLE
Fix VM tags being deleted during targeted refresh

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
@@ -10,8 +10,12 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister < ManageIQ
     add_collection(infra, :distributed_virtual_lans)
     add_collection(infra, :clusters)
     add_collection(infra, :ems_custom_attributes, :parent_inventory_collections => %i[vms_and_templates])
-    add_collection(infra, :vm_and_template_labels, :parent_inventory_collections => %i[vms_and_templates])
-    add_collection(infra, :vm_and_template_taggings, :parent_inventory_collections => %i[vms_and_templates])
+    add_collection(infra, :vm_and_template_labels, :parent_inventory_collections => %i[vms_and_templates]) do |builder|
+      builder.add_properties(:complete => false) if targeted?
+    end
+    add_collection(infra, :vm_and_template_taggings, :parent_inventory_collections => %i[vms_and_templates]) do |builder|
+      builder.add_properties(:complete => false) if targeted?
+    end
     add_collection(infra, :ems_extensions)
     add_collection(infra, :ems_folders)
     add_collection(infra, :ems_licenses)


### PR DESCRIPTION
The vm_and_template_labels and vm_and_template_taggings collections have a parent inventory collection of vms_and_templates, this means that if the target is a vm_or_template that collection is considered "complete" (this is how e.g. associated disks and nics get deleted).

The problem is that we don't get a VM's tags when a VM update is caught since it is a totally separate API call.  The result of this is that it looked like there were 0 tags for the VM when the VM was targeted, causing them all to be cleared until the next full refresh.

We can mark the collection as incomplete if it is a targeted refresh, preventing deletion of tags during a targeted refresh of a VM.

Fixes https://github.com/ManageIQ/manageiq-providers-vmware/issues/740