### PR TITLE
Drop require_nested and include_concern

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -1,15 +1,4 @@
 class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudManager
-  require_nested :AvailabilityZone
-  require_nested :OrchestrationServiceOptionConverter
-  require_nested :OrchestrationStack
-  require_nested :OrchestrationTemplate
-  require_nested :EventCatcher
-  require_nested :EventParser
-  require_nested :RefreshWorker
-  require_nested :Refresher
-  require_nested :Template
-  require_nested :Vm
-
   include ManageIQ::Providers::Vmware::ManagerAuthMixin
   include ManageIQ::Providers::Vmware::CloudManager::ManagerEventsMixin
   include HasNetworkManagerMixin

--- a/app/models/manageiq/providers/vmware/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/event_catcher.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Vmware::CloudManager::EventCatcher < ::MiqEventCatcher
-  require_nested :Runner
-
   def self.settings_name
     :event_catcher_vmware_cloud
   end

--- a/app/models/manageiq/providers/vmware/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/orchestration_stack.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack < ManageIQ::Providers::CloudManager::OrchestrationStack
-  require_nested :Status
-
   def self.raw_create_stack(orchestration_manager, stack_name, template, options = {})
     log_prefix = "stack=[#{stack_name}]"
     orchestration_manager.with_provider_connection do |service|

--- a/app/models/manageiq/providers/vmware/cloud_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/refresh_worker.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Vmware::CloudManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
-  require_nested :Runner
 end

--- a/app/models/manageiq/providers/vmware/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm.rb
@@ -1,7 +1,7 @@
 class ManageIQ::Providers::Vmware::CloudManager::Vm < ManageIQ::Providers::CloudManager::Vm
-  include_concern 'Operations'
-  include_concern 'RemoteConsole'
-  include_concern 'Reconfigure'
+  include Operations
+  include RemoteConsole
+  include Reconfigure
 
   supports :snapshots
   supports :remove_all_snapshots

--- a/app/models/manageiq/providers/vmware/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm/operations.rb
@@ -1,8 +1,7 @@
 module ManageIQ::Providers::Vmware::CloudManager::Vm::Operations
   extend ActiveSupport::Concern
-
-  include_concern 'Power'
-  include_concern 'Snapshot'
+  include Power
+  include Snapshot
 
   included do
     supports :terminate do

--- a/app/models/manageiq/providers/vmware/container_manager.rb
+++ b/app/models/manageiq/providers/vmware/container_manager.rb
@@ -1,18 +1,6 @@
 ManageIQ::Providers::Kubernetes::ContainerManager.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::Vmware::ContainerManager < ManageIQ::Providers::Kubernetes::ContainerManager
-  require_nested :Container
-  require_nested :ContainerGroup
-  require_nested :ContainerNode
-  require_nested :ContainerTemplate
-  require_nested :EventCatcher
-  require_nested :EventParser
-  require_nested :Refresher
-  require_nested :RefreshWorker
-  require_nested :ServiceInstance
-  require_nested :ServiceOffering
-  require_nested :ServiceParametersSet
-
   supports :create
 
   def self.ems_type

--- a/app/models/manageiq/providers/vmware/container_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/vmware/container_manager/event_catcher.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Vmware::ContainerManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
-
   def self.settings_name
     :event_catcher_vmware_tanzu
   end

--- a/app/models/manageiq/providers/vmware/container_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/vmware/container_manager/refresh_worker.rb
@@ -1,7 +1,4 @@
 class ManageIQ::Providers::Vmware::ContainerManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
-  require_nested :Runner
-  require_nested :WatchThread
-
   def self.settings_name
     :ems_refresh_worker_vmware_tanzu
   end

--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -1,33 +1,5 @@
 module ManageIQ::Providers
   class Vmware::InfraManager < InfraManager
-    require_nested :Cluster
-    require_nested :Datacenter
-    require_nested :DistributedVirtualSwitch
-    require_nested :EventCatcher
-    require_nested :EventParser
-    require_nested :Folder
-    require_nested :Host
-    require_nested :HostEsx
-    require_nested :HostVirtualSwitch
-    require_nested :Inventory
-    require_nested :MetricsCapture
-    require_nested :MetricsCollectorWorker
-    require_nested :OpaqueSwitch
-    require_nested :OperationsWorker
-    require_nested :OrchestrationTemplate
-    require_nested :Provision
-    require_nested :ProvisionViaPxe
-    require_nested :ProvisionWorkflow
-    require_nested :RefreshParser # This has to be before Refresher because that includes RefreshParser::Filter
-    require_nested :Refresher
-    require_nested :RefreshWorker
-    require_nested :ResourcePool
-    require_nested :Snapshot
-    require_nested :Storage
-    require_nested :StorageCluster
-    require_nested :Template
-    require_nested :Vm
-
     include VimConnectMixin
     include CisConnectMixin
 

--- a/app/models/manageiq/providers/vmware/infra_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/event_catcher.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Vmware::InfraManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
-
   self.rails_worker = -> { !!worker_settings[:rails_worker] }
   self.worker_settings_paths = [
     %i[http_proxy vmwarews],

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory.rb
@@ -1,6 +1,2 @@
 class ManageIQ::Providers::Vmware::InfraManager::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Cache
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb
@@ -2,13 +2,12 @@ require 'VMwareWebService/VimTypes'
 
 class ManageIQ::Providers::Vmware::InfraManager::Inventory::Parser
   include Vmdb::Logging
-
-  include_concern :ComputeResource
-  include_concern :Datastore
-  include_concern :DistributedVirtualSwitch
-  include_concern :HostSystem
-  include_concern :ResourcePool
-  include_concern :VirtualMachine
+  include ComputeResource
+  include Datastore
+  include DistributedVirtualSwitch
+  include HostSystem
+  include ResourcePool
+  include VirtualMachine
 
   attr_reader :cache, :collector, :persister
   private     :cache, :collector, :persister

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/persister.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :Batch
-  require_nested :Full
-  require_nested :Targeted
-
   attr_reader :tracking_uuid
 
   def initialize_inventory_collections

--- a/app/models/manageiq/providers/vmware/infra_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/metrics_collector_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Vmware::InfraManager::MetricsCollectorWorker < ManageIQ::Providers::BaseManager::MetricsCollectorWorker
-  require_nested :Runner
-
   self.default_queue_name = "vmware"
 
   def friendly_name

--- a/app/models/manageiq/providers/vmware/infra_manager/operations_worker.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/operations_worker.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Vmware::InfraManager::OperationsWorker < ManageIQ::Providers::BaseManager::OperationsWorker
-  require_nested :Runner
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/provision.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision.rb
@@ -1,9 +1,9 @@
 class ManageIQ::Providers::Vmware::InfraManager::Provision < ::MiqProvision
-  include_concern 'Cloning'
-  include_concern 'Configuration'
-  include_concern 'Customization'
-  include_concern 'Placement'
-  include_concern 'StateMachine'
+  include Cloning
+  include Configuration
+  include Customization
+  include Placement
+  include StateMachine
 
   VALID_REQUEST_TYPES = %w(template clone_to_vm clone_to_template)
   validates_inclusion_of :request_type, :in => VALID_REQUEST_TYPES, :message => "should be one of: #{VALID_REQUEST_TYPES.join(', ')}"

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/configuration.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/configuration.rb
@@ -1,9 +1,8 @@
 module ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration
   extend ActiveSupport::Concern
-
-  include_concern 'Container'
-  include_concern 'Network'
-  include_concern 'Disk'
+  include Container
+  include Network
+  include Disk
 
   def reconfigure_container_on_destination?
     # Do we need to perform a post-clone hardware reconfigure on the new VM?

--- a/app/models/manageiq/providers/vmware/infra_manager/provision_via_pxe.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision_via_pxe.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Vmware::InfraManager::ProvisionViaPxe < ManageIQ::Providers::Vmware::InfraManager::Provision
-  include_concern 'Cloning'
-  include_concern 'Pxe'
-  include_concern 'StateMachine'
+  include Cloning
+  include Pxe
+  include StateMachine
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow < ManageIQ::Providers::InfraManager::ProvisionWorkflow
-  include_concern "DialogFieldValidation"
+  include DialogFieldValidation
 
   def self.default_dialog_file
     'miq_provision_dialogs'

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_worker.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Vmware::InfraManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
-  require_nested :Runner
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/scanning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/scanning.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Vmware::InfraManager::Scanning
-  require_nested :Job
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/template.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/template.rb
@@ -1,7 +1,6 @@
 class ManageIQ::Providers::Vmware::InfraManager::Template < ManageIQ::Providers::InfraManager::Template
-  include_concern 'ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared'
-
-  include_concern 'Scanning'
+  include ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared
+  include Scanning
 
   supports :provisioning do
     if ext_management_system

--- a/app/models/manageiq/providers/vmware/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm.rb
@@ -1,10 +1,9 @@
 class ManageIQ::Providers::Vmware::InfraManager::Vm < ManageIQ::Providers::InfraManager::Vm
-  include_concern 'ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared'
-
-  include_concern 'Operations'
-  include_concern 'RemoteConsole'
-  include_concern 'Reconfigure'
-  include_concern 'Scanning'
+  include ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared
+  include Operations
+  include RemoteConsole
+  include Reconfigure
+  include Scanning
 
   supports :capture
   supports :clone do

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/operations.rb
@@ -1,8 +1,7 @@
 module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations
   extend ActiveSupport::Concern
-
-  include_concern 'Guest'
-  include_concern 'Snapshot'
+  include Guest
+  include Snapshot
 
   included do
     supports :terminate do

--- a/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared.rb
@@ -2,11 +2,10 @@ module ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared
   extend ActiveSupport::Concern
 
   include ManageIQ::Providers::Vmware::InfraManager::EmsRefObjMixin
-
-  include_concern 'Disconnect'
-  include_concern 'Operations'
-  include_concern 'RefreshOnScan'
-  include_concern 'Scanning'
+  include Disconnect
+  include Operations
+  include RefreshOnScan
+  include Scanning
 
   POWER_STATES = {
     "poweredOn"  => "on",

--- a/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/operations.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/operations.rb
@@ -1,9 +1,9 @@
 module ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared::Operations
   extend ActiveSupport::Concern
 
-  include_concern "Configuration"
-  include_concern "Power"
-  include_concern "Relocation"
+  include Configuration
+  include Power
+  include Relocation
 
   def raw_set_custom_field(attribute, value)
     run_command_via_parent(:vm_set_custom_field, :attribute => attribute, :value => value)

--- a/app/models/manageiq/providers/vmware/inventory.rb
+++ b/app/models/manageiq/providers/vmware/inventory.rb
@@ -1,5 +1,2 @@
 class ManageIQ::Providers::Vmware::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
 end

--- a/app/models/manageiq/providers/vmware/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/inventory/collector.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Vmware::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
-  require_nested :CloudManager
-  require_nested :ContainerManager
-  require_nested :NetworkManager
-
   def initialize(_manager, _target)
     super
 

--- a/app/models/manageiq/providers/vmware/inventory/collector/container_manager.rb
+++ b/app/models/manageiq/providers/vmware/inventory/collector/container_manager.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Vmware::Inventory::Collector::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Collector::ContainerManager
-  require_nested :WatchNotice
-
   def persistent_volumes
     # VMware Tanzu Administrator cannot access persistent_volumes
     []

--- a/app/models/manageiq/providers/vmware/inventory/parser.rb
+++ b/app/models/manageiq/providers/vmware/inventory/parser.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Vmware::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-  require_nested :CloudManager
-  require_nested :ContainerManager
-  require_nested :NetworkManager
-
   def parse
     vdcs
     vapps

--- a/app/models/manageiq/providers/vmware/inventory/parser/container_manager.rb
+++ b/app/models/manageiq/providers/vmware/inventory/parser/container_manager.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Vmware::Inventory::Parser::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager
-  require_nested :WatchNotice
 end

--- a/app/models/manageiq/providers/vmware/inventory/persister.rb
+++ b/app/models/manageiq/providers/vmware/inventory/persister.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Vmware::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :CloudManager
-  require_nested :ContainerManager
-  require_nested :NetworkManager
-
   def initialize_inventory_collections
     initialize_cloud_inventory_collections
     initialize_network_inventory_collections

--- a/app/models/manageiq/providers/vmware/inventory/persister/container_manager.rb
+++ b/app/models/manageiq/providers/vmware/inventory/persister/container_manager.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Vmware::Inventory::Persister::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Persister::ContainerManager
-  require_nested :WatchNotice
 end

--- a/app/models/manageiq/providers/vmware/network_manager.rb
+++ b/app/models/manageiq/providers/vmware/network_manager.rb
@@ -1,16 +1,4 @@
 class ManageIQ::Providers::Vmware::NetworkManager < ManageIQ::Providers::NetworkManager
-  require_nested :CloudNetwork
-  require_nested :CloudSubnet
-  require_nested :LoadBalancer
-  require_nested :LoadBalancerHealthCheck
-  require_nested :LoadBalancerListener
-  require_nested :LoadBalancerPool
-  require_nested :LoadBalancerPoolMember
-
-  require_nested :NetworkPort
-  require_nested :Refresher
-  require_nested :SecurityGroup
-
   include ManageIQ::Providers::Vmware::ManagerAuthMixin
 
   # Auth and endpoints delegations, editing of this type of manager must be disabled

--- a/app/models/manageiq/providers/vmware/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/vmware/network_manager/cloud_network.rb
@@ -1,4 +1,2 @@
 class ManageIQ::Providers::Vmware::NetworkManager::CloudNetwork < ::CloudNetwork
-  require_nested :VappNet
-  require_nested :OrgVdcNet
 end


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854