### PR TITLE
Delegate refresh_ems class method to parent cloud manager

### DIFF
--- a/app/models/manageiq/providers/vmware/network_manager.rb
+++ b/app/models/manageiq/providers/vmware/network_manager.rb
@@ -20,6 +20,10 @@ class ManageIQ::Providers::Vmware::NetworkManager < ManageIQ::Providers::Network
            :to        => :parent_manager,
            :allow_nil => true
 
+  class << self
+    delegate :refresh_ems, :to => ManageIQ::Providers::Vmware::CloudManager
+  end
+
   def self.ems_type
     @ems_type ||= "vmware_cloud_network".freeze
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,6 +21,8 @@
       :saver_strategy: batch
   :vmware_cloud:
     :get_public_images: false
+  :vmware_cloud_network:
+    :refresh_interval: 0
   :vmwarews:
     :refresh_interval: 24.hours
     :update_poll_interval: 1.second


### PR DESCRIPTION
Reasoning here: https://github.com/ManageIQ/manageiq-providers-azure/pull/564#issuecomment-2445034651

@miq-bot assign @agrare
@miq-bot add_label bug, radjabov/yes?
@miq-bot add_reviewer @agrare