### PR TITLE
Override CloudManager#network_manager to define type

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -14,6 +14,14 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
   include ManageIQ::Providers::Vmware::CloudManager::ManagerEventsMixin
   include HasNetworkManagerMixin
 
+  # override the relation defined in HasNetowrkManagerMixin
+  has_one :network_manager,
+          :foreign_key => :parent_ems_id,
+          :class_name  => "ManageIQ::Providers::Vmware::NetworkManager",
+          :autosave    => true,
+          :dependent   => :destroy,
+          :inverse_of  => :parent_manager
+
   has_many :orchestration_templates, :foreign_key => :ems_id, :inverse_of => :ext_management_system, :dependent => :destroy
   has_many :snapshots, :through => :vms_and_templates
 
@@ -21,10 +29,6 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
 
   supports :create
   supports :catalog
-
-  def ensure_network_manager
-    build_network_manager(:type => 'ManageIQ::Providers::Vmware::NetworkManager') unless network_manager
-  end
 
   def self.ems_type
     @ems_type ||= "vmware_cloud".freeze


### PR DESCRIPTION
This ensures the network manager created is the right type for a vmware cloud manager.


Surprised to find this had not been changed yet.
`HasNetworkManager#ensure_managers` has a comment to get away from `ensure_managers`, but I left this code alone here.