### PR TITLE
[MORPHY] Replace rbvmomi with rbvmomi2

### DIFF
--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "fog-vcloud-director",    "~> 0.3.0"
   spec.add_dependency "ffi-vix_disk_lib",       "~>1.1"
-  spec.add_dependency "rbvmomi",                "~>3.0"
+  spec.add_dependency "rbvmomi2",               "~>3.0"
   spec.add_dependency "vmware_web_service",     "~>2.1.0"
   spec.add_dependency "vsphere-automation-sdk", "~>0.4.7"
 


### PR DESCRIPTION
Merge pull request #748 from agrare/switch_to_use_rbvmomi2
Replace rbvmomi with rbvmomi2

(cherry picked from commit 955f191ccb49e70f5aabcebc88079d6bf83ced0f)