### PR TITLE
make default credentials verify ws

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/host_esx.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/host_esx.rb
@@ -164,6 +164,10 @@ class ManageIQ::Providers::Vmware::InfraManager::HostEsx < ManageIQ::Providers::
     end
   end
 
+  def verify_credentials_default(auth_type, _options)
+    verify_credentials_with_ws(auth_type)
+  end
+
   def refresh_logs
     if self.missing_credentials?
       _log.warn "No credentials defined for Host [#{name}]"


### PR DESCRIPTION
part of https://github.com/ManageIQ/manageiq/pull/22336
(this can be merged before that PR)

`Host` used to default credential verification to `ws`.
`HostEsx` is the only host that implements `ws`.
So now, the default verification is going over `ssh`.

This change keeps the default verification method as `ws` for Esx Hosts

