### PR TITLE
drop unsupported_reason_add

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm.rb
@@ -10,7 +10,7 @@ class ManageIQ::Providers::Vmware::CloudManager::Vm < ManageIQ::Providers::Cloud
   supports :revert_to_snapshot
   supports :reconfigure_disks
   supports :reconfigure_disksize do
-    unsupported_reason_add(:reconfigure_disksize, 'Cannot resize disks of a VM with snapshots') unless snapshots.empty?
+    _("Cannot resize disks of a VM with snapshots") unless snapshots.empty?
   end
   supports :reconfigure_network_adapters
 

--- a/app/models/manageiq/providers/vmware/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm/operations.rb
@@ -5,8 +5,11 @@ module ManageIQ::Providers::Vmware::CloudManager::Vm::Operations
 
   included do
     supports :terminate do
-      unsupported_reason_add(:terminate, unsupported_reason(:control)) unless supports?(:control)
-      unsupported_reason_add(:terminate, "The VM is powered on") if vm_powered_on?
+      if vm_powered_on?
+        _("The VM is powered on")
+      else
+        unsupported_reason(:control)
+      end
     end
   end
 

--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -14,7 +14,7 @@ module ManageIQ::Providers
     supports :provisioning
     supports :smartstate_analysis
     supports :streaming_refresh do
-      unsupported_reason_add(:streaming_refresh, "Streaming refresh not enabled") unless streaming_refresh_enabled?
+      _("Streaming refresh not enabled") unless streaming_refresh_enabled?
     end
 
     def self.ems_type

--- a/app/models/manageiq/providers/vmware/infra_manager/host.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/host.rb
@@ -7,10 +7,10 @@ class ManageIQ::Providers::Vmware::InfraManager::Host < ::Host
 
   # overrides base start to support "standby" powerstate
   supports :start do
-    if !supports?(:ipmi)
-      unsupported_reason_add(:start, unsupported_reason(:ipmi))
-    elsif %w[off standby].exclude?(power_state)
-      unsupported_reason_add(:start, _("The Host is not in power state off or standby"))
+    if %w[off standby].exclude?(power_state)
+      _("The Host is not in power state off or standby")
+    else
+      unsupported_reason(:ipmi)
     end
   end
 

--- a/app/models/manageiq/providers/vmware/infra_manager/host_esx.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/host_esx.rb
@@ -3,37 +3,37 @@ class ManageIQ::Providers::Vmware::InfraManager::HostEsx < ManageIQ::Providers::
   supports :refresh_firewall_rules
   supports :refresh_logs
   supports :start do
-    unsupported_reason_add(:reboot, _("The Host is not connected to an active Provider")) unless has_active_ems?
-    unsupported_reason_add(:reboot, _("The host is not in standby"))                      unless power_state == "standby"
+    return _("The Host is not connected to an active Provider") unless has_active_ems?
+    return _("The host is not in standby")                      unless power_state == "standby"
   end
   supports :reboot do
-    unsupported_reason_add(:reboot, _("The Host is not connected to an active Provider")) unless has_active_ems?
-    unsupported_reason_add(:reboot, _("The host is not running"))                         unless power_state == "on"
+    return _("The Host is not connected to an active Provider") unless has_active_ems?
+    return _("The host is not running")                         unless power_state == "on"
   end
   supports :shutdown do
-    unsupported_reason_add(:shutdown, _("The Host is not connected to an active Provider")) unless has_active_ems?
-    unsupported_reason_add(:shutdown, _("The host is not running"))                         unless power_state == "on"
+    return _("The Host is not connected to an active Provider") unless has_active_ems?
+    return _("The host is not running")                         unless power_state == "on"
   end
   supports :standby do
-    unsupported_reason_add(:standby, _("The Host is not connected to an active Provider")) unless has_active_ems?
-    unsupported_reason_add(:standby, _("The host is not running"))                         unless power_state == "on"
+    return _("The Host is not connected to an active Provider") unless has_active_ems?
+    return _("The host is not running")                         unless power_state == "on"
   end
   supports :enter_maint_mode do
-    unsupported_reason_add(:enter_maint_mode, _("The Host is not connected to an active Provider")) unless has_active_ems?
-    unsupported_reason_add(:enter_maint_mode, _("The host is not running"))                         unless power_state == "on"
+    return _("The Host is not connected to an active Provider") unless has_active_ems?
+    return _("The host is not running")                         unless power_state == "on"
   end
   supports :exit_maint_mode do
-    unsupported_reason_add(:exit_maint_mode, _("The Host is not connected to an active Provider")) unless has_active_ems?
-    unsupported_reason_add(:exit_maint_mode, _("The host is not in maintenance mode"))             unless power_state == "maintenance"
+    return _("The Host is not connected to an active Provider") unless has_active_ems?
+    return _("The host is not in maintenance mode")             unless power_state == "maintenance"
   end
   supports :enable_vmotion do
-    validate_active_with_power_state(:enable_vmotion, "on")
+    validate_active_with_power_state
   end
   supports :disable_vmotion do
-    validate_active_with_power_state(:disable_vmotion, "on")
+    validate_active_with_power_state
   end
   supports :vmotion_enabled do
-    validate_active_with_power_state(:vmotion, "on")
+    validate_active_with_power_state
   end
 
   def vim_shutdown(force = false)
@@ -218,8 +218,8 @@ class ManageIQ::Providers::Vmware::InfraManager::HostEsx < ManageIQ::Providers::
 
   private
 
-  def validate_active_with_power_state(feature, expected_power_state)
-    return unsupported_reason_add(feature, _("The Host is not connected to an active Provider"))   unless has_active_ems?
-    return unsupported_reason_add(feature, _("The host is not powered '#{expected_power_state}'")) unless expected_power_state == power_state
+  def validate_active_with_power_state(expected_power_state = "on")
+    return _("The Host is not connected to an active Provider")   unless has_active_ems?
+    return _("The host is not powered '#{expected_power_state}'") unless expected_power_state == power_state
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/template.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/template.rb
@@ -4,9 +4,9 @@ class ManageIQ::Providers::Vmware::InfraManager::Template < ManageIQ::Providers:
 
   supports :provisioning do
     if ext_management_system
-      unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports?(:provisioning)
+      ext_management_system.unsupported_reason(:provisioning)
     else
-      unsupported_reason_add(:provisioning, _('not connected to ems'))
+      _('not connected to ems')
     end
   end
 

--- a/app/models/manageiq/providers/vmware/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm.rb
@@ -7,16 +7,16 @@ class ManageIQ::Providers::Vmware::InfraManager::Vm < ManageIQ::Providers::Infra
 
   supports :capture
   supports :clone do
-    unsupported_reason_add(:clone, _('Clone operation is not supported')) if blank? || orphaned? || archived?
+    _('Clone operation is not supported') if blank? || orphaned? || archived?
   end
   supports :publish do
-    unsupported_reason_add(:publish, _('Publish operation is not supported')) if blank? || orphaned? || archived?
+    _('Publish operation is not supported') if blank? || orphaned? || archived?
   end
 
   supports :reconfigure_disks
   supports :reconfigure_network_adapters
   supports :reconfigure_disksize do
-    unsupported_reason_add(:reconfigure_disksize, 'Cannot resize disks of a VM with snapshots') unless snapshots.empty?
+    _("Cannot resize disks of a VM with snapshots") unless snapshots.empty?
   end
   supports :reconfigure_cdroms
   supports :set_description

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/operations/guest.rb
@@ -3,37 +3,45 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations::Guest
 
   included do
     supports :reboot_guest do
-      unsupported_reason_add(:reboot_guest, unsupported_reason(:control)) unless supports?(:control)
+      reason = unsupported_reason(:control)
+      return reason if reason
+
       if current_state == "on"
         if tools_status == 'toolsNotInstalled'
-          unsupported_reason_add(:reboot_guest, _("The VM tools is not installed"))
+          _("The VM tools is not installed")
         end
       else
-        unsupported_reason_add(:reboot_guest, _("The VM is not powered on"))
+        _("The VM is not powered on")
       end
     end
 
     supports :shutdown_guest do
-      unsupported_reason_add(:shutdown_guest, unsupported_reason(:control)) unless supports?(:control)
+      reason = unsupported_reason(:control)
+      return reason if reason
+
       if current_state == "on"
         if tools_status == 'toolsNotInstalled'
-          unsupported_reason_add(:shutdown_guest, _("The VM tools is not installed"))
+          _("The VM tools is not installed")
         end
       else
-        unsupported_reason_add(:shutdown_guest, _("The VM is not powered on"))
+        _("The VM is not powered on")
       end
     end
 
     supports :reset do
-      reason   = unsupported_reason(:control) unless supports?(:control)
-      reason ||= _("The VM is not powered on") unless current_state == "on"
-      unsupported_reason_add(:reset, reason) if reason
+      if current_state != "on"
+        _("The VM is not powered on")
+      else
+        unsupported_reason(:control)
+      end
     end
 
     supports :standby_guest do
-      reason   = unsupported_reason(:control) unless supports?(:control)
-      reason ||= _("The VM is not powered on") unless current_state == "on"
-      unsupported_reason_add(:standby_guest, reason) if reason
+      if current_state != "on"
+        _("The VM is not powered on")
+      else
+        unsupported_reason(:control)
+      end
     end
   end
 

--- a/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/operations/relocation.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/operations/relocation.rb
@@ -6,15 +6,13 @@ module ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared::Operations
       reason   = _("Migrate not supported because VM is blank")    if blank?
       reason ||= _("Migrate not supported because VM is orphaned") if orphaned?
       reason ||= _("Migrate not supported because VM is archived") if archived?
-      unsupported_reason_add(:migrate, reason) if reason
+      reason
     end
     supports :move_into_folder do
-      reason = _("Move not supported because VM is not active") if ext_management_system.nil?
-      unsupported_reason_add(:migrate, reason) if reason
+      _("Move not supported because VM is not active") if ext_management_system.nil?
     end
     supports :relocate do
-      reason = _("Relocate not supported because VM is not active") if ext_management_system.nil?
-      unsupported_reason_add(:migrate, reason) if reason
+      _("Relocate not supported because VM is not active") if ext_management_system.nil?
     end
   end
 

--- a/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/scanning.rb
@@ -4,13 +4,12 @@ module ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared::Scanning
   included do
     supports :smartstate_analysis do
       feature_supported, reason = check_feature_support('smartstate_analysis')
-      unless feature_supported
-        unsupported_reason_add(:smartstate_analysis, reason)
-      end
-      if storage.nil?
-        unsupported_reason_add(:smartstate_analysis, "Vm is not located on a storage")
+      if !feature_supported
+        reason
+      elsif storage.nil?
+        "Vm is not located on a storage"
       elsif !storage.storage_type_supported_for_ssa?
-        unsupported_reason_add(:smartstate_analysis, "Smartstate Analysis unsupported for storage type %{store_type}" % {:store_type => storage.store_type})
+        "Smartstate Analysis unsupported for storage type %{store_type}" % {:store_type => storage.store_type}
       end
     end
   end


### PR DESCRIPTION
part of:
- https://github.com/ManageIQ/manageiq/pull/22898
 
Deprecating `unsupported_reason_add`. Returning the string instead

Note, these are all the same:

```ruby
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports_feature2?
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports?(:feature2)
unsupported_reason(:feature2) unless supports?(:feature2)
unsupported_reason(:feature2)
```
