### PR TITLE
Update event_catcher gem dependencies

### DIFF
--- a/workers/event_catcher/worker
+++ b/workers/event_catcher/worker
@@ -5,12 +5,12 @@ require "bundler/inline"
 gemfile(false) do
   source "https://rubygems.org"
 
-  gem "manageiq-loggers", "~>1.0"
-  gem "manageiq-messaging", "~> 1.0"
-  gem "rbvmomi2", "~> 3.3"
+  gem "manageiq-loggers", "~>1.2"
+  gem "manageiq-messaging", "~> 2.0"
+  gem "rbvmomi2", "~>3.8"
   if ENV.fetch("APPLIANCE", nil)
-    gem "sd_notify"
-    gem "systemd-journal"
+    gem "sd_notify", "~>0.1.0"
+    gem "systemd-journal", "~>1.4.2"
   end
   gem "json"
 end


### PR DESCRIPTION
We really need some sort of spec test to confirm that these are kept up to date.  The `bundler/inline` `gemfile()` method doesn't have an option to not install new gems, just to not force update to the latest version 

`https://github.com/rubygems/rubygems/pull/8170`

Fixes https://github.com/ManageIQ/manageiq-providers-vmware/issues/952
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
