### PR TITLE
Changed Feature Name from native to management_console

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -38,7 +38,7 @@ module ManageIQ::Providers
     supports :create
     supports :label_mapping
     supports :metrics
-    supports :native_console
+    supports :management_console
     supports :provisioning
     supports :smartstate_analysis
     supports :streaming_refresh do


### PR DESCRIPTION
Related: https://github.com/ManageIQ/manageiq/pull/22474

Changes the feature name from native_console to management_console since native_console is already used by the RHV provider.