### PR TITLE
Fix VM Provision datastore location class

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
@@ -168,7 +168,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
 
   def datastore_ems_ref(clone_opts)
     datastore = Storage.find_by(:id => clone_opts[:datastore].id)
-    datastore.try(:ems_ref)
+    datastore.try(:ems_ref_obj)
   end
 
   def get_selected_snapshot

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
@@ -298,7 +298,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
         before(:each) do
           Array.new(2) do |i|
             ds_mor = "datastore-#{i}"
-            storage = FactoryBot.create(:storage_nfs, :ems_ref => ds_mor, :ems_ref_type => "Datastore")
+            storage = FactoryBot.create(:storage_vmware, :ems_ref => ds_mor, :ems_ref_type => "Datastore")
 
             cluster_mor = "cluster-#{i}"
             cluster     = FactoryBot.create(:ems_cluster, :ems_ref => cluster_mor)


### PR DESCRIPTION
When building the `VirtualMachineRelocateSpec` the `datastore` property is a `ManagedObjectReference` to a `Datastore`.  We were setting the value to a simple `String` rather than a `VimString` with the proper `xsiType`/`vimType`.

This would have broken when we moved from having VimString in ems_ref as a serialized yaml column and added ems_ref_obj.

This causes the clone to fail when using a vcsim (https://github.com/vmware/govmomi/tree/main/vcsim)

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/23043


<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
