### PR TITLE
add a customizable disk_size field to vm post-provision 

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/configuration.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/configuration.rb
@@ -5,11 +5,37 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration
   include_concern 'Network'
   include_concern 'Disk'
 
-  def reconfigure_hardware_on_destination?
+  def reconfigure_container_on_destination?
     # Do we need to perform a post-clone hardware reconfigure on the new VM?
     [:cpu_limit, :memory_limit, :cpu_reserve, :memory_reserve].any? do |k|
       return false unless options.key?(k)
       destination.send(k) != options[k]
     end
+  end
+
+  def reconfigure_disk_on_destination?
+    return false unless options.key?(:allocated_disk_storage)
+
+    # TODO: short-term fix to only enable :allocated_disk_storage in machines that have a single hard disk
+    #   in the long-term it should be able to deal with multiple hard disks
+    if vm.hardware.disks.where(:device_type => "disk").length != 1
+      _log.info("custom disk size is currently only supported for machines that have a single hard disk")
+      return false
+    end
+
+    default_size = vm.hardware.disks.find_by(:device_type => "disk").size / (1024**3)
+    get_option(:allocated_disk_storage).to_f > default_size
+  end
+
+  def reconfigure_hardware
+    config_spec = VimHash.new("VirtualMachineConfigSpec") do |vmcs|
+      set_cpu_and_memory_allocation(vmcs) if reconfigure_container_on_destination?
+      set_disk_allocation(vm, vmcs) if reconfigure_disk_on_destination?
+    end
+    return if config_spec.empty?
+
+    _log.info("Calling VM reconfiguration")
+    dump_obj(config_spec, "#{_log.prefix} Post-create Config spec: ", $log, :info)
+    vm.spec_reconfigure(config_spec)
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/container.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/container.rb
@@ -107,25 +107,19 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration::Cont
     @new_device_idx -= 1
   end
 
-  def set_cpu_and_memory_allocation(vm)
-    config_spec = VimHash.new("VirtualMachineConfigSpec") do |vmcs|
-      vmcs.cpuAllocation    = VimHash.new("ResourceAllocationInfo") do |rai|
-        set_spec_option(rai, :limit,       :cpu_limit,   nil, :to_i)
-        set_spec_option(rai, :reservation, :cpu_reserve, nil, :to_i)
-      end
-
-      vmcs.memoryAllocation = VimHash.new("ResourceAllocationInfo") do |rai|
-        set_spec_option(rai, :limit,       :memory_limit,   nil, :to_i)
-        set_spec_option(rai, :reservation, :memory_reserve, nil, :to_i)
-      end
-
-      # Only explicitly disable #MemoryReservationLockedToMax if the memory reserve
-      # is less than the total vm memory
-      vmcs.memoryReservationLockedToMax = false if get_option(:memory_reserve).to_i < get_option(:vm_memory).to_i
+  def set_cpu_and_memory_allocation(vmcs)
+    vmcs.cpuAllocation = VimHash.new("ResourceAllocationInfo") do |rai|
+      set_spec_option(rai, :limit,       :cpu_limit,   nil, :to_i)
+      set_spec_option(rai, :reservation, :cpu_reserve, nil, :to_i)
     end
 
-    _log.info("Calling VM reconfiguration")
-    dump_obj(config_spec, "#{_log.prefix} Post-create Config spec: ", $log, :info)
-    vm.spec_reconfigure(config_spec)
+    vmcs.memoryAllocation = VimHash.new("ResourceAllocationInfo") do |rai|
+      set_spec_option(rai, :limit,       :memory_limit,   nil, :to_i)
+      set_spec_option(rai, :reservation, :memory_reserve, nil, :to_i)
+    end
+
+    # Only explicitly disable #MemoryReservationLockedToMax if the memory reserve
+    # is less than the total vm memory
+    vmcs.memoryReservationLockedToMax = false if get_option(:memory_reserve).to_i < get_option(:vm_memory).to_i
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb
@@ -72,7 +72,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::StateMachine
     _log.info("Post-processing #{destination_type} id: [#{destination.id}], name: [#{dest_name}]")
     update_and_notify_parent(:message => "Starting New #{destination_type} Customization")
 
-    set_cpu_and_memory_allocation(destination) if reconfigure_hardware_on_destination?
+    reconfigure_hardware
     signal :autostart_destination
   end
 

--- a/app/models/manageiq/providers/vmware/infra_manager/provision_via_pxe/state_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision_via_pxe/state_machine.rb
@@ -3,8 +3,7 @@ module ManageIQ::Providers::Vmware::InfraManager::ProvisionViaPxe::StateMachine
     _log.info("Post-processing #{destination_type} id: [#{destination.id}], name: [#{dest_name}]")
     update_and_notify_parent(:message => "Starting New #{destination_type} Customization")
 
-    set_cpu_and_memory_allocation(destination) if reconfigure_hardware_on_destination?
-
+    reconfigure_hardware
     signal :create_pxe_configuration_file
   end
 

--- a/content/miq_dialogs/miq_provision_vmware_cluster_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_cluster_dialogs_template.yaml
@@ -615,6 +615,13 @@
           :display: :edit
           :default: unchanged
           :data_type: :string
+        :allocated_disk_storage:
+          :description: Allocated Disk Storage (GB)
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :notes: (default taken from template, custom can only be larger)
+          :notes_display: :show
         :cpu_limit:
           :description: CPU (MHz)
           :required: false

--- a/content/miq_dialogs/miq_provision_vmware_dialogs_clone_to_template.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_dialogs_clone_to_template.yaml
@@ -652,6 +652,13 @@
           :display: :edit
           :default: unchanged
           :data_type: :string
+        :allocated_disk_storage:
+          :description: Allocated Disk Storage (GB)
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :notes: (default taken from template, custom can only be larger)
+          :notes_display: :show
         :cpu_limit:
           :description: CPU (MHz)
           :required: false

--- a/content/miq_dialogs/miq_provision_vmware_dialogs_clone_to_vm.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_dialogs_clone_to_vm.yaml
@@ -661,6 +661,13 @@
           :display: :edit
           :default: unchanged
           :data_type: :string
+        :allocated_disk_storage:
+          :description: Allocated Disk Storage (GB)
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :notes: (default taken from template, custom can only be larger)
+          :notes_display: :show
         :cpu_limit:
           :description: CPU (MHz)
           :required: false

--- a/content/miq_dialogs/miq_provision_vmware_dialogs_ovf.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_dialogs_ovf.yaml
@@ -677,6 +677,13 @@
           :display: :edit
           :default: unchanged
           :data_type: :string
+        :allocated_disk_storage:
+          :description: Allocated Disk Storage (GB)
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :notes: (default taken from template, custom can only be larger)
+          :notes_display: :show
         :cpu_limit:
           :description: CPU (MHz)
           :required: false

--- a/content/miq_dialogs/miq_provision_vmware_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_dialogs_template.yaml
@@ -693,6 +693,13 @@
           :display: :edit
           :default: unchanged
           :data_type: :string
+        :allocated_disk_storage:
+          :description: Allocated Disk Storage (GB)
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :notes: (default taken from template, custom can only be larger)
+          :notes_display: :show
         :cpu_limit:
           :description: CPU (MHz)
           :required: false

--- a/content/miq_dialogs/miq_provision_vmware_folder_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_folder_dialogs_template.yaml
@@ -605,6 +605,13 @@
           :display: :edit
           :default: unchanged
           :data_type: :string
+        :allocated_disk_storage:
+          :description: Allocated Disk Storage (GB)
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :notes: (default taken from template, custom can only be larger)
+          :notes_display: :show
         :cpu_limit:
           :description: CPU (MHz)
           :required: false


### PR DESCRIPTION
add a customizable disk_size field to vm post-provision, including refactoring to separate between container reconfiguration (memory, CPU) and disk resize.

![](https://user-images.githubusercontent.com/106743023/204128420-8d87eadb-76d8-4fcc-98c5-5798bdfda701.png)

related PRs:
manageiq: https://github.com/ManageIQ/manageiq/pull/22251

ui-classic: https://github.com/ManageIQ/manageiq-ui-classic/pull/8547