### PR TITLE
Add supports :publish to VMware Infra VMs

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm.rb
@@ -9,6 +9,9 @@ class ManageIQ::Providers::Vmware::InfraManager::Vm < ManageIQ::Providers::Infra
   supports :clone do
     unsupported_reason_add(:clone, _('Clone operation is not supported')) if blank? || orphaned? || archived?
   end
+  supports :publish do
+    unsupported_reason_add(:publish, _('Publish operation is not supported')) if blank? || orphaned? || archived?
+  end
 
   supports :reconfigure_disks
   supports :reconfigure_network_adapters


### PR DESCRIPTION
This previously defaulted to true in core and providers set supports_not which is not the standard and allows for features accidentally being supported that aren't implemented.