### PR TITLE
remove return from supports blocks

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/operations/guest.rb
@@ -3,28 +3,22 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations::Guest
 
   included do
     supports :reboot_guest do
-      reason = unsupported_reason(:control)
-      return reason if reason
-
-      if current_state == "on"
-        if tools_status == 'toolsNotInstalled'
-          _("The VM tools is not installed")
-        end
-      else
+      if current_state != "on"
         _("The VM is not powered on")
+      elsif tools_status == 'toolsNotInstalled'
+        _("The VM tools is not installed")
+      else
+        unsupported_reason(:control)
       end
     end
 
     supports :shutdown_guest do
-      reason = unsupported_reason(:control)
-      return reason if reason
-
-      if current_state == "on"
-        if tools_status == 'toolsNotInstalled'
-          _("The VM tools is not installed")
-        end
-      else
+      if current_state != "on"
         _("The VM is not powered on")
+      elsif tools_status == 'toolsNotInstalled'
+        _("The VM tools is not installed")
+      else
+        unsupported_reason(:control)
       end
     end
 


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq/pull/22898 (as a followup)
Introduced by https://github.com/ManageIQ/manageiq-providers-vmware/pull/901

Return from a block behaves in strange ways.
What we wanted is to return that value from the block (aka, acted like it is a proc)

Solution is to change the order of the if block so we can avoid supports? and
avoid setting a variable. (and obviously, avoiding the bad return)

Error
-----

```
ERROR -- evm: [LocalJumpError]: unexpected return  Method:[block (2 levels) in <class:LogProxy>]
ERROR -- evm:
manageiq-providers-vmware/app/models/manageiq/providers/vmware/infra_manager/vm/operations/guest.rb:20:
  in `block (2 levels) in <module:Guest>'
manageiq/app/models/mixins/supports_feature_mixin.rb:113:in `instance_eval'
manageiq/app/models/mixins/supports_feature_mixin.rb:113:in `check_supports'
manageiq/app/models/mixins/supports_feature_mixin.rb:71:in `supports?'
```