### PR TITLE
[WIP] Add vSphere Cloud-Init Support

### DIFF
--- a/content/miq_dialogs/miq_provision_vmware_dialogs_clone_to_vm.yaml
+++ b/content/miq_dialogs/miq_provision_vmware_dialogs_clone_to_vm.yaml
@@ -240,6 +240,14 @@
           :display: :edit
           :default: false
           :data_type: :boolean
+        :customization_template_id:
+          :values_from:
+            :method: :allowed_customization_templates
+          :auto_select_single: false
+          :description: Script Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
         :addr_mode:
           :values:
             static: Static


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-providers-vmware/issues/951

I haven't gotten the dropdown to show up in the UI yet due to the `_prov_dialog.html.haml` :spaghetti:  There is a special conditional branch for Ovirt [[ref]](https://github.com/ManageIQ/manageiq-ui-classic/blob/afa3d77de91e3b9eaa93a106fe58ab0120a02865/app/views/shared/views/_prov_dialog.html.haml#L198) which appears to handle the CustomizationTemplate selection [[ref]](https://github.com/ManageIQ/manageiq-ui-classic/blob/afa3d77de91e3b9eaa93a106fe58ab0120a02865/app/views/shared/views/_prov_dialog.html.haml#L221-L235).

Ideally we would unify that and have something like supports_customization_templates, TBD.

TODO:
- [ ] How to handle "metadata" vs "userdata"
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
