### PR TITLE
Fix snapshot ems ref obj no method error

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/ems_ref_obj_mixin.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/ems_ref_obj_mixin.rb
@@ -1,6 +1,8 @@
 module ManageIQ::Providers::Vmware::InfraManager::EmsRefObjMixin
   extend ActiveSupport::Concern
 
+  autoload :VimString, 'VMwareWebService/VimTypes'
+
   def ems_ref_obj
     @ems_ref_obj ||= VimString.new(ems_ref, ems_ref_type, :ManagedObjectReference) if ems_ref.present? && ems_ref_type.present?
   end

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
@@ -117,10 +117,16 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
 
     [:config, :customization, :linked_clone].each { |key| vim_clone_options[key] = clone_options[key] }
 
-    [:folder, :host, :pool, :snapshot].each do |key|
+    [:folder, :host, :pool].each do |key|
       ci = clone_options[key]
       next if ci.nil?
+
       vim_clone_options[key] = ci.ems_ref_obj
+    end
+
+    if clone_options[:snapshot]
+      ci = clone_options[:snapshot]
+      vim_clone_options[:snapshot] = VimString.new(ci.ems_ref, ci.ems_ref_type, :ManagedObjectReference) if ci.ems_ref.present? && ci.ems_ref_type.present?
     end
 
     vim_clone_options[:datastore]       = datastore_ems_ref(clone_options)

--- a/spec/factories/resource_pool.rb
+++ b/spec/factories/resource_pool.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :resource_pool_vmware, :class => "ManageIQ::Providers::Vmware::InfraManager::ResourcePool", :parent => :resource_pool do
+    sequence(:ems_ref) { |n| "resgroups-#{n}" }
+    ems_ref_type { "ResourcePool" }
+  end
+end

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision/cloning_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision/cloning_spec.rb
@@ -1,51 +1,38 @@
 describe ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning do
+  let(:ems)               { FactoryBot.create(:ems_vmware_with_authentication) }
+  let(:user_admin)        { FactoryBot.create(:user_admin) }
+  let(:template)          { FactoryBot.create(:template_vmware, :name => "template1", :ext_management_system => ems, :cpu_limit => -1, :cpu_reserve => 0) }
+  let(:provision)         { FactoryBot.create(:miq_provision_vmware, :userid => user_admin.userid, :miq_request => provision_request, :source => template, :request_type => 'template', :state => 'pending', :status => 'Ok', :options => options) }
+  let(:provision_request) { FactoryBot.create(:miq_provision_request, :requester => user_admin, :src_vm_id => template.id) }
+  let(:options) do
+    {
+      :pass          => 1,
+      :vm_name       => "clone test",
+      :number_of_vms => 1,
+      :cpu_limit     => -1,
+      :cpu_reserve   => 0,
+      :src_vm_id     => [template.id, template.name],
+    }
+  end
+
   context "#dest_folder" do
-    before do
-      @os = FactoryBot.create(:operating_system)
-      @admin = FactoryBot.create(:user_admin)
-      @target_vm_name = 'clone test'
-      @options = {
-        :pass          => 1,
-        :vm_name       => @target_vm_name,
-        :number_of_vms => 1,
-        :cpu_limit     => -1,
-        :cpu_reserve   => 0
-      }
-      @ems         = FactoryBot.create(:ems_vmware_with_authentication, :api_version => '6.0')
-      @vm_template = FactoryBot.create(:template_vmware, :name => "template1", :ext_management_system => @ems, :operating_system => @os, :cpu_limit => -1, :cpu_reserve => 0)
-      @pr          = FactoryBot.create(:miq_provision_request, :requester => @admin, :src_vm_id => @vm_template.id)
-      @options[:src_vm_id] = [@vm_template.id, @vm_template.name]
-      @vm_prov = FactoryBot.create(:miq_provision_vmware, :userid => @admin.userid, :miq_request => @pr, :source => @vm_template, :request_type => 'template', :state => 'pending', :status => 'Ok', :options => @options)
-    end
-
-    let(:folder_name) { 'folder_one' }
-    let(:ems_folder)  { double('ems_folder') }
-    let(:dest_host) do
-      FactoryBot.create(:host_vmware, :ext_management_system => ems)
-    end
-
-    let(:dc_nested) do
-      EvmSpecHelper::EmsMetadataHelper.vmware_nested_folders(@ems)
-    end
-
-    let(:dest_host_nested) do
-      FactoryBot.create(:host_vmware, :ext_management_system => @ems).tap { |h| h.parent = dc_nested }
-    end
-
-    let(:vm_folder_nested) do
-      FactoryBot.create(:ems_folder, :name => 'vm', :ems_id => @ems.id).tap { |v| v.parent = dc_nested }
-    end
+    let(:folder_name)      { 'folder_one' }
+    let(:ems_folder)       { FactoryBot.create(:vmware_folder_vm) }
+    let(:dest_host)        { FactoryBot.create(:host_vmware, :ext_management_system => ems) }
+    let(:dc_nested)        { EvmSpecHelper::EmsMetadataHelper.vmware_nested_folders(ems) }
+    let(:dest_host_nested) { FactoryBot.create(:host_vmware, :ext_management_system => ems).tap { |h| h.parent = dc_nested } }
+    let(:vm_folder_nested) { FactoryBot.create(:ems_folder, :name => 'vm', :ems_id => ems.id).tap { |v| v.parent = dc_nested } }
 
     it "returns a folder if one is found" do
-      expect(EmsFolder).to receive(:find_by).and_return(:ems_folder)
-      expect(@vm_prov).to receive(:find_folder).never
-      @vm_prov.dest_folder
+      options[:placement_folder_name] = [ems_folder.id, ems_folder.name]
+      expect(provision).to receive(:find_folder).never
+      provision.dest_folder
     end
 
     it "attempts to find a usable folder if the ems_folder does not exist" do
-      @vm_prov.options[:dest_host] = [dest_host_nested.id, dest_host_nested.name]
-      expect(@vm_prov).to receive(:find_folder).once
-      @vm_prov.dest_folder
+      provision.options[:dest_host] = [dest_host_nested.id, dest_host_nested.name]
+      expect(provision).to receive(:find_folder).once
+      provision.dest_folder
     end
   end
 end

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision/cloning_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision/cloning_spec.rb
@@ -1,5 +1,6 @@
 describe ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning do
-  let(:ems)               { FactoryBot.create(:ems_vmware_with_authentication) }
+  let(:zone)              { EvmSpecHelper.local_miq_server.zone }
+  let(:ems)               { FactoryBot.create(:ems_vmware_with_authentication, :zone => zone) }
   let(:user_admin)        { FactoryBot.create(:user_admin) }
   let(:template)          { FactoryBot.create(:template_vmware, :name => "template1", :ext_management_system => ems, :cpu_limit => -1, :cpu_reserve => 0) }
   let(:provision)         { FactoryBot.create(:miq_provision_vmware, :userid => user_admin.userid, :miq_request => provision_request, :source => template, :request_type => 'template', :state => 'pending', :status => 'Ok', :options => options) }
@@ -33,6 +34,44 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning do
       provision.options[:dest_host] = [dest_host_nested.id, dest_host_nested.name]
       expect(provision).to receive(:find_folder).once
       provision.dest_folder
+    end
+  end
+
+  context "#start_clone" do
+    let(:folder)    { FactoryBot.create(:vmware_folder_vm, :ext_management_system => ems) }
+    let(:host)      { FactoryBot.create(:host_vmware_esx, :ext_management_system => ems, :ems_ref => "host-1") }
+    let(:pool)      { FactoryBot.create(:resource_pool_vmware, :ext_management_system => ems) }
+    let(:snapshot)  { FactoryBot.create(:snapshot, :ems_ref => "snapshot-1", :ems_ref_type => "Snapshot") }
+    let(:datastore) { FactoryBot.create(:storage_vmware, :ext_management_system => ems) }
+
+    let(:clone_options) do
+      {
+        :name      => "clone test",
+        :folder    => folder,
+        :host      => host,
+        :pool      => pool,
+        :snapshot  => snapshot,
+        :datastore => datastore
+      }
+    end
+
+    # Building the disk relocate spec has to connect to the ems so we need to
+    # stub that out here.
+    before { allow(provision).to receive(:build_disk_relocate_spec) }
+
+    it "converts AR objects to VimTypes" do
+      expect(provision)
+        .to receive(:clone_vm)
+        .with(
+          hash_including(
+            :folder   => folder.ems_ref_obj,
+            :host     => host.ems_ref_obj,
+            :pool     => pool.ems_ref_obj,
+            :snapshot => VimString.new(snapshot.ems_ref, snapshot.ems_ref_type, :ManagedObjectReference)
+          )
+        )
+
+      provision.start_clone(clone_options)
     end
   end
 end


### PR DESCRIPTION
If you choose to provision a from a linked clone you have to select a template.  Many releases ago we dropped the ems_ref_obj column to not have to store serialized YAML classes in a string column, but `::Snapshot` does not have STI and thus does not include the `EmsRefObjMixin` which builds the VimString from `ems_ref+ems_ref_type`.

This is a fix which can be made without schema changes for backport, I will follow-up with another change to add STI to Snapshots and `include EmsRefObjMixin` like the rest of these models.

Fixes https://github.com/ManageIQ/manageiq-providers-vmware/issues/825