### PR TITLE
Prevent `""` domain_name causing trailing `.`

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/host_system.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/host_system.rb
@@ -46,7 +46,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
         hostname    = dns_config[:hostName]
         domain_name = dns_config[:domainName]
 
-        hostname = "#{hostname}.#{domain_name}" if domain_name
+        hostname = "#{hostname}.#{domain_name}" if domain_name.present?
 
         host_hash[:name]     = hostname
         host_hash[:hostname] = hostname


### PR DESCRIPTION
If a domain_name is an empty string and not just blank we will build a hostname with a trailing `.`