### PR TITLE
Add a UUID to track persister instance

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
@@ -3,7 +3,12 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister < ManageIQ
   require_nested :Full
   require_nested :Targeted
 
+  attr_reader :tracking_uuid
+
   def initialize_inventory_collections
+    # Build a UUID which can be used to track the collection and saving of this persister instance
+    @tracking_uuid = SecureRandom.uuid
+
     add_collection(infra, :customization_specs)
     add_collection(infra, :disks, :parent_inventory_collections => %i[vms_and_templates])
     add_collection(infra, :distributed_virtual_switches)

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/saver.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/saver.rb
@@ -36,6 +36,8 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Saver
   # intend to queue up save_inventory from multiple calling threads a mutex
   # must be added around ensure_saver_thread
   def queue_save_inventory(persister)
+    _log.debug { "queueing save_inventory [#{persister.tracking_uuid}]" }
+
     if threaded
       ensure_saver_thread
       queue.push(persister)
@@ -76,6 +78,8 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Saver
   end
 
   def save_inventory(persister)
+    _log.debug { "running save_inventory [#{persister.tracking_uuid}]" }
+
     save_inventory_start_time = Time.now.utc
     persister.persist!
     update_ems_refresh_stats(persister.manager)


### PR DESCRIPTION
With separate collector and saver threads it can be difficult to tell what logs from the saver thread match up to what object_updates were raised by VMware.

With this change you get context on the collector side:
```
INFO -- evm: MIQ(ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector#process_update_set) EMS: [vc], id: [2] Processing 1 updates...
DEBUG -- evm: MIQ(ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector#log_object_update) EMS: [vc], id: [2] Object: [VirtualMachine:vm-7166] Kind: [modify] Props: [name]
INFO -- evm: MIQ(ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector#process_update_set) EMS: [vc], id: [2] Processing 1 updates...Complete
DEBUG -- evm: MIQ(ManageIQ::Providers::Vmware::InfraManager::Inventory::Saver#queue_save_inventory) queueing save_inventory [96be8174-5cb7-4d2c-85a4-97717fccc0dc]
```

And then on the saver side:
```
DEBUG -- evm: MIQ(ManageIQ::Providers::Vmware::InfraManager::Inventory::Saver#save_inventory) running save_inventory [96be8174-5cb7-4d2c-85a4-97717fccc0dc]
DEBUG -- evm: EMS: [vc], id: [2] Scanning Inventory Collections...StartDEBUG -- evm: EMS: [vc], id: [2] Scanning Inventory Collections...Complete
INFO -- evm: EMS: [vc], id: [2] Saving EMS Inventory...
DEBUG -- evm: Saving manager vc...
DEBUG -- evm: Topological sorting of manager vc resulted in these layers processable in parallel:
digraph {
  subgraph cluster_0 {  label = "Layer 0";
```