### PR TITLE
Delay WaitForUpdates and save in one thread to prevent "update storm" causing saver thread to be backed up

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -5,7 +5,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
   def initialize(ems)
     @ems            = ems
     @exit_requested = false
-    @cache          = ems.class::Inventory::Cache.new
+    @cache          = ManageIQ::Providers::Vmware::InfraManager::Inventory::Cache.new
     @vim_thread     = nil
   end
 
@@ -424,18 +424,18 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
   end
 
   def full_persister_klass
-    @full_persister_klass ||= ems.class::Inventory::Persister::Full
+    ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister::Full
   end
 
   def targeted_persister_klass
-    @targeted_persister_klass ||= ems.class::Inventory::Persister::Targeted
+    ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister::Targeted
   end
 
   def parser_klass
-    @parser_klass ||= ems.class::Inventory::Parser
+    ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
   end
 
   def saver_klass
-    @saver_klass ||= self.class.module_parent::Saver
+    ManageIQ::Providers::Vmware::InfraManager::Inventory::Saver
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -5,7 +5,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
   def initialize(ems)
     @ems            = ems
     @exit_requested = false
-    @cache          = ManageIQ::Providers::Vmware::InfraManager::Inventory::Cache.new
+    @cache          = cache_klass.new
     @vim_thread     = nil
   end
 
@@ -430,6 +430,10 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
 
   def refresh_settings
     Settings.ems_refresh.vmwarews
+  end
+
+  def cache_klass
+    ManageIQ::Providers::Vmware::InfraManager::Inventory::Cache
   end
 
   def full_persister_klass

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -6,6 +6,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
     @ems            = ems
     @exit_requested = false
     @cache          = cache_klass.new
+    @saver          = saver_klass.new
     @vim_thread     = nil
   end
 
@@ -40,7 +41,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
 
   private
 
-  attr_reader   :ems
+  attr_reader   :ems, :saver
   attr_accessor :exit_requested, :vim_thread, :last_full_refresh
 
   def vim_collector_thread
@@ -397,7 +398,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
   end
 
   def save_inventory(persister)
-    saver_klass.save_inventory(persister)
+    saver.save_inventory(persister)
   end
 
   def log_header

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -2,11 +2,10 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
   include PropertyCollector
   include Vmdb::Logging
 
-  def initialize(ems, saver)
+  def initialize(ems)
     @ems            = ems
     @exit_requested = false
     @cache          = ems.class::Inventory::Cache.new
-    @saver          = saver
     @vim_thread     = nil
   end
 
@@ -41,7 +40,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
 
   private
 
-  attr_reader   :ems, :saver
+  attr_reader   :ems
   attr_accessor :exit_requested, :vim_thread, :last_full_refresh
 
   def vim_collector_thread
@@ -393,7 +392,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
   end
 
   def save_inventory(persister)
-    saver.queue_save_inventory(persister)
+    saver_klass.save_inventory(persister)
   end
 
   def log_header
@@ -434,5 +433,9 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
 
   def parser_klass
     @parser_klass ||= ems.class::Inventory::Parser
+  end
+
+  def saver_klass
+    @saver_klass ||= self.class.module_parent::Saver
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/saver.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/saver.rb
@@ -1,120 +1,46 @@
 class ManageIQ::Providers::Vmware::InfraManager::Inventory::Saver
   include Vmdb::Logging
 
-  def initialize(threaded: true)
-    @join_limit  = 30
-    @queue       = Queue.new
-    @should_exit = Concurrent::AtomicBoolean.new
-    @threaded    = threaded
-    @thread      = nil
-  end
+  class << self
+    def save_inventory(persister)
+      save_inventory_start_time = Time.now.utc
+      persister.persist!
+      update_ems_refresh_stats(persister.manager)
+      post_refresh(persister.manager, save_inventory_start_time)
+    rescue => err
+      log_header = log_header_for_ems(persister.manager)
 
-  def start_thread
-    return unless threaded
+      _log.error("#{log_header} Save Inventory failed")
+      _log.log_backtrace(err)
 
-    @thread = Thread.new do
-      saver_thread
-      _log.info("Save inventory thread exiting")
+      update_ems_refresh_stats(persister.manager, :error => err.to_s)
     end
 
-    _log.info("Save inventory thread started")
-  end
+    private
 
-  def stop_thread(wait: true)
-    return unless threaded
-
-    _log.info("Save inventory thread stopping...")
-
-    should_exit.make_true
-    queue.push(nil) # Force the blocking queue.pop call to return
-    join_thread if wait
-  end
-
-  # This method will re-start the saver thread if it has crashed or terminated
-  # prematurely, but is only safe to be called from a single thread.  Given
-  # wait_for_updates has to be single threaded this should be fine but if you
-  # intend to queue up save_inventory from multiple calling threads a mutex
-  # must be added around ensure_saver_thread
-  def queue_save_inventory(persister)
-    _log.debug { "queueing save_inventory [#{persister.tracking_uuid}]" }
-
-    if threaded
-      ensure_saver_thread
-      queue.push(persister)
-    else
-      save_inventory(persister)
+    def update_ems_refresh_stats(ems, error: nil)
+      ems.update(:last_refresh_error => error, :last_refresh_date => Time.now.utc)
     end
-  end
 
-  private
+    def post_refresh(ems, save_inventory_start_time)
+      log_header = log_header_for_ems(ems)
 
-  attr_reader :join_limit, :queue, :should_exit, :thread, :threaded
+      # Do any post-operations for this EMS
+      post_process_refresh_classes.each do |klass|
+        next unless klass.respond_to?(:post_refresh_ems)
 
-  def saver_thread
-    until should_exit.true?
-      persister = queue.pop
-      next if persister.nil?
-
-      save_inventory(persister)
+        _log.info("#{log_header} Performing post-refresh operations for #{klass} instances...")
+        klass.post_refresh_ems(ems.id, save_inventory_start_time)
+        _log.info("#{log_header} Performing post-refresh operations for #{klass} instances...Complete")
+      end
     end
-  rescue => err
-    _log.warn(err)
-    _log.log_backtrace(err)
-  end
 
-  def join_thread
-    return unless thread&.alive?
-
-    unless thread.join(join_limit)
-      thread.kill
+    def post_process_refresh_classes
+      [VmOrTemplate]
     end
-  end
 
-  def ensure_saver_thread
-    return if thread&.alive?
-
-    _log.warn("Save inventory thread exited, restarting")
-    start_thread
-  end
-
-  def save_inventory(persister)
-    _log.debug { "running save_inventory [#{persister.tracking_uuid}]" }
-
-    save_inventory_start_time = Time.now.utc
-    persister.persist!
-    update_ems_refresh_stats(persister.manager)
-    post_refresh(persister.manager, save_inventory_start_time)
-  rescue => err
-    log_header = log_header_for_ems(persister.manager)
-
-    _log.error("#{log_header} Save Inventory failed")
-    _log.log_backtrace(err)
-
-    update_ems_refresh_stats(persister.manager, :error => err.to_s)
-  end
-
-  def update_ems_refresh_stats(ems, error: nil)
-    ems.update(:last_refresh_error => error, :last_refresh_date => Time.now.utc)
-  end
-
-  def post_refresh(ems, save_inventory_start_time)
-    log_header = log_header_for_ems(ems)
-
-    # Do any post-operations for this EMS
-    post_process_refresh_classes.each do |klass|
-      next unless klass.respond_to?(:post_refresh_ems)
-
-      _log.info("#{log_header} Performing post-refresh operations for #{klass} instances...")
-      klass.post_refresh_ems(ems.id, save_inventory_start_time)
-      _log.info("#{log_header} Performing post-refresh operations for #{klass} instances...Complete")
+    def log_header_for_ems(ems)
+      "EMS: [#{ems.name}], id: [#{ems.id}]"
     end
-  end
-
-  def post_process_refresh_classes
-    [VmOrTemplate]
-  end
-
-  def log_header_for_ems(ems)
-    "EMS: [#{ems.name}], id: [#{ems.id}]"
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/saver.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/saver.rb
@@ -1,46 +1,44 @@
 class ManageIQ::Providers::Vmware::InfraManager::Inventory::Saver
   include Vmdb::Logging
 
-  class << self
-    def save_inventory(persister)
-      save_inventory_start_time = Time.now.utc
-      persister.persist!
-      update_ems_refresh_stats(persister.manager)
-      post_refresh(persister.manager, save_inventory_start_time)
-    rescue => err
-      log_header = log_header_for_ems(persister.manager)
+  def save_inventory(persister)
+    save_inventory_start_time = Time.now.utc
+    persister.persist!
+    update_ems_refresh_stats(persister.manager)
+    post_refresh(persister.manager, save_inventory_start_time)
+  rescue => err
+    log_header = log_header_for_ems(persister.manager)
 
-      _log.error("#{log_header} Save Inventory failed")
-      _log.log_backtrace(err)
+    _log.error("#{log_header} Save Inventory failed")
+    _log.log_backtrace(err)
 
-      update_ems_refresh_stats(persister.manager, :error => err.to_s)
+    update_ems_refresh_stats(persister.manager, :error => err.to_s)
+  end
+
+  private
+
+  def update_ems_refresh_stats(ems, error: nil)
+    ems.update(:last_refresh_error => error, :last_refresh_date => Time.now.utc)
+  end
+
+  def post_refresh(ems, save_inventory_start_time)
+    log_header = log_header_for_ems(ems)
+
+    # Do any post-operations for this EMS
+    post_process_refresh_classes.each do |klass|
+      next unless klass.respond_to?(:post_refresh_ems)
+
+      _log.info("#{log_header} Performing post-refresh operations for #{klass} instances...")
+      klass.post_refresh_ems(ems.id, save_inventory_start_time)
+      _log.info("#{log_header} Performing post-refresh operations for #{klass} instances...Complete")
     end
+  end
 
-    private
+  def post_process_refresh_classes
+    [VmOrTemplate]
+  end
 
-    def update_ems_refresh_stats(ems, error: nil)
-      ems.update(:last_refresh_error => error, :last_refresh_date => Time.now.utc)
-    end
-
-    def post_refresh(ems, save_inventory_start_time)
-      log_header = log_header_for_ems(ems)
-
-      # Do any post-operations for this EMS
-      post_process_refresh_classes.each do |klass|
-        next unless klass.respond_to?(:post_refresh_ems)
-
-        _log.info("#{log_header} Performing post-refresh operations for #{klass} instances...")
-        klass.post_refresh_ems(ems.id, save_inventory_start_time)
-        _log.info("#{log_header} Performing post-refresh operations for #{klass} instances...Complete")
-      end
-    end
-
-    def post_process_refresh_classes
-      [VmOrTemplate]
-    end
-
-    def log_header_for_ems(ems)
-      "EMS: [#{ems.name}], id: [#{ems.id}]"
-    end
+  def log_header_for_ems(ems)
+    "EMS: [#{ems.name}], id: [#{ems.id}]"
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
@@ -35,7 +35,7 @@ class ManageIQ::Providers::Vmware::InfraManager::RefreshWorker::Runner < ManageI
   attr_accessor :ems, :collector
 
   def start_inventory_collector
-    self.collector = ems.class::Inventory::Collector.new(ems)
+    self.collector = ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector.new(ems)
     collector.start
     _log.info("Started inventory collector")
   end

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
@@ -35,7 +35,7 @@ class ManageIQ::Providers::Vmware::InfraManager::RefreshWorker::Runner < ManageI
   attr_accessor :ems, :collector
 
   def saver
-    @saver ||= ems.class::Inventory::Saver.new
+    @saver ||= ems.class::Inventory::Saver.new(:threaded => worker_settings[:threaded_saver])
   end
 
   def start_inventory_collector

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_worker/runner.rb
@@ -34,12 +34,8 @@ class ManageIQ::Providers::Vmware::InfraManager::RefreshWorker::Runner < ManageI
 
   attr_accessor :ems, :collector
 
-  def saver
-    @saver ||= ems.class::Inventory::Saver.new(:threaded => worker_settings[:threaded_saver])
-  end
-
   def start_inventory_collector
-    self.collector = ems.class::Inventory::Collector.new(ems, saver)
+    self.collector = ems.class::Inventory::Collector.new(ems)
     collector.start
     _log.info("Started inventory collector")
   end

--- a/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
@@ -1,6 +1,3 @@
-require 'VMwareWebService/MiqVim'
-require 'http-access2' # Required in case it is not already loaded
-
 module ManageIQ::Providers
   module Vmware
     class InfraManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
@@ -16,8 +13,7 @@ module ManageIQ::Providers
         raise NotImplementedError, "not implemented in production mode" if Rails.env.production?
 
         ems_by_ems_id.each do |_ems_id, ems|
-          saver     = ems.class::Inventory::Saver.new(:threaded => false)
-          collector = ems.class::Inventory::Collector.new(ems, saver)
+          collector = ems.class::Inventory::Collector.new(ems)
           collector.refresh
         end
       end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -53,7 +53,8 @@
         :ems_operations_worker_vmware:
           :memory_threshold: 1.gigabytes
       :ems_refresh_worker:
-        :ems_refresh_worker_vmware: {}
+        :ems_refresh_worker_vmware:
+          :threaded_saver: false
         :ems_refresh_worker_vmware_cloud: {}
         :ems_refresh_worker_vmware_cloud_network: {}
         :ems_refresh_worker_vmware_tanzu: {}

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,6 +17,9 @@
       :saver_strategy: batch
   :vmware_cloud:
     :get_public_images: false
+  :vmwarews:
+    :refresh_interval: 24.hours
+    :update_poll_interval: 1.second
 :http_proxy:
   :vmware_cloud:
     :host:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -53,8 +53,7 @@
         :ems_operations_worker_vmware:
           :memory_threshold: 1.gigabytes
       :ems_refresh_worker:
-        :ems_refresh_worker_vmware:
-          :threaded_saver: false
+        :ems_refresh_worker_vmware: {}
         :ems_refresh_worker_vmware_cloud: {}
         :ems_refresh_worker_vmware_cloud_network: {}
         :ems_refresh_worker_vmware_tanzu: {}

--- a/spec/models/manageiq/providers/vmware/infra_manager/inventory/parser_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/inventory/parser_spec.rb
@@ -1,7 +1,6 @@
 describe ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser do
   let(:ems)       { FactoryBot.create(:ems_vmware) }
-  let(:saver)     { ManageIQ::Providers::Vmware::InfraManager::Inventory::Saver.new(:threaded => false) }
-  let(:collector) { ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector.new(ems, saver) }
+  let(:collector) { ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector.new(ems) }
   let(:persister) { ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister::Targeted.new(ems) }
   let(:parser)    { described_class.new(collector, persister) }
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -16,8 +16,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       ems.update_authentication(:default => {:userid => username, :password => password})
     end
   end
-  let(:saver)     { ManageIQ::Providers::Vmware::InfraManager::Inventory::Saver.new(:threaded => false) }
-  let(:collector) { ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector.new(ems, saver) }
+  let(:collector) { ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector.new(ems) }
   let(:category) do
     require "vsphere-automation-cis"
     VSphereAutomation::CIS::CisTaggingCategoryModel.new(


### PR DESCRIPTION
With separate collector and saver threads it is possible for the rate of collection to be faster than the rate of saving which causes saving inventory to be very delayed.

The WaitForUpdatesEx method takes a version and returns updates that have happened since that version so updates aren't going to be missed, and leads to more updates being processed in each save_inventory call which is more efficient.

https://github.com/ManageIQ/manageiq-providers-vmware/issues/745