### PR TITLE
Fix API call to get Current Time

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -434,7 +434,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
 
         # Run an API call periodically to ensure vCenter doesn't
         # timeout our session out from under us
-        vim.currentTime
+        vim.serviceInstance.CurrentTime
       end
     end
 


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/manageiq-providers-vmware/pull/790
Had tested with `ems.connect` but that returns a different connection object than we have here.