### PR TITLE
Drop vSphere 6.x support

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -146,6 +146,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
     username, password = ems.auth_user_pwd
 
     insecure = ems.verify_ssl == OpenSSL::SSL::VERIFY_NONE
+    settings = Settings.ems.ems_vmware
 
     _log.info("#{log_header} Connecting to #{username}@#{host}...")
 
@@ -157,8 +158,8 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
       :ca_cert  => ems.certificate_authority,
       :path     => '/sdk',
       :port     => port,
-      :rev      => '7.0',
-      :debug    => Settings.ems.ems_vmware.debug_vim_requests
+      :rev      => settings.minimum_supported_version,
+      :debug    => settings.debug_vim_requests
     }
 
     require 'rbvmomi'

--- a/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/inventory/collector.rb
@@ -157,7 +157,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Inventory::Collector
       :ca_cert  => ems.certificate_authority,
       :path     => '/sdk',
       :port     => port,
-      :rev      => '6.5',
+      :rev      => '7.0',
       :debug    => Settings.ems.ems_vmware.debug_vim_requests
     }
 

--- a/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
@@ -57,6 +57,8 @@ module ManageIQ::Providers::Vmware::InfraManager::VimConnectMixin
   end
 
   module ClassMethods
+    MINIMUM_SUPPORTED_VERSION = "7.0".freeze
+
     def raw_connect(options)
       require 'handsoap'
       require 'VMwareWebService/MiqVim'
@@ -79,6 +81,9 @@ module ManageIQ::Providers::Vmware::InfraManager::VimConnectMixin
 
         raise MiqException::Error, _("Adding ESX/ESXi Hosts is not supported") if !vim.isVirtualCenter && !Settings.prototype.ems_vmware.allow_direct_hosts
         raise MiqException::Error, _("vCenter version %{version} is unsupported") % {:version => vim.apiVersion} if !version_supported?(vim.apiVersion)
+        if Gem::Version.new(vim.apiVersion) < Gem::Version.new(MINIMUM_SUPPORTED_VERSION)
+          _log.warn("vCenter version [#{vim.apiVersion}] is below the minimum supported version [#{MINIMUM_SUPPORTED_VERSION}]")
+        end
 
         # If the time on the vCenter is very far off from MIQ system time then
         # any comparison of last_refresh_on and VMware TaskInfo.completeTime can be
@@ -93,7 +98,8 @@ module ManageIQ::Providers::Vmware::InfraManager::VimConnectMixin
     end
 
     def version_supported?(api_version)
-      Gem::Version.new(api_version) >= Gem::Version.new('7.0')
+      minimum_version = Settings.ems.ems_vmware.minimum_supported_version || MINIMUM_SUPPORTED_VERSION
+      Gem::Version.new(api_version) >= Gem::Version.new(minimum_version)
     end
 
     def validate_connection

--- a/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
@@ -93,7 +93,7 @@ module ManageIQ::Providers::Vmware::InfraManager::VimConnectMixin
     end
 
     def version_supported?(api_version)
-      Gem::Version.new(api_version) >= Gem::Version.new('6.0')
+      Gem::Version.new(api_version) >= Gem::Version.new('7.0')
     end
 
     def validate_connection

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,6 +28,7 @@
       :historical: 100
       :hourly: 250
       :realtime: 100
+    :minimum_supported_version: "7.0"
   :ems_vmware_cloud:
     :blacklisted_event_names: []
   :ems_vmware_tanzu:

--- a/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
@@ -98,6 +98,42 @@ describe ManageIQ::Providers::Vmware::InfraManager do
           .to raise_error(MiqException::Error, "vCenter version #{api_version} is unsupported")
       end
     end
+
+    context "vCenter version below recommended minimum" do
+      let(:api_version) { '6.5.0' }
+
+      before do
+        stub_settings_merge(:ems => {:ems_vmware => {:minimum_supported_version => "6.0"}})
+      end
+
+      it "is successful but logs a warning" do
+        expect(described_class._log).to receive(:warn).with("vCenter version [6.5.0] is below the minimum supported version [7.0]")
+        expect(described_class.verify_credentials(verify_params)).to be_truthy
+      end
+    end
+  end
+
+  describe ".version_supported?" do
+    it "returns true for version equal to minimum_supported_version" do
+      stub_settings_merge(:ems => {:ems_vmware => {:minimum_supported_version => "6.5"}})
+      expect(described_class.version_supported?("6.5.0")).to be_truthy
+    end
+
+    it "returns true for version greater than minimum_supported_version" do
+      stub_settings_merge(:ems => {:ems_vmware => {:minimum_supported_version => "6.5"}})
+      expect(described_class.version_supported?("7.0.0")).to be_truthy
+    end
+
+    it "returns false for version less than minimum_supported_version" do
+      stub_settings_merge(:ems => {:ems_vmware => {:minimum_supported_version => "6.5"}})
+      expect(described_class.version_supported?("6.0.0")).to be_falsey
+    end
+
+    it "uses the configured minimum_supported_version setting" do
+      stub_settings_merge(:ems => {:ems_vmware => {:minimum_supported_version => "7.0"}})
+      expect(described_class.version_supported?("6.5.0")).to be_falsey
+      expect(described_class.version_supported?("7.0.0")).to be_truthy
+    end
   end
 
   context "#verify_credentials" do

--- a/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
@@ -45,7 +45,7 @@ describe ManageIQ::Providers::Vmware::InfraManager do
     let(:verify_params) { {"endpoints" => {"default" => {"hostname" => "vcenter"}}, "authentications" => {"default" => {"username" => "root", "password" => "vmware"}}} }
     let(:current_time)  { Time.now.utc.to_s }
     let(:is_virtual_center) { true }
-    let(:api_version) { '6.5.0' }
+    let(:api_version) { '7.0.0' }
 
     before do
       miq_vim = double("VMwareWebService/MiqVim")
@@ -103,7 +103,7 @@ describe ManageIQ::Providers::Vmware::InfraManager do
   context "#verify_credentials" do
     let(:ems) { FactoryBot.create(:ems_vmware_with_authentication) }
     let(:current_time) { Time.now.utc.to_s }
-    let(:api_version) { '6.5.0' }
+    let(:api_version) { '7.0.0' }
 
     before do
       miq_vim = double("VMwareWebService/MiqVim")

--- a/workers/event_catcher/event_catcher.rb
+++ b/workers/event_catcher/event_catcher.rb
@@ -68,7 +68,7 @@ class EventCatcher
       :insecure => endpoint["verify_ssl"] == OpenSSL::SSL::VERIFY_NONE,
       :ca_cert  => endpoint["certificate_authority"],
       :path     => '/sdk',
-      :rev      => '7.0',
+      :rev      => settings.dig("ems", "ems_vmware", "minimum_supported_version") || "7.0",
     }
 
     RbVmomi::VIM.new(vim_opts).tap do |vim|


### PR DESCRIPTION
End of general support for 6.0 was 2020, and 6.5/6.7 was 2022.

https://knowledge.broadcom.com/external/article/318892/end-of-general-support-for-vsphere-60.html
https://knowledge.broadcom.com/external/article/326984/end-of-general-support-for-vsan-656667.html

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
