### PR TITLE
Fix non-rails event_parser not linking up VMs

### DIFF
--- a/spec/workers/event_catcher/data/event_ex.yml
+++ b/spec/workers/event_catcher/data/event_ex.yml
@@ -1,0 +1,32 @@
+--- !ruby/object:RbVmomi::VIM::EventEx
+props:
+  :key: 13784001
+  :chainId: 13784001
+  :createdTime: 2022-10-20 19:16:43.173941000 Z
+  :userName: ''
+  :datacenter: !ruby/object:RbVmomi::VIM::DatacenterEventArgument
+    props:
+      :name: DC1
+      :datacenter: !ruby/object:RbVmomi::VIM::Datacenter
+        connection: nil
+        ref: datacenter-6548
+  :computeResource: !ruby/object:RbVmomi::VIM::ComputeResourceEventArgument
+    props:
+      :name: Cluster1
+      :computeResource: !ruby/object:RbVmomi::VIM::ClusterComputeResource
+        connection: nil
+        soap: nil
+        ref: domain-c6564
+  :host: !ruby/object:RbVmomi::VIM::HostEventArgument
+    props:
+      :name: esx1
+      :host: !ruby/object:RbVmomi::VIM::HostSystem
+        connection: nil
+        soap: nil
+        ref: host-6528
+  :fullFormattedMessage: ''
+  :changeTag: ''
+  :eventTypeId: ''
+  :arguments: []
+  :objectId: ha-eventmgr
+  :objectType: HostSystem

--- a/spec/workers/event_catcher/data/user_login_session_event.yml
+++ b/spec/workers/event_catcher/data/user_login_session_event.yml
@@ -1,0 +1,13 @@
+--- !ruby/object:RbVmomi::VIM::UserLoginSessionEvent
+props:
+  :key: 13782694
+  :chainId: 13782694
+  :createdTime: 2022-10-20 19:05:38.988613000 Z
+  :userName: root
+  :fullFormattedMessage: User root logged in as
+    HTTPClient/1.0 (2.8.3, ruby 2.7.6 (2022-04-12))
+  :changeTag: ''
+  :ipAddress: 127.0.0.1
+  :userAgent: HTTPClient/1.0 (2.8.3, ruby 2.7.6 (2022-04-12))
+  :locale: en
+  :sessionId: 52cbdd94-bf4a-ed81-2a2f-698e5bd83fe6

--- a/spec/workers/event_catcher/data/virtual_machine_event_ex.yml
+++ b/spec/workers/event_catcher/data/virtual_machine_event_ex.yml
@@ -1,0 +1,41 @@
+--- !ruby/object:RbVmomi::VIM::EventEx
+props:
+  :key: 13784001
+  :chainId: 13784001
+  :createdTime: 2022-10-20 19:16:43.173941000 Z
+  :userName: ''
+  :datacenter: !ruby/object:RbVmomi::VIM::DatacenterEventArgument
+    props:
+      :name: DC1
+      :datacenter: !ruby/object:RbVmomi::VIM::Datacenter
+        connection: nil
+        ref: datacenter-6548
+  :computeResource: !ruby/object:RbVmomi::VIM::ComputeResourceEventArgument
+    props:
+      :name: Cluster1
+      :computeResource: !ruby/object:RbVmomi::VIM::ClusterComputeResource
+        connection: nil
+        soap: nil
+        ref: domain-c6564
+  :host: !ruby/object:RbVmomi::VIM::HostEventArgument
+    props:
+      :name: esx1
+      :host: !ruby/object:RbVmomi::VIM::HostSystem
+        connection: nil
+        soap: nil
+        ref: host-6528
+  :vm: !ruby/object:RbVmomi::VIM::VmEventArgument
+    props:
+      :name: event_test
+      :vm: !ruby/object:RbVmomi::VIM::VirtualMachine
+        connection: nil
+        soap: nil
+        ref: vm-67544
+  :fullFormattedMessage: Virtual machine event_test in cluster Cluster1 in DC1
+    is not vSphere HA Protected.
+  :changeTag: ''
+  :eventTypeId: com.vmware.vc.HA.VmUnprotectedEvent
+  :arguments: []
+  :objectId: vm-67544
+  :objectType: VirtualMachine
+  :objectName: event_test

--- a/spec/workers/event_catcher/data/virtual_machine_power_off_task_event.yml
+++ b/spec/workers/event_catcher/data/virtual_machine_power_off_task_event.yml
@@ -1,0 +1,59 @@
+--- !ruby/object:RbVmomi::VIM::TaskEvent
+props:
+  :key: 13783975
+  :chainId: 13783975
+  :createdTime: 2022-10-20 19:16:30.085025000 Z
+  :userName: root
+  :datacenter: !ruby/object:RbVmomi::VIM::DatacenterEventArgument
+    props:
+      :name: DC1
+      :datacenter: !ruby/object:RbVmomi::VIM::Datacenter
+        connection: nil
+        soap: nil
+        ref: datacenter-6548
+  :computeResource: !ruby/object:RbVmomi::VIM::ComputeResourceEventArgument
+    props:
+      :name: Cluster1
+      :computeResource: !ruby/object:RbVmomi::VIM::ClusterComputeResource
+        connection: nil
+        soap: nil
+        ref: domain-c6564
+  :host: !ruby/object:RbVmomi::VIM::HostEventArgument
+    props:
+      :name: esx1
+      :host: !ruby/object:RbVmomi::VIM::HostSystem
+        connection: nil
+        soap: nil
+        ref: host-6528
+  :vm: !ruby/object:RbVmomi::VIM::VmEventArgument
+    props:
+      :name: event_test
+      :vm: !ruby/object:RbVmomi::VIM::VirtualMachine
+        connection: nil
+        soap: nil
+        ref: vm-67544
+  :fullFormattedMessage: 'Task: Power Off virtual machine'
+  :changeTag: ''
+  :info: !ruby/object:RbVmomi::VIM::TaskInfo
+    props:
+      :key: task-783502
+      :task: !ruby/object:RbVmomi::VIM::Task
+        connection: nil
+        soap: nil
+        ref: task-783502
+      :name: PowerOffVM_Task
+      :descriptionId: VirtualMachine.powerOff
+      :entity: !ruby/object:RbVmomi::VIM::VirtualMachine
+        connection: nil
+        soap: nil
+        ref: vm-67544
+      :entityName: event_test
+      :locked: []
+      :state: queued
+      :cancelled: false
+      :cancelable: true
+      :reason: !ruby/object:RbVmomi::VIM::TaskReasonUser
+        props:
+          :userName: root
+      :queueTime: 2022-10-20 19:16:30.084901000 Z
+      :eventChainId: 0

--- a/spec/workers/event_catcher/data/virtual_machine_power_on_task_event.yml
+++ b/spec/workers/event_catcher/data/virtual_machine_power_on_task_event.yml
@@ -1,0 +1,38 @@
+--- !ruby/object:RbVmomi::VIM::TaskEvent
+props:
+  :key: 13784890
+  :chainId: 13784890
+  :createdTime: 2022-10-20 19:25:25.308626000 Z
+  :userName: root
+  :datacenter: !ruby/object:RbVmomi::VIM::DatacenterEventArgument
+    props:
+      :name: DC1
+      :datacenter: !ruby/object:RbVmomi::VIM::Datacenter
+        connection: nil
+        soap: nil
+        ref: datacenter-6548
+  :fullFormattedMessage: 'Task: Initialize powering On'
+  :changeTag: ''
+  :info: !ruby/object:RbVmomi::VIM::TaskInfo
+    props:
+      :key: task-783503
+      :task: !ruby/object:RbVmomi::VIM::Task
+        connection: nil
+        soap: nil
+        ref: task-783503
+      :name: PowerOnMultiVM_Task
+      :descriptionId: Datacenter.powerOnVm
+      :entity: !ruby/object:RbVmomi::VIM::Datacenter
+        connection: nil
+        soap: nil
+        ref: datacenter-6548
+      :entityName: DC1
+      :locked: []
+      :state: queued
+      :cancelled: false
+      :cancelable: true
+      :reason: !ruby/object:RbVmomi::VIM::TaskReasonUser
+        props:
+          :userName: root
+      :queueTime: 2022-10-20 19:25:25.308277000 Z
+      :eventChainId: 0

--- a/spec/workers/event_catcher/event_parser_spec.rb
+++ b/spec/workers/event_catcher/event_parser_spec.rb
@@ -1,0 +1,89 @@
+require ManageIQ::Providers::Vmware::Engine.root.join("workers/event_catcher/event_parser.rb").to_s
+
+RSpec.describe EventParser do
+  require "rbvmomi"
+
+  context "with a general user event" do
+    let(:event) { load_event("user_login_session_event") }
+
+    it "parses the event" do
+      expect(described_class.parse_event(event)).to include(
+        :chain_id   => 13_782_694,
+        :event_type => "UserLoginSessionEvent",
+        :source     => "VC",
+        :is_task    => false,
+        :message    => a_string_including("User root logged in"),
+        :username   => "root",
+        :full_data  => hash_including(
+          :chainId   => 13_782_694,
+          :changeTag => "",
+          :key       => 13_782_694,
+          :locale    => "en",
+          :sessionId => "52cbdd94-bf4a-ed81-2a2f-698e5bd83fe6",
+          :userAgent => "HTTPClient/1.0 (2.8.3, ruby 2.7.6 (2022-04-12))",
+          :userName  => "root"
+        )
+      )
+    end
+  end
+
+  context "with a VM event" do
+    let(:event) { load_event("virtual_machine_power_off_task_event") }
+
+    it "sets vm_ems_ref, vm_name, host_ems_ref, and host_name" do
+      expect(described_class.parse_event(event)).to include(
+        :event_type   => "PowerOffVM_Task",
+        :vm_ems_ref   => "vm-67544",
+        :vm_name      => "event_test",
+        :host_ems_ref => "host-6528",
+        :host_name    => "esx1"
+      )
+    end
+  end
+
+  context "with an EventEx event" do
+    context "with an eventTypeId" do
+      let(:event) { load_event("virtual_machine_event_ex") }
+
+      it "sets the event_type to the EventTypeId" do
+        expect(described_class.parse_event(event)).to include(
+          :event_type => "com.vmware.vc.HA.VmUnprotectedEvent",
+          :message    => "Virtual machine event_test in cluster Cluster1 in DC1 is not vSphere HA Protected."
+        )
+      end
+    end
+
+    context "without an eventTypeId" do
+      let(:event) { load_event("event_ex") }
+
+      it "sets the event_type to EventEx" do
+        expect(described_class.parse_event(event)).to include(
+          :event_type => "EventEx",
+          :message    => ""
+        )
+      end
+    end
+  end
+
+  context "with a TaskEvent" do
+    let(:event) { load_event("virtual_machine_power_on_task_event") }
+
+    it "set is_task to true" do
+      expect(described_class.parse_event(event)).to include(
+        :is_task => true
+      )
+    end
+  end
+
+  # TODO: add events with sourceVm, srcTemplate, destName, destHost
+
+  private
+
+  def load_event(event_name)
+    YAML.load_file(event_data_dir.join("#{event_name}.yml"))
+  end
+
+  def event_data_dir
+    @event_data_dir ||= Pathname.new(__dir__).join("data")
+  end
+end

--- a/workers/event_catcher/event_parser.rb
+++ b/workers/event_catcher/event_parser.rb
@@ -42,46 +42,42 @@ class EventParser
     result[:username] = event.userName if event.userName.present?
 
     # Get the vm information
-    vm_key = "vm"          if event.props.key?("vm")
-    vm_key = "sourceVm"    if event.props.key?("sourceVm")
-    vm_key = "srcTemplate" if event.props.key?("srcTemplate")
+    vm_key = :vm          if event.props.key?(:vm)
+    vm_key = :sourceVm    if event.props.key?(:sourceVm)
+    vm_key = :srcTemplate if event.props.key?(:srcTemplate)
     if vm_key
-      vm_data = event.send(vm_key)
-
-      result[:vm_ems_ref]  = vm_data&.vm                 if vm_data&.vm
-      result[:vm_name]     = CGI.unescape(vm_data&.name) if vm_data&.name
-      result[:vm_location] = vm_data&.path               if vm_data&.path
-      result[:vm_uid_ems]  = vm_data&.uuid               if vm_data&.uuid
-
-      result
+      vm = event.send(vm_key)
+      if vm
+        result[:vm_ems_ref] = vm.vm._ref                   if vm.vm
+        result[:vm_name]    = CGI.unescape(vm.name)        if vm.name
+      end
     end
 
     # Get the dest vm information
     has_dest = false
     if %w[sourceVm srcTemplate].include?(vm_key)
-      vm_data = event.vm
-      if vm_data
-        result[:dest_vm_ems_ref]  = vm_data&.vm                 if vm_data&.vm
-        result[:dest_vm_name]     = CGI.unescape(vm_data&.name) if vm_data&.name
-        result[:dest_vm_location] = vm_data&.path               if vm_data&.path
+      vm = event.vm
+      if vm
+        result[:dest_vm_ems_ref] = vm.vm._ref                   if vm.vm
+        result[:dest_vm_name]    = CGI.unescape(vm.name)        if vm.name
       end
 
       has_dest = true
-    elsif event.props.key?("destName")
+    elsif event.props.key?(:destName)
       result[:dest_vm_name] = event.destName
       has_dest = true
     end
 
     if event.props.key?(:host)
       result[:host_name]    = event.host.name
-      result[:host_ems_ref] = event.host.host
+      result[:host_ems_ref] = event.host.host._ref
     end
 
     if has_dest
-      host_data = event.props["destHost"] || event.props["host"]
+      host_data = event.props[:destHost] || event.props[:host]
       if host_data
-        result[:dest_host_ems_ref] = host_data["host"]
-        result[:dest_host_name]    = host_data["name"]
+        result[:dest_host_ems_ref] = host_data[:host]
+        result[:dest_host_name]    = host_data[:name]
       end
     end
 


### PR DESCRIPTION
The non-rails parser was based on the standard Vmware::InfraManager::EventCatcher which uses VMwareWebService so the hash keys were strings not symbols like they are in RbVmomi.

Also add specs covering the cases covered by the standard event parser.