### PR TITLE
Fix missing Tanzu subclasses and VmOrTemplate auto_model_class

### DIFF
--- a/app/models/manageiq/providers/vmware/container_manager.rb
+++ b/app/models/manageiq/providers/vmware/container_manager.rb
@@ -4,10 +4,15 @@ class ManageIQ::Providers::Vmware::ContainerManager < ManageIQ::Providers::Kuber
   require_nested :Container
   require_nested :ContainerGroup
   require_nested :ContainerNode
+  require_nested :ContainerTemplate
+  require_nested :ContainerVolume
   require_nested :EventCatcher
   require_nested :EventParser
   require_nested :Refresher
   require_nested :RefreshWorker
+  require_nested :ServiceInstance
+  require_nested :ServiceOffering
+  require_nested :ServiceParametersSet
 
   supports :create
 

--- a/app/models/manageiq/providers/vmware/container_manager/container_template.rb
+++ b/app/models/manageiq/providers/vmware/container_manager/container_template.rb
@@ -1,0 +1,4 @@
+ManageIQ::Providers::Kubernetes::ContainerManager::ContainerTemplate.include(ActsAsStiLeafClass)
+
+class ManageIQ::Providers::Vmware::ContainerManager::ContainerTemplate < ManageIQ::Providers::Kubernetes::ContainerManager::ContainerTemplate
+end

--- a/app/models/manageiq/providers/vmware/container_manager/container_volume.rb
+++ b/app/models/manageiq/providers/vmware/container_manager/container_volume.rb
@@ -1,0 +1,4 @@
+ManageIQ::Providers::Kubernetes::ContainerManager::ContainerVolume.include(ActsAsStiLeafClass)
+
+class ManageIQ::Providers::Vmware::ContainerManager::ContainerVolume < ManageIQ::Providers::Kubernetes::ContainerManager::ContainerVolume
+end

--- a/app/models/manageiq/providers/vmware/container_manager/service_instance.rb
+++ b/app/models/manageiq/providers/vmware/container_manager/service_instance.rb
@@ -1,0 +1,4 @@
+ManageIQ::Providers::Kubernetes::ContainerManager::ServiceInstance.include(ActsAsStiLeafClass)
+
+class ManageIQ::Providers::Vmware::ContainerManager::ServiceInstance < ManageIQ::Providers::Kubernetes::ContainerManager::ServiceInstance
+end

--- a/app/models/manageiq/providers/vmware/container_manager/service_offering.rb
+++ b/app/models/manageiq/providers/vmware/container_manager/service_offering.rb
@@ -1,0 +1,4 @@
+ManageIQ::Providers::Kubernetes::ContainerManager::ServiceOffering.include(ActsAsStiLeafClass)
+
+class ManageIQ::Providers::Vmware::ContainerManager::ServiceOffering < ManageIQ::Providers::Kubernetes::ContainerManager::ServiceOffering
+end

--- a/app/models/manageiq/providers/vmware/container_manager/service_parameters_set.rb
+++ b/app/models/manageiq/providers/vmware/container_manager/service_parameters_set.rb
@@ -1,0 +1,4 @@
+ManageIQ::Providers::Kubernetes::ContainerManager::ServiceParametersSet.include(ActsAsStiLeafClass)
+
+class ManageIQ::Providers::Vmware::ContainerManager::ServiceParametersSet < ManageIQ::Providers::Kubernetes::ContainerManager::ServiceParametersSet
+end

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
@@ -51,7 +51,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister < ManageIQ
     add_collection(infra, :storage_profiles)
     add_collection(infra, :storage_profile_storages)
     add_collection(infra, :parent_blue_folders)
-    add_collection(infra, :vms_and_templates) do |builder|
+    add_collection(infra, :vms_and_templates, {}, {:without_sti => true}) do |builder|
       builder.vm_template_shared
       builder.add_properties(:custom_reconnect_block => vms_and_templates_reconnect_block)
     end

--- a/app/models/manageiq/providers/vmware/network_manager.rb
+++ b/app/models/manageiq/providers/vmware/network_manager.rb
@@ -1,8 +1,12 @@
 class ManageIQ::Providers::Vmware::NetworkManager < ManageIQ::Providers::NetworkManager
   require_nested :CloudNetwork
   require_nested :CloudSubnet
+  require_nested :LoadBalancer
+  require_nested :LoadBalancerPool
+  require_nested :LoadBalancerPoolMember
   require_nested :NetworkPort
   require_nested :Refresher
+  require_nested :SecurityGroup
 
   include ManageIQ::Providers::Vmware::ManagerAuthMixin
 

--- a/app/models/manageiq/providers/vmware/network_manager.rb
+++ b/app/models/manageiq/providers/vmware/network_manager.rb
@@ -2,8 +2,11 @@ class ManageIQ::Providers::Vmware::NetworkManager < ManageIQ::Providers::Network
   require_nested :CloudNetwork
   require_nested :CloudSubnet
   require_nested :LoadBalancer
+  require_nested :LoadBalancerHealthCheck
+  require_nested :LoadBalancerListener
   require_nested :LoadBalancerPool
   require_nested :LoadBalancerPoolMember
+
   require_nested :NetworkPort
   require_nested :Refresher
   require_nested :SecurityGroup

--- a/app/models/manageiq/providers/vmware/network_manager/load_balancer.rb
+++ b/app/models/manageiq/providers/vmware/network_manager/load_balancer.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Vmware::NetworkManager::LoadBalancer < ::LoadBalancer
+end

--- a/app/models/manageiq/providers/vmware/network_manager/load_balancer_health_check.rb
+++ b/app/models/manageiq/providers/vmware/network_manager/load_balancer_health_check.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Vmware::NetworkManager::LoadBalancerHealthCheck < ::LoadBalancerHealthCheck
+end

--- a/app/models/manageiq/providers/vmware/network_manager/load_balancer_listener.rb
+++ b/app/models/manageiq/providers/vmware/network_manager/load_balancer_listener.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Vmware::NetworkManager::LoadBalancerListener < ::LoadBalancerListener
+end

--- a/app/models/manageiq/providers/vmware/network_manager/load_balancer_pool.rb
+++ b/app/models/manageiq/providers/vmware/network_manager/load_balancer_pool.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Vmware::NetworkManager::LoadBalancerPool < ::LoadBalancerPool
+end

--- a/app/models/manageiq/providers/vmware/network_manager/load_balancer_pool_member.rb
+++ b/app/models/manageiq/providers/vmware/network_manager/load_balancer_pool_member.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Vmware::NetworkManager::LoadBalancerPoolMember < ::LoadBalancerPoolMember
+end

--- a/app/models/manageiq/providers/vmware/network_manager/security_group.rb
+++ b/app/models/manageiq/providers/vmware/network_manager/security_group.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Vmware::NetworkManager::SecurityGroup < ::SecurityGroup
+end


### PR DESCRIPTION
Required for: https://github.com/ManageIQ/manageiq/pull/21597