### PR TITLE
Bump rbvmomi2 to 3.7.0 for vSphere 8.0U2

### DIFF
--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "ffi-vix_disk_lib",       "~>1.3", ">= 1.3.1"
   spec.add_dependency "fog-vcloud-director",    "~> 0.3.0"
-  spec.add_dependency "rbvmomi2",               "~>3.5"
+  spec.add_dependency "rbvmomi2",               "~>3.7"
   spec.add_dependency "vmware_web_service",     "~>3.2"
   spec.add_dependency "vsphere-automation-sdk", "~>0.4.7"
 


### PR DESCRIPTION
https://github.com/ManageIQ/rbvmomi2/releases/tag/v3.7.0