### PR TITLE
Fix missing log service name for non-rails event catcher

### DIFF
--- a/workers/event_catcher/event_catcher.rb
+++ b/workers/event_catcher/event_catcher.rb
@@ -18,17 +18,18 @@ class EventCatcher
 
     notify_started
 
-    logger.info("Collecting events...")
+    log_prefix = "MIQ(ManageIQ::Providers::Vmware::InfraManager::EventCatcher)".freeze
+    logger.info("#{log_prefix} Collecting events...")
 
     wait_for_updates(vim) do |property_change|
-      logger.info(property_change.name)
+      logger.info("#{log_prefix} #{property_change.name}")
       next unless property_change.name.match?(/latestPage.*/)
 
       events = Array(property_change.val).map do |event|
         EventParser.parse_event(event).merge(:ems_id => ems["id"])
       end
 
-      logger.info(events.to_json)
+      logger.info("#{log_prefix} events: [#{events.to_json}]")
 
       publish_events(events)
     end

--- a/workers/event_catcher/worker
+++ b/workers/event_catcher/worker
@@ -35,7 +35,9 @@ end
 def main(args)
   setproctitle
 
-  logger         = build_logger
+  logger = build_logger
+  logger.progname = "evm"
+
   ems            = args["ems"].detect { |e| e["type"] == "ManageIQ::Providers::Vmware::InfraManager" }
   messaging      = args["messaging"].symbolize_keys
   endpoint       = ems["endpoints"].detect { |ep| ep["role"] == "default" }


### PR DESCRIPTION
The non-rails event catcher was not setting the progname for the ManageIQ::Loggers instance which defaulted to `"manageiq"`.

This meant that the event catcher logging would be missed if you were e.g. `journalctl -f -t evm`

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
