### PR TITLE
Catch a Handsoap Fault when logging a user event

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -670,7 +670,13 @@ module ManageIQ::Providers
 
       if obj.kind_of?(self.class::Vm) || obj.kind_of?(self.class::Template) || obj.kind_of?(self.class::Host) || obj.kind_of?(EmsCluster) || obj.kind_of?(EmsFolder)
         obj.with_provider_object do |vim_obj|
-          vim_obj.logUserEvent(user_event) if user_event && obj.kind_of?(Vm)
+          if user_event && obj.kind_of?(Vm)
+            begin
+              vim_obj.logUserEvent(user_event)
+            rescue Handsoap::Fault => err
+              _log.warn("#{log_header} Failed to log user event [#{err}]")
+            end
+          end
 
           _log.info("#{log_header} Invoking [#{cmd}]...")
           result = vim_obj.send(cmd, *opts)


### PR DESCRIPTION
We don't want failure to log a user event to prevent execution of the requested method.

On a vc simulator the EventManager doesn't implement LogUserEvent: `2024/05/21 10:11:54 EventManager:EventManager does not implement: LogUserEvent` this prevents `vm_start` from completing successfully

```
[----] I, [2024-05-21T10:39:55.602351#38873:9ee8]  INFO -- evm: MIQ(ManageIQ::Providers::Vmware::InfraManager#with_provider_connection) Connecting through ManageIQ::Providers::Vmware::InfraManager: [vcsim]
[----] I, [2024-05-21T10:39:55.608078#38873:9ee8]  INFO -- evm: Starting Phase <provision_error>
[----] E, [2024-05-21T10:39:55.616737#38873:9ee8] ERROR -- evm: MIQ(ManageIQ::Providers::Vmware::InfraManager::Provision#provision_error) [[Handsoap::Fault]: Handsoap::Fault { :code => 'ServerFaultCode', :reason => 'EventManager:EventManager does not implement: LogUserEvent' }] encountered during phase [autostart_destination]
[----] E, [2024-05-21T10:39:55.616848#38873:9ee8] ERROR -- evm: /home/grare/adam/.gem/ruby/3.1.0/gems/handsoap-0.2.5.5/lib/handsoap/service.rb:217:in `on_fault'
/home/grare/adam/.gem/ruby/3.1.0/gems/handsoap-0.2.5.5/lib/handsoap/service.rb:307:in `dispatch'
/home/grare/adam/.gem/ruby/3.1.0/gems/handsoap-0.2.5.5/lib/handsoap/service.rb:211:in `invoke'
/home/grare/adam/.gem/ruby/3.1.0/gems/vmware_web_service-3.3.0/lib/VMwareWebService/VimService.rb:483:in `logUserEvent'
/home/grare/adam/.gem/ruby/3.1.0/gems/vmware_web_service-3.3.0/lib/VMwareWebService/MiqVimInventory.rb:2012:in `logUserEvent'
/home/grare/adam/.gem/ruby/3.1.0/gems/vmware_web_service-3.3.0/lib/VMwareWebService/MiqVimVm.rb:1275:in `logUserEvent'
/home/grare/adam/src/manageiq/manageiq-providers-vmware/app/models/manageiq/providers/vmware/infra_manager.rb:673:in `block in invoke_vim_ws'
/home/grare/adam/src/manageiq/manageiq/app/models/mixins/provider_object_mixin.rb:14:in `block in with_provider_object'
/home/grare/adam/src/manageiq/manageiq-providers-vmware/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb:46:in `with_provider_connection'
/home/grare/adam/src/manageiq/manageiq/app/models/mixins/provider_object_mixin.rb:11:in `with_provider_object'
/home/grare/adam/src/manageiq/manageiq-providers-vmware/app/models/manageiq/providers/vmware/infra_manager.rb:672:in `invoke_vim_ws'
/home/grare/adam/src/manageiq/manageiq-providers-vmware/app/models/manageiq/providers/vmware/infra_manager.rb:373:in `vm_start'
/home/grare/adam/src/manageiq/manageiq/app/models/vm_or_template.rb:380:in `run_command_via_parent'
/home/grare/adam/src/manageiq/manageiq-providers-vmware/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/operations/power.rb:5:in `raw_start'
/home/grare/adam/src/manageiq/manageiq-providers-vmware/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb:64:in `autostart_destination'
/home/grare/adam/src/manageiq/manageiq/app/models/miq_request_task/state_machine.rb:22:in `signal'
/home/grare/adam/src/manageiq/manageiq-providers-vmware/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb:76:in `customize_destination'
/home/grare/adam/src/manageiq/manageiq/app/models/miq_request_task/state_machine.rb:22:in `signal'
/home/grare/adam/src/manageiq/manageiq-providers-vmware/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb:51:in `poll_destination_in_vmdb'
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
