### PR TITLE
Add missing supports :create to vCloud

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -19,6 +19,7 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
 
   before_create :ensure_managers
 
+  supports :create
   supports :catalog
 
   def ensure_network_manager


### PR DESCRIPTION
We missed this one while working on https://github.com/ManageIQ/manageiq/pull/21573