### PR TITLE
Handle a HostSystem with missing product vendor

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/host_system.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser/host_system.rb
@@ -113,14 +113,21 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
       product = props.fetch_path(:summary, :config, :product)
       return if product.nil?
 
-      vendor = product[:vendor].split(",").first.to_s.downcase
-      vendor = "unknown" unless Host::VENDOR_TYPES.include?(vendor)
-      host_hash[:vmm_vendor] = vendor
+      host_hash[:vmm_vendor] = host_system_vendor(product[:vendor])
 
       product_name = product[:name]
       host_hash[:vmm_product]     = product_name.nil? ? nil : product_name.to_s.gsub(/^VMware\s*/i, "")
       host_hash[:vmm_version]     = product[:version]
       host_hash[:vmm_buildnumber] = product[:build]
+    end
+
+    def host_system_vendor(vendor)
+      return "unknown" if vendor.nil?
+
+      vendor = vendor.split(",").first.to_s.downcase
+      vendor = "unknown" unless Host::VENDOR_TYPES.include?(vendor)
+
+      vendor
     end
 
     def parse_host_system_runtime(host_hash, props)


### PR DESCRIPTION
Handle the case where a HostSystem is missing `summary.config.product.vendor`.
We already set the `vmm_vendor` to `"unknown"` if we do not recognize the vendor, but this will throw an exception if the attribute is completely missing:
```
     Failure/Error: vendor = product[:vendor].split(",").first.to_s.downcase
     
     NoMethodError:
       undefined method `split' for nil:NilClass
     # ./app/models/manageiq/providers/vmware/infra_manager/inventory/parser/host_system.rb:116:in `parse_host_system_product'
     # ./app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb:205:in `parse_host_system'
     # ./app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb:28:in `parse'
     # ./app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb:252:in `block in parse_updates'
     # ./app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb:242:in `each'
     # ./app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb:242:in `parse_updates'
```