### PR TITLE
Fix Host default_authentication_type

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/host.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/host.rb
@@ -97,23 +97,23 @@ class ManageIQ::Providers::Vmware::InfraManager::Host < ::Host
                 :fields    => [
                   {
                     :component  => 'validate-host-credentials',
-                    :id         => 'endpoints.ws.valid',
-                    :name       => 'endpoints.ws.valid',
+                    :id         => 'authentications.default.valid',
+                    :name       => 'authentications.default.valid',
                     :skipSubmit => true,
                     :isRequired => true,
                     :fields     => [
                       {
                         :component  => "text-field",
-                        :id         => "authentications.ws.userid",
-                        :name       => "authentications.ws.userid",
+                        :id         => "authentications.default.userid",
+                        :name       => "authentications.default.userid",
                         :label      => _("Username"),
                         :isRequired => true,
                         :validate   => [{:type => "required"}],
                       },
                       {
                         :component  => "password-field",
-                        :id         => "authentications.ws.password",
-                        :name       => "authentications.ws.password",
+                        :id         => "authentications.default.password",
+                        :name       => "authentications.default.password",
                         :label      => _("Password"),
                         :type       => "password",
                         :isRequired => true,
@@ -150,8 +150,8 @@ class ManageIQ::Providers::Vmware::InfraManager::Host < ::Host
                   },
                   {
                     :component  => 'validate-host-credentials',
-                    :id         => 'endpoints.remote.valid',
-                    :name       => 'endpoints.remote.valid',
+                    :id         => 'authentications.remote.valid',
+                    :name       => 'authentications.remote.valid',
                     :skipSubmit => true,
                     :condition  => {
                       :when => 'remoteEnabled',

--- a/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
@@ -2,8 +2,6 @@ module ManageIQ::Providers::Vmware::InfraManager::VimConnectMixin
   extend ActiveSupport::Concern
 
   def vim_connect(options = {})
-    options[:auth_type] ||= :ws
-
     raise _("no console credentials defined") if options[:auth_type] == :console && !authentication_type(options[:auth_type])
     raise _("no credentials defined") if missing_credentials?(options[:auth_type])
 


### PR DESCRIPTION
As part of the Host Edit Form React Conversion (https://github.com/ManageIQ/manageiq-ui-classic/pull/8608) we changed how host credentials were saved.

Previously we were using https://github.com/ManageIQ/manageiq-ui-classic/pull/8608/files#diff-2f9b6ee0650a1df116a5ec2bc289814be20808a8107e27fd15cffc2394ad416aL199 which set the `:default` authentication type.

Now as of https://github.com/ManageIQ/manageiq-providers-vmware/pull/851 and https://github.com/ManageIQ/manageiq-providers-vmware/pull/859 the authentication type being set is "ws".

This causes issues with `host.authentication_status_ok?` (which is used by SSA https://github.com/ManageIQ/manageiq/blob/master/app/models/vm_or_template.rb#L991) because it is looking for a `:default` authentication.

NOTE we will have upgrade scenarios where existing hosts will have "default" authentication records, we'll need to resolve this likely with a data migration.