### PR TITLE
Fix VM terminate showing supported when running

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/template/operations.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/template/operations.rb
@@ -1,0 +1,17 @@
+module ManageIQ::Providers::Vmware::InfraManager::Template::Operations
+  extend ActiveSupport::Concern
+
+  included do
+    supports :terminate do
+      if retired?
+        _('The VM is retired')
+      elsif terminated?
+        _('The VM is terminated')
+      elsif disconnected?
+        _('The VM does not have a valid connection state')
+      elsif !has_active_ems?
+        _("The VM is not connected to an active Provider")
+      end
+    end
+  end
+end

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/operations.rb
@@ -3,4 +3,14 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations
 
   include_concern 'Guest'
   include_concern 'Snapshot'
+
+  included do
+    supports :terminate do
+      if !supports?(:control)
+        unsupported_reason(:control)
+      elsif power_state != "off"
+        _('The VM is not powered off')
+      end
+    end
+  end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/operations.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/operations.rb
@@ -9,12 +9,6 @@ module ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared::Operations
     run_command_via_parent(:vm_set_custom_field, :attribute => attribute, :value => value)
   end
 
-  included do
-    supports :terminate do
-      unsupported_reason_add(:terminate, unsupported_reason(:control)) unless supports?(:control)
-    end
-  end
-
   def raw_clone(name, folder, pool = nil, host = nil, datastore = nil, powerOn = false, template_flag = false, transform = nil, config = nil, customization = nil, disk = nil)
     folder_mor    = folder.ems_ref_obj    if folder.respond_to?(:ems_ref_obj)
     pool_mor      = pool.ems_ref_obj      if pool.respond_to?(:ems_ref_obj)


### PR DESCRIPTION
VMware does not allow Destroy_Task to be called on a VM while it is running or suspended.  Also we were not allowing terminate on Templates because we were using `supports?(:control)` which has an explicit `!template?` condition.  Also also the spec tests for VMs were using "poweredOff" for the "suspended" cases so I've added explicit suspended contexts and changed the power state to "poweredOff" for any of the existing "off" tests.

![image](https://github.com/ManageIQ/manageiq-providers-vmware/assets/12851112/252bb1da-6710-4dc9-8599-e561318b78c8)
