### PR TITLE
Keep session alive during save_inventory

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -87,7 +87,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
     parse_storage_profiles(vim, parser)
     parse_content_libraries(cis, parser) if cis.present?
 
-    save_inventory(persister)
+    save_inventory(vim, persister)
 
     self.last_full_refresh = Time.now.utc
     clear_cis_taggings
@@ -104,7 +104,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
       parser    = parser_klass.new(self, persister)
 
       parse_updates(vim, parser, updated_objects)
-      save_inventory(persister)
+      save_inventory(vim, persister)
 
       # Prevent WaitForUpdatesEx from "spinning" in a tight loop if updates are
       # constantly available.  This allows for more updates to be batched together
@@ -415,8 +415,39 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
     _log.warn("#{log_header} Unable to collect storage profiles: #{err}")
   end
 
-  def save_inventory(persister)
-    saver.save_inventory(persister)
+  def save_inventory(vim, persister)
+    with_heartbeat(vim) do
+      saver.save_inventory(persister)
+    end
+  end
+
+  def with_heartbeat(vim)
+    should_exit = Concurrent::AtomicBoolean.new
+    wakeup      = Concurrent::Event.new
+
+    heartbeat_thread = Thread.new do
+      loop do
+        # Check should_exit before making the API call in case save_inventory
+        # doesn't take a long time we don't want to waste an API call
+        wakeup.wait(2.minutes)
+        break if should_exit.true?
+
+        # Run an API call periodically to ensure vCenter doesn't
+        # timeout our session out from under us
+        vim.currentTime
+      end
+    end
+
+    begin
+      yield
+    ensure
+      should_exit.make_true
+      wakeup.set
+
+      # Give the thread a short duration to exit cleanly before
+      # killing it and moving on
+      heartbeat_thread.join(5) || heartbeat_thread.kill
+    end
   end
 
   def log_header

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -573,7 +573,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
         updated_objects = collector.send(:process_update_set, property_filter, update_set)
 
         collector.send(:parse_updates, vim, parser, updated_objects)
-        collector.send(:save_inventory, persister)
+        collector.send(:save_inventory, vim, persister)
 
         expect(ems.reload.last_refresh_error).to be_nil
       end


### PR DESCRIPTION
If save_inventory (especially the initial one) takes long enough the VIM session can timeout and go stale which results in the subsequent WaitForUpdatesEx call to fail.

Execute a simple API call (currentTime) periodically during long save_inventory calls to keep the session alive.

https://github.com/ManageIQ/manageiq-providers-vmware/issues/780