### PR TITLE
Set sub_event_type for com.vmware.cns.tasks.updatevolume

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/event_parser.rb
@@ -27,8 +27,10 @@ module ManageIQ::Providers::Vmware::InfraManager::EventParser
       case sub_event_type
       when nil
         # Handle cases where event name is missing
-        sub_event_type = 'PowerOnVM_Task'    if event['fullFormattedMessage'].to_s.downcase == 'task: power on virtual machine'
-        sub_event_type = 'DrsMigrateVM_Task' if sub_event_type.nil? && event.fetch_path('info', 'descriptionId') == 'Drm.ExecuteVMotionLRO'
+        sub_event_type = 'PowerOnVM_Task'       if event['fullFormattedMessage'].to_s.downcase == 'task: power on virtual machine'
+        sub_event_type = 'DrsMigrateVM_Task'    if sub_event_type.nil? && event.fetch_path('info', 'descriptionId') == 'Drm.ExecuteVMotionLRO'
+        sub_event_type = 'CnsUpdateVolume_Task' if sub_event_type.nil? && event.fetch_path('info', 'descriptionId') == 'com.vmware.cns.tasks.updatevolume'
+
         if sub_event_type.nil?
           _log.warn("#{log_header}Event Type cannot be determined for TaskEvent. Using generic eventType [TaskEvent] instead. event: [#{event.inspect}]")
           sub_event_type = 'TaskEvent'


### PR DESCRIPTION
VMware Cloud Native Storage (CNS) is a component of Tanzu,
> Cloud Native Storage (CNS) is a vSphere and Kubernetes (K8s) feature that makes K8s aware of how to provision storage on vSphere on-demand

These events do not have enough info to be classified as anything other than generic TaskEvents.