### PR TITLE
Allow collection of disconnected hosts in inventory

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/host_system.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/host_system.rb
@@ -13,10 +13,10 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
     end
 
     def validate_host_system_props(object, props)
-      if props.fetch_path(:config).nil? || props.fetch_path(:summary).nil? || props.fetch_path(:summary, :config, :product).nil?
-        [true, "Missing configuration for Host [#{object._ref}]"]
-      elsif props.fetch_path(:config, :network, :dnsConfig, :hostName).blank?
-        [true, "Missing hostname information for Host [#{object._ref}]"]
+      # We use summary and summary.config in order to set some required properties for hosts,
+      # if these are missing we won't have enough information to build a useful record.
+      if props.fetch_path(:summary, :config, :product).nil?
+        [true, "Missing summary for Host [#{object._ref}]"]
       else
         false
       end


### PR DESCRIPTION
Currently we skip any hosts that have a null `config` property, but also have logic to save the connectionState of the host.  When a host is disconnected the vSphere can't get the current `config` but will have `summary.config`.

This means we are skipping all disconnected hosts rather than collecting them in inventory and reporting that they are disconnected which is more useful than pretending that they don't exist.

E.g. I think a "Filter hosts by not responding" would be very helpful