### PR TITLE
Fix Uninitialized constant Handsoap verify ESXi

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/host_esx.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/host_esx.rb
@@ -144,6 +144,7 @@ class ManageIQ::Providers::Vmware::InfraManager::HostEsx < ManageIQ::Providers::
   def verify_credentials_with_ws(auth_type = nil)
     raise "No credentials defined" if self.missing_credentials?(auth_type)
 
+    require "handsoap"
     begin
       with_provider_connection(:use_broker => false, :auth_type => auth_type) {}
     rescue SocketError, Errno::EHOSTUNREACH, Errno::ENETUNREACH => err


### PR DESCRIPTION
Fix the uninitialized constant Handsoap failure when verifying host
credentials.

```
ERROR -- evm: MIQ(host_controller-update): uninitialized constant ManageIQ::Providers::Vmware::InfraManager::HostEsx::Handsoap
```

Fixes https://github.com/ManageIQ/manageiq-providers-vmware/issues/847