### PR TITLE
Enable non-rails event catcher by default

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -45,7 +45,7 @@
         :flooding_monitor_enabled: true
         :poll: 1.seconds
         :ems_event_max_wait: 60
-        :rails_worker: true
+        :rails_worker: false
       :event_catcher_vmware_cloud:
         :poll: 15.seconds
         :duration: 10.seconds


### PR DESCRIPTION
Since Kafka is now enabled as the default messaging we should enable the vmware non rails event catcher worker by default

- https://github.com/ManageIQ/manageiq/pull/22799

@miq-bot add_labels enhancement, quinteros/yes
@miq-bot assign @Fryguy 
@miq-bot add_reviewer @agrare 