### PR TITLE
Parse the VM name from the root object

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -378,10 +378,13 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
       return
     end
 
+    name = CGI.unescape(props[:name]) if props[:name]
+
     vm_hash = {
       :ems_ref       => object._ref,
       :ems_ref_type  => object.class.wsdl_name,
       :vendor        => "vmware",
+      :name          => name,
       :parent        => lazy_find_managed_object(props[:parent]),
       :resource_pool => lazy_find_managed_object(props[:resourcePool]),
     }

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/virtual_machine.rb
@@ -54,7 +54,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
         vm_hash[:uid_ems] = clean_guid(uuid) if uuid.present?
 
         name = summary_config[:name]
-        vm_hash[:name] = CGI.unescape(name) if name
+        vm_hash[:name] ||= CGI.unescape(name) if name
 
         pathname = summary_config[:vmPathName]
         begin


### PR DESCRIPTION
Every ManagedObject has a top-level "name" property.  VMs also have a summary.config.name which we were using but the Go VC Sim doesn't report a change to summary.config.name when renaming a VM.

Related to #745