### PR TITLE
Replace rbvmomi with rbvmomi2

### DIFF
--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "fog-vcloud-director",    "~> 0.3.0"
   spec.add_dependency "ffi-vix_disk_lib",       "~>1.1"
-  spec.add_dependency "rbvmomi",                "~>3.0"
+  spec.add_dependency "rbvmomi2",               "~>3.0"
   spec.add_dependency "vmware_web_service",     "~>3.0"
   spec.add_dependency "vsphere-automation-sdk", "~>0.4.7"
 


### PR DESCRIPTION
The vmware/rbvmomi gem has been archived and is no longer receiving updates, switch to ManageIQ/rbvmomi2