### PR TITLE
Converge batch_size and concurrent_requests

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/metrics_capture.rb
@@ -371,7 +371,7 @@ class ManageIQ::Providers::Vmware::InfraManager::MetricsCapture < ManageIQ::Prov
     Benchmark.current_realtime[:num_vim_queries] = params.length
     _log.debug { "Total item(s) to be requested: [#{params.length}], #{params.inspect}" }
 
-    query_size = Metric::Capture.concurrent_requests(interval_name)
+    query_size = concurrent_requests(interval_name)
     vim_trips = 0
     params.each_slice(query_size) do |query|
       vim_trips += 1
@@ -387,6 +387,13 @@ class ManageIQ::Providers::Vmware::InfraManager::MetricsCapture < ManageIQ::Prov
     Benchmark.current_realtime[:num_vim_trips] = vim_trips
 
     return counters_by_mor, counter_values_by_mor_and_ts
+  end
+
+  def concurrent_requests(interval_name)
+    query_size = super
+    # even when batching is turned off, still want to send multiple realtime records
+    query_size = 20 if query_size < 20 && interval_name == "realtime"
+    query_size
   end
 
   class << self

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,7 +8,10 @@
           :critical:
         :power:
           :critical:
-    :capture_batch_size: 250
+    :concurrent_requests:
+      :historical: 100
+      :hourly: 250
+      :realtime: 100
 :ems_refresh:
   :vmware_tanzu:
     :refresh_interval: 24.hours


### PR DESCRIPTION
part of: https://github.com/ManageIQ/manageiq/pull/22510

## Before

- concurrent_requests, thought it existed in core, was vmware only. It was split up into historical, hourly, and realtime.

- batch_size was per provider (but only implemented by vmware) It just has a single option.

## After

- concurrent_requests defined in the provider (but only implemented by vmare) It is split up into historical, hourly, and realtime.

## Reason for change

While  batch_size may be 250, concurrent_requests was then applied and we were sending only 20 requests for realtime and 1 for historical.

So in the end, we only are sending 1 request to the provider. The optimization has basically been disabled.

This gives better values for concurrent requests, and matches the requests sent to the collector over the queue and from the collector to the provider

This requires changes in both vmware and core.

NOTE: these values are estimates and have not been battle tested in production.
They are better than the current values though (read: 1)