### PR TITLE
[WIP] Fix VM Provisioning with a Template having a CD-ROM device and ISO datastore file

### DIFF
--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_workflow_spec.rb
@@ -96,14 +96,15 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
   end
 
   context 'provisioning a VM' do
+    let(:ems)      { FactoryBot.create(:ems_vmware) }
+    let!(:host1)   { FactoryBot.create(:host_vmware, :ems_id => ems.id) }
+    let!(:host2)   { FactoryBot.create(:host_vmware, :ems_id => ems.id) }
+    let!(:src_vm)  { FactoryBot.create(:vm_vmware, :host => host1, :ems_id => ems.id) }
+
     let(:workflow) { described_class.new({}, admin.userid) }
     before do
-      @ems    = FactoryBot.create(:ems_vmware)
-      @host1  = FactoryBot.create(:host_vmware, :ems_id => @ems.id)
-      @host2  = FactoryBot.create(:host_vmware, :ems_id => @ems.id)
-      @src_vm = FactoryBot.create(:vm_vmware, :host => @host1, :ems_id => @ems.id)
       stub_dialog(:get_dialogs)
-      workflow.instance_variable_set(:@values, :vm_tags => [], :src_vm_id => @src_vm.id)
+      workflow.instance_variable_set(:@values, :vm_tags => [], :src_vm_id => src_vm.id)
       workflow.instance_variable_set(:@target_resource, nil)
     end
 
@@ -119,7 +120,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
 
       context 'when storage_profile selection is not set' do
         it 'set storage_profile selection to [nil, nil] if template has no storage_profile' do
-          template = FactoryBot.create(:vm_vmware, :host => @host1, :ems_id => @ems.id)
+          template = FactoryBot.create(:vm_vmware, :host => host1, :ems_id => ems.id)
           workflow.instance_variable_set(:@values, :src_vm_id => template.id, :placement_storage_profile => nil)
           workflow.allowed_storage_profiles
           values = workflow.instance_variable_get(:@values)
@@ -127,7 +128,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
         end
 
         it 'set storage_profile selection to that of template if template has one' do
-          template = FactoryBot.create(:vm_vmware, :host => @host1, :ems_id => @ems.id, :storage_profile => profile)
+          template = FactoryBot.create(:vm_vmware, :host => host1, :ems_id => ems.id, :storage_profile => profile)
           workflow.instance_variable_set(:@values, :src_vm_id => template.id, :placement_storage_profile => nil)
           workflow.allowed_storage_profiles
           values = workflow.instance_variable_get(:@values)
@@ -150,8 +151,8 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
     context '#set_on_vm_id_changed' do
       before(:each) do
         workflow.instance_variable_set(:@filters, :Host => {21 => "ESX 6.0"}, :StorageProfile => {1 => "Tag 1"})
-        workflow.instance_variable_set(:@values, :src_vm_id => @src_vm.id, :placement_storage_profile => [])
-        allow(workflow).to receive(:set_or_default_hardware_field_values).with(@src_vm)
+        workflow.instance_variable_set(:@values, :src_vm_id => src_vm.id, :placement_storage_profile => [])
+        allow(workflow).to receive(:set_or_default_hardware_field_values).with(src_vm)
       end
       it 'clears StorageProfile filter' do
         workflow.set_on_vm_id_changed
@@ -185,8 +186,8 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
       end
 
       it '#allowed_vlans' do
-        @host1.switches = [s11, s12, s13]
-        allow(workflow).to receive(:allowed_hosts).with(no_args).and_return([workflow.host_to_hash_struct(@host1)])
+        host1.switches = [s11, s12, s13]
+        allow(workflow).to receive(:allowed_hosts).with(no_args).and_return([workflow.host_to_hash_struct(host1)])
         vlans, _hosts = workflow.allowed_vlans(:vlans => true, :dvs => true)
         lan_keys   = [@lan11.name, @lan13.name, @lan12.name]
         lan_values = [@lan11.name, @lan13.name, @lan12.name]
@@ -195,8 +196,8 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
       end
 
       it 'concatenates dvswitches of the same portgroup name' do
-        @host1.switches = [s11, s12, s13, s14, s15]
-        allow(workflow).to receive(:allowed_hosts).with(no_args).and_return([workflow.host_to_hash_struct(@host1)])
+        host1.switches = [s11, s12, s13, s14, s15]
+        allow(workflow).to receive(:allowed_hosts).with(no_args).and_return([workflow.host_to_hash_struct(host1)])
         vlans, _hosts = workflow.allowed_vlans(:vlans => true, :dvs => true)
         lan_keys = [@lan11.name, @lan13.name, @lan12.name, "dvs_#{@lan14.name}"]
         switches = [s14.name, s15.name].sort.join('/')
@@ -206,10 +207,10 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
       end
 
       it 'concatenates dvswitches of the same portgroup name from different hosts' do
-        @host1.switches = [s11, s12, s13, s14, s15]
-        @host2.switches = [s15, s21]
+        host1.switches = [s11, s12, s13, s14, s15]
+        host2.switches = [s15, s21]
         allow(workflow).to receive(:allowed_hosts).with(no_args).and_return(
-          [workflow.host_to_hash_struct(@host1), workflow.host_to_hash_struct(@host2)]
+          [workflow.host_to_hash_struct(host1), workflow.host_to_hash_struct(host2)]
         )
 
         vlans, _hosts = workflow.allowed_vlans(:vlans => true, :dvs => true)
@@ -221,10 +222,10 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
       end
 
       it 'excludes dvs if told so' do
-        @host1.switches = [s11, s12, s13, s14, s15]
-        @host2.switches = [s15, s21]
+        host1.switches = [s11, s12, s13, s14, s15]
+        host2.switches = [s15, s21]
         allow(workflow).to receive(:allowed_hosts).with(no_args).and_return(
-          [workflow.host_to_hash_struct(@host1), workflow.host_to_hash_struct(@host2)]
+          [workflow.host_to_hash_struct(host1), workflow.host_to_hash_struct(host2)]
         )
         vlans, _hosts = workflow.allowed_vlans(:vlans => true, :dvs => false)
         lan_keys = [@lan11.name, @lan13.name, @lan12.name]
@@ -233,9 +234,9 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
       end
 
       it 'concatenates dvswitches of the same portgroup name from different hosts when autoplacement is on' do
-        @host1.switches = [s11, s12, s13, s14, s15]
-        @host2.switches = [s21]
-        workflow.instance_variable_set(:@values, :vm_tags => [], :src_vm_id => @src_vm.id, :placement_auto => true)
+        host1.switches = [s11, s12, s13, s14, s15]
+        host2.switches = [s21]
+        workflow.instance_variable_set(:@values, :vm_tags => [], :src_vm_id => src_vm.id, :placement_auto => true)
         vlans, _hosts = workflow.allowed_vlans(:vlans => true, :dvs => true)
         lan_keys = [@lan11.name, @lan13.name, @lan12.name, "dvs_#{@lan14.name}"]
         switches = [s14.name, s15.name, s21.name].sort.join('/')
@@ -245,17 +246,17 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
       end
 
       it 'returns no vlans when autoplacement is off and no allowed_hosts' do
-        @host1.switches = [s11, s12, s13, s14, s15]
-        @host2.switches = [s21]
-        workflow.instance_variable_set(:@values, :vm_tags => [], :src_vm_id => @src_vm.id, :placement_auto => false)
+        host1.switches = [s11, s12, s13, s14, s15]
+        host2.switches = [s21]
+        workflow.instance_variable_set(:@values, :vm_tags => [], :src_vm_id => src_vm.id, :placement_auto => false)
         vlans, _hosts = workflow.allowed_vlans(:vlans => true, :dvs => true)
         expect(vlans.keys).to match_array([])
         expect(vlans.values).to match_array([])
       end
 
       it 'Returns both dvportgroup and lan with the same name' do
-        @host1.switches = [s11, s22]
-        allow(workflow).to receive(:allowed_hosts).with(no_args).and_return([workflow.host_to_hash_struct(@host1)])
+        host1.switches = [s11, s22]
+        allow(workflow).to receive(:allowed_hosts).with(no_args).and_return([workflow.host_to_hash_struct(host1)])
         vlans, _hosts = workflow.allowed_vlans(:vlans => true, :dvs => true)
 
         lan_keys   = [@lan11.name, "dvs_#{@lan22.name}"]
@@ -266,29 +267,29 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
 
       context '#allowed_hosts_obj' do
         before do
-          allow(workflow).to receive(:find_all_ems_of_type).and_return([@host1, @host2])
+          allow(workflow).to receive(:find_all_ems_of_type).and_return([host1, host2])
           allow(Rbac).to receive(:search) do |hash|
             [Array.wrap(hash[:targets])]
           end
         end
 
         it 'finds all hosts with no selected network' do
-          workflow.instance_variable_set(:@values, :src_vm_id => @src_vm.id)
-          expect(workflow.allowed_hosts_obj).to match_array([@host1, @host2])
+          workflow.instance_variable_set(:@values, :src_vm_id => src_vm.id)
+          expect(workflow.allowed_hosts_obj).to match_array([host1, host2])
         end
 
         it 'finds only the hosts that can access the selected vSwitch network' do
-          @host1.switches = [s11]
-          @host2.switches = [s22]
-          workflow.instance_variable_set(:@values, :src_vm_id => @src_vm.id, :vlan => [@lan11.name, @lan11.name])
-          expect(workflow.allowed_hosts_obj).to match_array([@host1])
+          host1.switches = [s11]
+          host2.switches = [s22]
+          workflow.instance_variable_set(:@values, :src_vm_id => src_vm.id, :vlan => [@lan11.name, @lan11.name])
+          expect(workflow.allowed_hosts_obj).to match_array([host1])
         end
 
         it 'finds only the hosts that can access the selected dvSwitch network' do
-          @host1.switches = [s11]
-          @host2.switches = [s22]
-          workflow.instance_variable_set(:@values, :src_vm_id => @src_vm.id, :vlan => ["dvs_#{@lan22.name}", @lan22.name])
-          expect(workflow.allowed_hosts_obj).to match_array([@host2])
+          host1.switches = [s11]
+          host2.switches = [s22]
+          workflow.instance_variable_set(:@values, :src_vm_id => src_vm.id, :vlan => ["dvs_#{@lan22.name}", @lan22.name])
+          expect(workflow.allowed_hosts_obj).to match_array([host2])
           expect(workflow.instance_variable_get(:@values)[:vlan]).to match_array(["dvs_#{@lan22.name}", @lan22.name])
         end
       end


### PR DESCRIPTION
If a template has a CD-ROM with an ISO backed by a datastore file then the template can't be cloned to a VM on a host that doesn't have that datastore mounted.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
