### PR TITLE
Fix vCloud and Tanzu inheriting vSphere's filtered events

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -27,6 +27,10 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
     @description ||= "VMware vCloud".freeze
   end
 
+  def self.default_blacklisted_event_names
+    Settings.ems["ems_#{ems_type}"].blacklisted_event_names
+  end
+
   def self.params_for_create
     {
       :fields => [

--- a/app/models/manageiq/providers/vmware/container_manager.rb
+++ b/app/models/manageiq/providers/vmware/container_manager.rb
@@ -15,6 +15,10 @@ class ManageIQ::Providers::Vmware::ContainerManager < ManageIQ::Providers::Kuber
     n_('Container Provider (Vmware)', 'Container Providers (Vmware)', number)
   end
 
+  def self.default_blacklisted_event_names
+    Settings.ems["ems_#{ems_type}"].blacklisted_event_names
+  end
+
   def self.kubernetes_auth_options(options)
     {:bearer_token => options[:bearer] || wcp_login(options)}
   end

--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -337,6 +337,10 @@ module ManageIQ::Providers
       end
     end
 
+    def self.default_blacklisted_event_names
+      Settings.ems.ems_vmware.blacklisted_event_names
+    end
+
     def verify_credentials(auth_type = nil, _options = {})
       user, pwd = auth_user_pwd(auth_type)
       self.class.raw_connect(:ip => hostname, :port => port, :user => user, :pass => pwd, :verify_ssl => verify_ssl, :certificate_authority => certificate_authority)

--- a/app/models/manageiq/providers/vmware/network_manager.rb
+++ b/app/models/manageiq/providers/vmware/network_manager.rb
@@ -36,6 +36,10 @@ class ManageIQ::Providers::Vmware::NetworkManager < ManageIQ::Providers::Network
     false
   end
 
+  def self.default_blacklisted_event_names
+    Settings.ems["ems_#{ems_type}"].blacklisted_event_names
+  end
+
   def description
     @description ||= "VMware Cloud Network".freeze
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,6 +28,12 @@
       :historical: 100
       :hourly: 250
       :realtime: 100
+  :ems_vmware_cloud:
+    :blacklisted_event_names: []
+  :ems_vmware_cloud_network:
+    :blacklisted_event_names: []
+  :ems_vmware_tanzu:
+    :blacklisted_event_names: []
 :ems_refresh:
   :vmware_tanzu:
     :refresh_interval: 24.hours


### PR DESCRIPTION
The `BaseManager.default_blacklisted_event_names` method uses the provider name (aka Vmware) rather than the `ems_type` so all
`ManageIQ::Providers::Vmware::*Managers` were getting the vSphere blacklisted events

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
