### PR TITLE
Skip DV PortGroups with missing DV Switches

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -250,13 +250,19 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
   end
   alias parse_opaque_network parse_network
 
-  def parse_distributed_virtual_portgroup(_object, kind, props)
+  def parse_distributed_virtual_portgroup(object, kind, props)
     dvs = props.fetch_path(:config, :distributedVirtualSwitch)
 
     # If the dvportgroup is deleted we don't want to pass kind="leave" to the
     # switch parser because it will think the switch is being deleted
     kind = "update" if kind == "leave"
-    parse_distributed_virtual_switch(dvs, kind, cache.find(dvs))
+
+    dvs_props = cache.find(dvs)
+    if dvs_props.nil?
+      _log.warn("#{object.class.wsdl_name}:#{object._ref} DVSwitch [#{dvs._ref}] not found in cache...Skipping")
+    else
+      parse_distributed_virtual_switch(dvs, kind, dvs_props)
+    end
   end
 
   def parse_portgroups_internal(object, props)

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -429,6 +429,11 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
         expect(new_dvpg.switch.uid_ems).to eq("dvs-8")
       end
 
+      it "adding a new distributed virtual portgroup with an invalid DVS" do
+        expect { run_targeted_refresh(targeted_update_set([dvpg_create_invalid_object_update])) }
+          .not_to raise_error
+      end
+
       it "deleting a distributed virtual portgroup" do
         run_targeted_refresh(targeted_update_set([dvpg_delete_object_update]))
 
@@ -945,6 +950,23 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
         :obj       => RbVmomi::VIM.DistributedVirtualPortgroup(vim, "dvportgroup-99"),
         :changeSet => [
           RbVmomi::VIM.PropertyChange(:name => "config.distributedVirtualSwitch", :op => "assign", :val => RbVmomi::VIM.VmwareDistributedVirtualSwitch(vim, "dvs-8")),
+          RbVmomi::VIM.PropertyChange(:name => "config.key",                      :op => "assign", :val => "dvportgroup-99"),
+          RbVmomi::VIM.PropertyChange(:name => "config.name",                     :op => "assign", :val => "New DVPG"),
+          RbVmomi::VIM.PropertyChange(:name => "host",                            :op => "assign", :val => []),
+          RbVmomi::VIM.PropertyChange(:name => "parent",                          :op => "assign", :val => RbVmomi::VIM.Folder(vim, "group-n6")),
+          RbVmomi::VIM.PropertyChange(:name => "name",                            :op => "assign", :val => "New DVPG"),
+          RbVmomi::VIM.PropertyChange(:name => "summary.name",                    :op => "assign", :val => "New DVPG"),
+          RbVmomi::VIM.PropertyChange(:name => "tag",                             :op => "assign", :val => [])
+        ]
+      )
+    end
+
+    def dvpg_create_invalid_object_update
+      RbVmomi::VIM.ObjectUpdate(
+        :kind      => "enter",
+        :obj       => RbVmomi::VIM.DistributedVirtualPortgroup(vim, "dvportgroup-99"),
+        :changeSet => [
+          RbVmomi::VIM.PropertyChange(:name => "config.distributedVirtualSwitch", :op => "assign", :val => RbVmomi::VIM.VmwareDistributedVirtualSwitch(vim, "dvs-9999999")),
           RbVmomi::VIM.PropertyChange(:name => "config.key",                      :op => "assign", :val => "dvportgroup-99"),
           RbVmomi::VIM.PropertyChange(:name => "config.name",                     :op => "assign", :val => "New DVPG"),
           RbVmomi::VIM.PropertyChange(:name => "host",                            :op => "assign", :val => []),


### PR DESCRIPTION
If a DVSwitch isn't in the cache for whatever reason skip that DV PortGroup

```
INFO -- evm: MIQ(ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector#process_update_set) EMS: [ems_0000000000001], id: [51000000003750] Processing 1 updates...
INFO -- evm: MIQ(ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector#process_update_set) EMS: [ems_0000000000001], id: [51000000003750] Processing 1 updates...Complete
WARN -- evm: MIQ(ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser#parse_distributed_virtual_portgroup) DistributedVirtualPortgroup:dvportgroup-99 DVSwitch [dvs-9999999] not found in cache...Skipping
```

Fixes this exception:
```
MIQ(ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector#parse_updates) **Failed to parse DistributedVirtualPortgroup:dvportgroup-24233**: undefined method `[]' for nil:NilClass
[NoMethodError]: undefined method `[]' for nil:NilClass  Method:[block (2 levels) in <class:LogProxy>]
```

https://github.com/ManageIQ/manageiq-providers-vmware/issues/763