### PR TITLE
Continue refresh if cis_connect fails

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -190,6 +190,9 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
     return if vim.rev < '6.0' || vim.serviceContent.about.apiType != 'VirtualCenter'
 
     ems.connect(:service => :cis)
+  rescue => err
+    _log.warn("Failed to connect to CIS API: #{err}")
+    nil
   end
 
   def disconnect(vim)


### PR DESCRIPTION
The CIS vsphere-automation endpoint allows us to get tags and content libraries that aren't present in the VIM API.  If there is a failure connecting to this endpoint for whatever reason we shouldn't fail the rest of the refresh.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
