### PR TITLE
Drop lib/gem-name.rb in favor of lib/gem/name.rb

### DIFF
--- a/lib/manageiq-providers-vmware.rb
+++ b/lib/manageiq-providers-vmware.rb
@@ -1,4 +1,0 @@
-require "manageiq/providers/vmware/engine"
-require "manageiq/providers/vmware/version"
-
-require "manageiq/providers/vmware"

--- a/lib/manageiq/providers/vmware.rb
+++ b/lib/manageiq/providers/vmware.rb
@@ -1,3 +1,6 @@
+require "manageiq/providers/vmware/engine"
+require "manageiq/providers/vmware/version"
+
 module ManageIQ
   module Providers
     module Vmware

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ end
 Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }
 Dir[File.join(__dir__, "support/**/*.rb")].each { |f| require f }
 
-require "manageiq-providers-vmware"
+require "manageiq/providers/vmware"
 
 VCR.configure do |config|
   config.ignore_hosts 'codeclimate.com' if ENV['CI']


### PR DESCRIPTION
Adopt convention already supported by bundler and required by zeitwerk so we don't need to tell zeitwerk to ignore this lib/gem-name.rb file.