### PR TITLE
Add a setting to allow ESXi hosts to be added

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
@@ -79,7 +79,7 @@ module ManageIQ::Providers::Vmware::InfraManager::VimConnectMixin
           }
         )
 
-        raise MiqException::Error, _("Adding ESX/ESXi Hosts is not supported") unless vim.isVirtualCenter
+        raise MiqException::Error, _("Adding ESX/ESXi Hosts is not supported") if !vim.isVirtualCenter && !Settings.prototype.ems_vmware.allow_direct_hosts
         raise MiqException::Error, _("vCenter version %{version} is unsupported") % {:version => vim.apiVersion} if !version_supported?(vim.apiVersion)
 
         # If the time on the vCenter is very far off from MIQ system time then

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -60,3 +60,6 @@
         :ems_refresh_worker_vmware_cloud: {}
         :ems_refresh_worker_vmware_cloud_network: {}
         :ems_refresh_worker_vmware_tanzu: {}
+:prototype:
+  :ems_vmware:
+    :allow_direct_hosts: false

--- a/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
@@ -71,6 +71,14 @@ describe ManageIQ::Providers::Vmware::InfraManager do
         expect { described_class.verify_credentials(verify_params) }
           .to raise_error(MiqException::Error, "Adding ESX/ESXi Hosts is not supported")
       end
+
+      context "with allow_direct_hosts setting set to true" do
+        before { stub_settings_merge(:prototype => {:ems_vmware => {:allow_direct_hosts => true}}) }
+
+        it "is successful" do
+          expect(described_class.verify_credentials(verify_params)).to be_truthy
+        end
+      end
     end
 
     context "vCenter currentTime out of sync" do


### PR DESCRIPTION
Allow adding an ESXi host directly for development testing if a vCenter isn't available.  This isn't supported for production but we can add a prototype setting to allow this for development/testing

Related: https://github.com/ManageIQ/manageiq/issues/21957