### PR TITLE
Add an option to log XML body for VIM requests

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -160,6 +160,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
       :path     => '/sdk',
       :port     => port,
       :rev      => '6.5',
+      :debug    => Settings.ems.ems_vmware.debug_vim_requests
     }
 
     require 'rbvmomi'

--- a/app/models/manageiq/providers/vmware/infra_manager/metrics_collector_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/metrics_collector_worker/runner.rb
@@ -2,6 +2,7 @@ class ManageIQ::Providers::Vmware::InfraManager::MetricsCollectorWorker::Runner 
   def do_before_work_loop
     require "VMwareWebService/MiqVim"
     MiqVim.cacheScope = :cache_scope_core
+    MiqVim.on_log_body { |body| $vim_log.debug(body) } if Settings.ems.ems_vmware.debug_vim_requests
   end
 
   def before_exit(_message, _exit_code)

--- a/app/models/manageiq/providers/vmware/infra_manager/operations_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/operations_worker/runner.rb
@@ -6,6 +6,7 @@ class ManageIQ::Providers::Vmware::InfraManager::OperationsWorker::Runner < Mana
     MiqVim.cacheScope = :cache_scope_core
     MiqVim.monitor_updates = true
     MiqVim.pre_load = true
+    MiqVim.on_log_body { |body| $vim_log.debug(body) } if Settings.ems.ems_vmware.debug_vim_requests
 
     # Prime the cache before starting the do_work loop
     ems.connect

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,6 +2,7 @@
 :ems:
   :ems_vmware:
     :blacklisted_event_names: []
+    :debug_vim_requests: false
     :event_handling:
       :event_groups:
         :addition:


### PR DESCRIPTION
This gives us the option to dump the entire XML doc of the request/response to the vim.log for further debugging, here is an example of a CloneVM_Task request/response on a govmomi vcsim:
```
[----] I, [2024-11-22T11:03:06.811252#86337:97f4]  INFO -- vim: Q-task_id([r9_miq_provision_9]) MiqVimInventory(localhost, user).getMoProp_local: return from retrieveProperties(SessionManager)
[----] I, [2024-11-22T11:03:06.811344#86337:97f4]  INFO -- vim: Q-task_id([r9_miq_provision_9]) MiqVimMod.getVimVmByMor: called
[----] I, [2024-11-22T11:03:06.811524#86337:97f4]  INFO -- vim: Q-task_id([r9_miq_provision_9]) MiqVimMod.getVimVmByMor: returning object 78760
[----] I, [2024-11-22T11:03:06.811599#86337:97f4]  INFO -- vim: Q-task_id([r9_miq_provision_9]) MiqVimVm(localhost, user).cloneVM_raw: calling cloneVM_Task
[----] I, [2024-11-22T11:03:06.813518#86337:97f4]  INFO -- vim: Q-task_id([r9_miq_provision_9]) HandSoap Request  [78780]: length: [3467], URI: [https://localhost:8989/sdk], Content-Type: [text/xml;charset=UTF-8], SOAPAction: [CloneVM_Task]
[----] D, [2024-11-22T11:03:06.813600#86337:97f4] DEBUG -- vim: Q-task_id([r9_miq_provision_9]) <?xml version='1.0' ?>
<env:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
  <env:Header />
  <env:Body>
    <n1:CloneVM_Task xmlns:n1="urn:vim25">
      <n1:_this type="VirtualMachine">vm-64</n1:_this>
      <n1:folder type="Folder">group-3</n1:folder>
      <n1:name>ag-prov-test</n1:name>
      <n1:spec xsi:type="VirtualMachineCloneSpec">
        <n1:location xsi:type="n1:VirtualMachineRelocateSpec">
          <n1:datastore type="Datastore" xsi:type="n1:ManagedObjectReference">datastore-52</n1:datastore>
          <n1:pool type="ResourcePool" xsi:type="n1:ManagedObjectReference">resgroup-22</n1:pool>
          <n1:host type="HostSystem" xsi:type="n1:ManagedObjectReference">host-21</n1:host>
        </n1:location>
        <n1:template>false</n1:template>
        <n1:config xsi:type="n1:VirtualMachineConfigSpec">
          <n1:annotation>Owner:  
Email: adam@grare.com
Source: DC0_C0_RP0_TEMPLATE0

MIQ GUID=fd110510-47fb-4ded-94fe-11ba7a287708</n1:annotation>
          <n1:numCPUs>1</n1:numCPUs>
          <n1:memoryMB>1024</n1:memoryMB>
          <n1:memoryHotAddEnabled>false</n1:memoryHotAddEnabled>
          <n1:cpuHotAddEnabled>false</n1:cpuHotAddEnabled>
          <n1:cpuHotRemoveEnabled>false</n1:cpuHotRemoveEnabled>
          <n1:deviceChange xsi:type="n1:VirtualDeviceConfigSpec">
            <n1:operation>edit</n1:operation>
            <n1:device xsi:type="n1:VirtualE1000">
              <n1:key xsi:type="n1:SOAP::SOAPInt">4000</n1:key>
              <n1:deviceInfo xsi:type="n1:Description">
                <n1:label xsi:type="n1:SOAP::SOAPString">ethernet-0</n1:label>
                <n1:summary xsi:type="n1:SOAP::SOAPString">DVSwitch: fea97929-4b2d-5972-b146-930c6d0b4014</n1:summary>
              </n1:deviceInfo>
              <n1:backing xsi:type="n1:VirtualEthernetCardDistributedVirtualPortBackingInfo">
                <n1:port xsi:type="n1:DistributedVirtualSwitchPortConnection">
                  <n1:switchUuid>fea97929-4b2d-5972-b146-930c6d0b4014</n1:switchUuid>
                  <n1:portgroupKey>dvportgroup-13</n1:portgroupKey>
                </n1:port>
              </n1:backing>
              <n1:connectable xsi:type="n1:VirtualDeviceConnectInfo">
                <n1:startConnected xsi:type="n1:SOAP::SOAPBoolean">true</n1:startConnected>
                <n1:allowGuestControl xsi:type="n1:SOAP::SOAPBoolean">true</n1:allowGuestControl>
                <n1:connected xsi:type="n1:SOAP::SOAPBoolean">false</n1:connected>
                <n1:status xsi:type="n1:SOAP::SOAPString">untried</n1:status>
              </n1:connectable>
              <n1:controllerKey xsi:type="n1:SOAP::SOAPInt">100</n1:controllerKey>
              <n1:unitNumber xsi:type="n1:SOAP::SOAPInt">7</n1:unitNumber>
              <n1:addressType xsi:type="n1:SOAP::SOAPString">generated</n1:addressType>
              <n1:macAddress xsi:type="n1:SOAP::SOAPString">00:0c:29:39:30:38</n1:macAddress>
              <n1:wakeOnLanEnabled xsi:type="n1:SOAP::SOAPBoolean">true</n1:wakeOnLanEnabled>
            </n1:device>
          </n1:deviceChange>
          <n1:extraConfig xsi:type="n1:OptionValue">
            <n1:key>cpuid.coresPerSocket</n1:key>
            <n1:value xsi:type="n1:xsd:string">1</n1:value>
          </n1:extraConfig>
        </n1:config>
        <n1:powerOn>false</n1:powerOn>
      </n1:spec>
    </n1:CloneVM_Task>
  </env:Body>
</env:Envelope>
[----] I, [2024-11-22T11:03:06.816331#86337:97f4]  INFO -- vim: Q-task_id([r9_miq_provision_9]) HandSoap Response [78780]: length: [424], HTTP-Status: [200], Content-Type: [text/xml; charset=utf-8]
[----] D, [2024-11-22T11:03:06.816464#86337:97f4] DEBUG -- vim: Q-task_id([r9_miq_provision_9]) <?xml version="1.0" encoding="UTF-8"?>
<soapenv:Envelope xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <soapenv:Body>
    <CloneVM_TaskResponse xmlns="urn:vim25">
      <returnval type="Task">task-2</returnval>
    </CloneVM_TaskResponse>
  </soapenv:Body>
</soapenv:Envelope>
```

https://github.com/ManageIQ/manageiq-documentation/pull/1823
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
