### PR TITLE
Use the new after_update_endpoints callback for RefreshWorker

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -344,14 +344,14 @@ module ManageIQ::Providers
       true
     end
 
-    def after_update_authentication
+    def after_update_authentication(changes)
       super
-      stop_refresh_worker_queue_on_credential_change
+      stop_refresh_worker_queue_on_credential_change(changes)
     end
 
-    def after_update_endpoints
+    def after_update_endpoints(changes)
       super
-      stop_refresh_worker_queue_on_change
+      stop_refresh_worker_queue_on_change(changes)
     end
 
     def self.event_monitor_class

--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -31,7 +31,6 @@ module ManageIQ::Providers
     include VimConnectMixin
     include CisConnectMixin
 
-    before_save :stop_event_monitor_queue_on_change, :stop_refresh_worker_queue_on_change
     before_destroy :stop_event_monitor, :stop_refresh_worker
 
     supports :catalog
@@ -348,6 +347,11 @@ module ManageIQ::Providers
     def after_update_authentication
       super
       stop_refresh_worker_queue_on_credential_change
+    end
+
+    def after_update_endpoints
+      super
+      stop_refresh_worker_queue_on_change
     end
 
     def self.event_monitor_class

--- a/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
@@ -239,39 +239,6 @@ describe ManageIQ::Providers::Vmware::InfraManager do
     end
   end
 
-  context "handling changes that may require EventCatcher restart" do
-    before(:each) do
-      zone = EvmSpecHelper.local_miq_server.zone
-      @ems = FactoryBot.create(:ems_vmware, :zone => zone)
-    end
-
-    it "will restart EventCatcher when ipaddress changes" do
-      @ems.update(:ipaddress => "1.1.1.1")
-      assert_event_catcher_restart_queued
-    end
-
-    it "will restart EventCatcher when hostname changes" do
-      @ems.update(:hostname => "something-else")
-      assert_event_catcher_restart_queued
-    end
-
-    it "will restart EventCatcher when credentials change" do
-      @ems.update_authentication(:default => {:userid => "new_user_id"})
-      assert_event_catcher_restart_queued
-    end
-
-    it "will not put multiple restarts of the EventCatcher on the queue" do
-      @ems.update(:ipaddress => "1.1.1.1")
-      @ems.update(:hostname => "something else")
-      assert_event_catcher_restart_queued
-    end
-
-    it "will not restart EventCatcher when name changes" do
-      @ems.update(:name => "something else")
-      expect(MiqQueue.count).to eq(0)
-    end
-  end
-
   context "catalog types" do
     it "#catalog_types" do
       ems = FactoryBot.create(:ems_vmware)


### PR DESCRIPTION
Restart the RefreshWorker after endpoints are updated

Related:
* https://github.com/ManageIQ/manageiq/pull/22269