### PR TITLE
Don't delegate NetworkManager#zone to parent_manager

### DIFF
--- a/app/models/manageiq/providers/vmware/network_manager.rb
+++ b/app/models/manageiq/providers/vmware/network_manager.rb
@@ -19,7 +19,6 @@ class ManageIQ::Providers::Vmware::NetworkManager < ManageIQ::Providers::Network
            :authentication_status_ok?,
            :authentications,
            :authentication_for_summary,
-           :zone,
            :connect,
            :verify_credentials,
            :with_provider_connection,


### PR DESCRIPTION
The zone_id is synchronized when the parent_manager is saved so this delegation causes issues with pausing the parent provider

https://github.com/ManageIQ/manageiq-providers-vmware/pull/885
https://github.com/ManageIQ/manageiq/actions/runs/6306276756/job/17121144898#step:8:353