### PR TITLE
Delete EventCatcher worker_cmdline for non-rails worker

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/event_catcher/runner.rb
@@ -110,8 +110,4 @@ class ManageIQ::Providers::Vmware::InfraManager::EventCatcher::Runner < ManageIQ
       ]
     )
   end
-
-  def worker_cmdline
-    ManageIQ::Providers::Vmware::Engine.root.join("workers/event_catcher/worker").to_s
-  end
 end


### PR DESCRIPTION
Depends on
- [x] https://github.com/ManageIQ/manageiq/pull/22236