### PR TITLE
Fix supports not working in vm_or_template_shared

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/template.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/template.rb
@@ -13,4 +13,5 @@ class ManageIQ::Providers::Vmware::InfraManager::Template < ManageIQ::Providers:
 
   supports :terminate
   supports :rename
+  supports :set_description
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm.rb
@@ -16,7 +16,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Vm < ManageIQ::Providers::Infra
     unsupported_reason_add(:reconfigure_disksize, 'Cannot resize disks of a VM with snapshots') unless snapshots.empty?
   end
   supports :reconfigure_cdroms
-
+  supports :set_description
   supports :rename
 
   def add_miq_alarm

--- a/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared.rb
@@ -8,10 +8,6 @@ module ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared
   include_concern 'RefreshOnScan'
   include_concern 'Scanning'
 
-  included do
-    supports :set_description
-  end
-
   POWER_STATES = {
     "poweredOn"  => "on",
     "poweredOff" => "off",


### PR DESCRIPTION
Even though VmOrTemplateShared extends activesupport concern the included {} block isn't working properly.