### PR TITLE
Fix Vm#set_description error

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -656,9 +656,9 @@ module ManageIQ::Providers
     end
     alias_method :host_quick_stats, :vm_quick_stats
 
-    def vm_set_description(vm, new_description, options = {})
+    def vm_set_description(vm, options = {})
       options[:spec] = VimHash.new("VirtualMachineConfigSpec") do |spec|
-        spec.annotation = new_description
+        spec.annotation = options.delete(:new_description)
       end
 
       vm_reconfigure(vm, options)

--- a/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/operations.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/operations.rb
@@ -40,7 +40,7 @@ module ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared::Operations
   end
 
   def raw_set_description(new_description)
-    run_command_via_parent(:vm_set_description, new_description)
+    run_command_via_parent(:vm_set_description, :new_description => new_description)
   end
 
   def log_user_event(event_message)


### PR DESCRIPTION
It appears at some point we assumed that all methods that end up calling `run_command_via_parent` assume the argument is a hash and not a simple string.

```
>> vm.set_description("new-description")
app/models/vm_or_template.rb:380:in `merge': no implicit conversion of String into Hash (TypeError)

    options = {:user_event => "Console Request Action [#{verb}], VM [#{name}]"}.merge(options)
                                                                                      ^^^^^^^
	from app/models/vm_or_template.rb:380:in `run_command_via_parent'
	from /home/grare/adam/src/manageiq/manageiq-providers-vmware/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/operations.rb:43:in `raw_set_description'
	from app/models/vm_or_template/operations.rb:95:in `set_description'
	from (irb):12:in `<main>'
	from <internal:kernel>:187:in `loop'
	from railties (7.0.8.4) lib/rails/commands/console/console_command.rb:74:in `start'
	from railties (7.0.8.4) lib/rails/commands/console/console_command.rb:19:in `start'
	from railties (7.0.8.4) lib/rails/commands/console/console_command.rb:106:in `perform'
	from thor (1.3.2) lib/thor/command.rb:28:in `run'
	from thor (1.3.2) lib/thor/invocation.rb:127:in `invoke_command'
	from thor (1.3.2) lib/thor.rb:538:in `dispatch'
	from railties (7.0.8.4) lib/rails/command/base.rb:87:in `perform'
	from railties (7.0.8.4) lib/rails/command.rb:48:in `invoke'
	from railties (7.0.8.4) lib/rails/commands.rb:18:in `<main>'
	from /usr/lib/ruby/3.3.0/bundled_gems.rb:75:in `require'
	from /usr/lib/ruby/3.3.0/bundled_gems.rb:75:in `block (2 levels) in replace_require'
	... 2 levels...
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
