### PR TITLE
Queue remote_console_acquire_ticket for OperationsWorker

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm/remote_console.rb
@@ -23,6 +23,7 @@ module ManageIQ::Providers::Vmware::CloudManager::Vm::RemoteConsole
       :class_name  => self.class.name,
       :instance_id => id,
       :method_name => 'remote_console_acquire_ticket',
+      :queue_name  => queue_name_for_ems_operations,
       :priority    => MiqQueue::HIGH_PRIORITY,
       :role        => 'ems_operations',
       :zone        => my_zone,

--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -725,6 +725,7 @@ module ManageIQ::Providers
         :class_name  => self.class.name,
         :instance_id => id,
         :method_name => 'assign_ems_created_on',
+        :queue_name  => queue_name_for_ems_operations,
         :role        => 'ems_operations',
         :args        => [vm_ids],
         :priority    => MiqQueue::MIN_PRIORITY

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
@@ -26,6 +26,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole
       :class_name  => self.class.name,
       :instance_id => id,
       :method_name => 'remote_console_acquire_ticket',
+      :queue_name  => queue_name_for_ems_operations,
       :priority    => MiqQueue::HIGH_PRIORITY,
       :role        => 'ems_operations',
       :zone        => my_zone,


### PR DESCRIPTION
The remote_console_acquire_ticket operation issues a VIM call to retrieve a ticket and must be queued for the operations worker not just any priority/generic worker.

Fixes https://github.com/ManageIQ/vmware_web_service/issues/112