### PR TITLE
Refactor RbVmomi to use cert_store not ca_file

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -44,7 +44,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
     start
   end
 
-  attr_accessor :cache, :categories_by_id, :ca_file, :tags_by_id, :tag_ids_by_attached_object
+  attr_accessor :cache, :categories_by_id, :tags_by_id, :tag_ids_by_attached_object
 
   private
 
@@ -149,14 +149,12 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
 
     _log.info("#{log_header} Connecting to #{username}@#{host}...")
 
-    self.ca_file = build_ca_file
-
     vim_opts = {
       :ns       => 'urn:vim25',
       :host     => host,
       :ssl      => true,
       :insecure => insecure,
-      :ca_file  => ca_file&.path,
+      :ca_cert  => ems.certificate_authority,
       :path     => '/sdk',
       :port     => port,
       :rev      => '6.5',
@@ -171,15 +169,6 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
 
     _log.info("#{log_header} Connected")
     conn
-  end
-
-  def build_ca_file
-    return if ems.certificate_authority.blank?
-
-    Tempfile.new.tap do |f|
-      f.write(ems.certificate_authority)
-      f.close
-    end
   end
 
   def pbm_connect(vim)
@@ -204,13 +193,6 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
       vim.close
     rescue => err
       _log.warn("Failed to logout of session: #{err}")
-    end
-
-    # Cleanup the certificate authority file if it exists
-    if ca_file
-      ca_file.close
-      ca_file.unlink
-      self.ca_file = nil
     end
   rescue => err
     _log.warn("Failed to disconnect: #{err}")

--- a/manageiq-providers-vmware.gemspec
+++ b/manageiq-providers-vmware.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "ffi-vix_disk_lib",       "~>1.4"
   spec.add_dependency "fog-vcloud-director",    "~> 0.3.0"
-  spec.add_dependency "rbvmomi2",               "~>3.9"
+  spec.add_dependency "rbvmomi2",               "~>3.10"
   spec.add_dependency "vmware_web_service",     "~>3.3"
   spec.add_dependency "vsphere-automation-sdk", "~>0.4.7"
 

--- a/workers/event_catcher/event_catcher.rb
+++ b/workers/event_catcher/event_catcher.rb
@@ -66,6 +66,7 @@ class EventCatcher
       :host     => endpoint["hostname"],
       :port     => endpoint["port"] || 443,
       :insecure => endpoint["verify_ssl"] == OpenSSL::SSL::VERIFY_NONE,
+      :ca_cert  => endpoint["certificate_authority"],
       :path     => '/sdk',
       :rev      => '7.0',
     }

--- a/workers/event_catcher/worker
+++ b/workers/event_catcher/worker
@@ -6,8 +6,8 @@ gemfile(false) do
   source "https://rubygems.org"
 
   gem "manageiq-loggers", "~>1.2"
-  gem "manageiq-messaging", "~> 2.0"
-  gem "rbvmomi2", "~>3.8"
+  gem "manageiq-messaging", "~>2.0"
+  gem "rbvmomi2", "~>3.10"
   if ENV.fetch("APPLIANCE", nil)
     gem "sd_notify", "~>0.1.0"
     gem "systemd-journal", "~>1.4.2"


### PR DESCRIPTION
Build an OpenSSL cert store rather than writing the certificate authority cert to a temp file that has to be unlinked after logout.

I had thought all options were passed directly to `Net::HTTP` but `RbVmomi::TrivialSoap` is pulling out specific options keys so this depends on a change in `RbVmomi`.

Depends:
- [x] https://github.com/ManageIQ/rbvmomi2/pull/84
- [x] Release of rbvmomi2 3.10

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
