### PR TITLE
Add allow_targeted_refresh? to Vmware InfraManager

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -302,6 +302,10 @@ module ManageIQ::Providers
       true
     end
 
+    def allow_targeted_refresh?
+      true
+    end
+
     def queue_name_for_ems_operations
       queue_name
     end


### PR DESCRIPTION
While not actually used by the VMware streaming refresh worker, not having allow_targeted_refresh? defined meant that any e.g. user automate code which queued a `vm.refresh_ems` would end up actually executing a full refresh and restarting the refresh worker's collector thread.

Adding allow_targeted_refresh? will queue up a simple target which will be ignored by the refresh worker since we are refreshing from `WaitForUpdatesEx` directly.