### PR TITLE
Ensure Remote Console tickets aren't VimStrings

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
@@ -42,7 +42,12 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole
   def remote_console_vmrc_acquire_ticket(_userid = nil, _originating_server = nil)
     validate_remote_console_acquire_ticket("vmrc")
     ticket = ext_management_system.remote_console_vmrc_acquire_ticket
-    {:ticket => ticket, :remote_url => build_vmrc_url(ticket), :proto => 'remote'}
+
+    {
+      :ticket     => ticket.to_s, # Ensure ticket is a basic String not a VimString
+      :remote_url => build_vmrc_url(ticket),
+      :proto      => 'remote'
+    }
   end
 
   def validate_remote_console_vmrc_support
@@ -66,11 +71,11 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole
       :vm_id      => id,
       :ssl        => true,
       :protocol   => 'webmks',
-      :secret     => ticket['ticket'],
+      :secret     => ticket['ticket'].to_s, # Ensure ticket is a basic String not a VimString
       :url_secret => SecureRandom.hex,
     }
 
-    SystemConsole.launch_proxy_if_not_local(console_args, originating_server, ticket['host'], ticket['port'].to_i)
+    SystemConsole.launch_proxy_if_not_local(console_args, originating_server, ticket['host'].to_s, ticket['port'].to_i)
   end
 
   def validate_remote_console_webmks_support

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/remote_console_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/remote_console_spec.rb
@@ -155,15 +155,17 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
       EvmSpecHelper.create_guid_miq_server_zone
       ems.update(:ipaddress => '192.168.252.14', :hostname => '192.168.252.14')
       auth = FactoryBot.create(:authentication,
-                                :userid   => 'dev1',
-                                :password => 'dev1pass',
-                                :authtype => 'console')
+                               :userid   => 'dev1',
+                               :password => 'dev1pass',
+                               :authtype => 'console')
       ems.authentications = [auth]
       ticket = VCR.use_cassette(described_class.name.underscore) do
         vm.remote_console_vmrc_acquire_ticket
       end
+
       expect(ticket).to have_key(:ticket)
       expect(ticket[:ticket]).to match(/^[0-9\-A-Z]{40}$/)
+      expect(ticket[:ticket]).to be_instance_of(String) # Ensure that VimStrings aren't returned
     end
 
     it 'with vm off' do


### PR DESCRIPTION
When openings a VMRC Console a MiqTask is created and `vm.remote_console_vmrc_acquire_ticket` is called on the queue.
The ticket string returned by `vim.acquireCloneTicket` is a `VimString` type.  This then is saved in the task_results which throws an exception when loaded due to `VMwareWebService/VimTypes` not being loaded in the webserver.

```
=> #<MiqTask id: 78, name: "acquiring Vm ag_/test_\\ren%amed VMRC remote consol...", state: "Finished", status: "Ok", message: "Task completed successfully", userid: "admin", created_on: "2022-01-14 15:25:10", updated_on: "2022-01-14 15:25:10", pct_complete: nil, context_data: nil, results: nil, miq_server_id: 1, identifier: nil, started_on: "2022-01-14 15:25:10", zone: nil>
>> vmrc_task.task_results
   (0.5ms)  SELECT "binary_blob_parts"."data" FROM "binary_blob_parts" WHERE "binary_blob_parts"."binary_blob_id" = $1 ORDER BY "binary_blob_parts"."id" ASC  [["binary_blob_id", 55]]
=> {:ticket=>"cst-VCT-5202d576-98d3-d347-39b5-eb798442a3dd--tp-85-88-00-9D-4C-D2-52-9B-10-B1-33-00-40-56-DA-6D-06-F5-C9-87", :remote_url=>"vmrc://clone:cst-VCT-5202d576-98d3-d347-39b5-eb798442a3dd--tp-85-88-00-9D-4C-D2-52-9B-10-B1-33-00-40-56-DA-6D-06-F5-C9-87@icovcpc65.rtp.raleigh.ibm.com:443/?moid=vm-53550", :proto=>"remote"}
>> vmrc_task.task_results[:ticket].class
   (0.4ms)  SELECT "binary_blob_parts"."data" FROM "binary_blob_parts" WHERE "binary_blob_parts"."binary_blob_id" = $1 ORDER BY "binary_blob_parts"."id" ASC  [["binary_blob_id", 55]]
=> VimString
```

The raw data looks like:
```
>> BinaryBlob.find(55).binary_blob_parts.first.data
  BinaryBlob Load (0.6ms)  SELECT "binary_blobs".* FROM "binary_blobs" WHERE "binary_blobs"."id" = $1 LIMIT $2  [["id", 55], ["LIMIT", 1]]
  BinaryBlob Inst Including Associations (0.1ms - 1rows)
  BinaryBlobPart Load (0.4ms)  SELECT "binary_blob_parts".* FROM "binary_blob_parts" WHERE "binary_blob_parts"."binary_blob_id" = $1 ORDER BY "binary_blob_parts"."id" ASC LIMIT $2  [["binary_blob_id", 55], ["LIMIT", 1]]
  BinaryBlobPart Inst Including Associations (0.1ms - 1rows)
=> "---\n:ticket: !ruby/string:VimString\n  str: cst-TICKET\n  xsiType: :SOAP::SOAPString\n  vimType:\n:remote_url: vmrc://clone:cst-TICKET@vcenter.local:443/?moid=vm-53550\n:proto: remote\n"
```

Data migration: https://github.com/ManageIQ/manageiq-schema/pull/631
Fixes https://github.com/ManageIQ/manageiq-providers-vmware/issues/778