### PR TITLE
Fix TypeError passing 2.minutes to Thread#join

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -32,7 +32,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
     if vim_thread
       # Give the collector thread a chance to exit cleanly, then kill it to
       # ensure we don't have multiple collector threads running.
-      result = vim_thread.join(join_timeout)
+      result = vim_thread.join(join_timeout.to_f)
       vim_thread.kill if result.nil?
     end
 


### PR DESCRIPTION
At some point (ruby 3 or rails 6.1 not sure yet) `Thread#join` wasn't able to accept `2.minutes` anymore.

```
>> thread = Thread.new { sleep 10 }
=> #<Thread:0x0000558767083588 (irb):1 run>
>> thread.join(2.minutes)
(irb):2:in `join': can't convert ActiveSupport::Duration into Float (TypeError)
```