### PR TITLE
Add a setting to enable / disable the non-rails event catcher

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/event_catcher.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Vmware::InfraManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
   require_nested :Runner
 
-  self.rails_worker = !!worker_settings[:rails_worker]
+  self.rails_worker = -> { !!worker_settings[:rails_worker] }
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/event_catcher.rb
@@ -1,3 +1,5 @@
 class ManageIQ::Providers::Vmware::InfraManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
   require_nested :Runner
+
+  self.rails_worker = !!worker_settings[:rails_worker]
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/event_catcher/runner.rb
@@ -97,4 +97,21 @@ class ManageIQ::Providers::Vmware::InfraManager::EventCatcher::Runner < ManageIQ
 
     [sub_event_type, display_name]
   end
+
+  private
+
+  def worker_options
+    super.merge(
+      :ems => [
+        @ems.attributes.merge(
+          "endpoints"       => @ems.endpoints,
+          "authentications" => @ems.authentications
+        )
+      ]
+    )
+  end
+
+  def worker_cmdline
+    ManageIQ::Providers::Vmware::Engine.root.join("workers/event_catcher/worker").to_s
+  end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -41,6 +41,7 @@
         :flooding_monitor_enabled: true
         :poll: 1.seconds
         :ems_event_max_wait: 60
+        :rails_worker: false
       :event_catcher_vmware_cloud:
         :poll: 15.seconds
         :duration: 10.seconds


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/22138