### PR TITLE
Handle session timeout errors when exiting collector

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -189,7 +189,11 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
     return if vim.nil?
 
     # sessionManager.Logout and close the http connection
-    vim.close
+    begin
+      vim.close
+    rescue => err
+      _log.warn("Failed to logout of session: #{err}")
+    end
 
     # Cleanup the certificate authority file if it exists
     if ca_file

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -197,6 +197,8 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
       ca_file.unlink
       self.ca_file = nil
     end
+  rescue => err
+    _log.warn("Failed to disconnect: #{err}")
   end
 
   def wait_for_updates(vim, version)

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector/property_collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector/property_collector.rb
@@ -7,6 +7,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector::Property
     return if property_filter.nil?
 
     property_filter.DestroyPropertyFilter
+  rescue RbVmomi::Fault => err
+    _log.warn("Failed to destroy property filter: #{err}") unless err.fault.kind_of?(RbVmomi::VIM::ManagedObjectNotFound)
   rescue => err
     _log.warn("Failed to destroy property filter: #{err}")
   end

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector/property_collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector/property_collector.rb
@@ -7,6 +7,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector::Property
     return if property_filter.nil?
 
     property_filter.DestroyPropertyFilter
+  rescue => err
+    _log.warn("Failed to destroy property filter: #{err}")
   end
 
   def ems_inventory_filter_spec(vim)


### PR DESCRIPTION
If the collector thread fails due to a session timeout then the destroy property filter and logout calls in the ensure are going to fail as well.  Catch exception in these methods to prevent raising an exception in the ensure causing the worker to exit.

```
INFO -- evm: MIQ(ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector#stop) EMS: [VCENTER], id: [1] Monitor updates thread exiting...
ERROR -- evm: MIQ(ManageIQ::Providers::Vmware::InfraManager::RefreshWorker::Runner) ID [1000002219930] PID [6234] GUID [] Error in before_exit: ManagedObjectNotFound: The object 'vmodl.query.PropertyCollector.Filter:session[52224bec-e421-21be-30ac-1fd5ac2b519c]52799047-f91b-c8cf-681a-53c59cb8d899' has already been deleted or has not been completely created
INFO -- evm: MIQ(ManageIQ::Providers::Vmware::InfraManager::RefreshWorker#log_status) [Refresh Worker for Provider: VCENTER] Worker ID [3], PID [6234], GUID [f108ace4-37dc-4b37-af0a-d820bb0dcae2], Last Heartbeat [2022-02-03 16:36:26 UTC], Process Info: Memory Usage [1642688512], Memory Size [2523136000], Proportional Set Size: [1588797000], Unique Set Size: [1587640000], Memory % [0.1], CPU Time [22503.0], CPU % [0.02], Priority [20]
ERROR -- evm: MIQ(ManageIQ::Providers::Vmware::InfraManager::RefreshWorker::Runner) ID [1000002219930] PID [6234] GUID [f108ace4-37dc-4b37-af0a-d820bb0dcae2] An error has occurred during work processing: ManagedObjectNotFound: The object 'vmodl.query.PropertyCollector.Filter:session[52224bec-e421-21be-30ac-1fd5ac2b519c]52799047-f91b-c8cf-681a-53c59cb8d899' has already been deleted or has not been completely created
INFO -- evm: Deleting worker record for ManageIQ::Providers::Vmware::InfraManager::RefreshWorker, id 30
```

https://github.com/ManageIQ/manageiq-providers-vmware/issues/780