### PR TITLE
Ruby 3.1: Specify vim classes as permitted in test

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,12 @@ Dir[File.join(__dir__, "support/**/*.rb")].each { |f| require f }
 
 require "manageiq/providers/vmware"
 
+RSpec.configure do |config|
+  config.before do
+    YamlPermittedClasses.app_yaml_permitted_classes |= [VimHash, VimString, VimArray]
+  end
+end
+
 VCR.configure do |config|
   config.ignore_hosts 'codeclimate.com' if ENV['CI']
   config.cassette_library_dir = File.join(ManageIQ::Providers::Vmware::Engine.root, 'spec/vcr_cassettes')


### PR DESCRIPTION
Depends on the interface to add these classes to the list in this PR: 

- [ ] https://github.com/ManageIQ/manageiq/pull/22698

- [ ] https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/835