### PR TITLE
Fix wrong number of arguments delete_snapshot_by_description

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/scanning/job.rb
@@ -191,7 +191,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Scanning::Job < VmScan
         begin
           password_decrypt = ManageIQ::Password.decrypt(miqVimHost[:password])
           require 'VMwareWebService/MiqVim'
-          miqVim = MiqVim.new(server, miqVimHost[:username], password_decrypt)
+          miqVim = MiqVim.new(:server => server, :username => miqVimHost[:username], :password => password_decrypt)
 
           vimVm = miqVim.getVimVm(vm.path)
           vimVm.removeSnapshotByDescription(mor, true) unless vimVm.nil?


### PR DESCRIPTION
Fix `wrong number of arguments (given 3, expected 0; required keywords: server, username, password)`

Ref: https://github.com/ManageIQ/manageiq-providers-vmware/issues/858#issuecomment-1454049175