### PR TITLE
Refactor cloud network factories from core

### DIFF
--- a/spec/factories/cloud_network.rb
+++ b/spec/factories/cloud_network.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :cloud_network_vmware_vdc,
+          :class  => "ManageIQ::Providers::Vmware::NetworkManager::CloudNetwork::OrgVdcNet",
+          :parent => :cloud_network
+  factory :cloud_network_vmware_vapp,
+          :class  => "ManageIQ::Providers::Vmware::NetworkManager::CloudNetwork::VappNet",
+          :parent => :cloud_network
+end


### PR DESCRIPTION
- part of the effort to move provider-specific code out of core repositories

@miq-bot add_labels refactoring, test
@miq-bot assign @agrare 