### PR TITLE
Only parse and save if there are updates

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -96,13 +96,14 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
   end
 
   def targeted_refresh(vim, property_filter, version)
-    persister = targeted_persister_klass.new(ems)
-    parser    = parser_klass.new(self, persister)
-
     version, updated_objects = monitor_updates(vim, property_filter, version)
+    if updated_objects.any?
+      persister = targeted_persister_klass.new(ems)
+      parser    = parser_klass.new(self, persister)
 
-    parse_updates(vim, parser, updated_objects)
-    save_inventory(persister)
+      parse_updates(vim, parser, updated_objects)
+      save_inventory(persister)
+    end
 
     version
   end


### PR DESCRIPTION
If WaitForUpdates times out without any updates it returns nil and we check to see if we should exit the collector.  We should only parse and save if there were updates returned to prevent needless calls to save inventory which won't have anything to save.