### PR TITLE
Fix Validation Message for SSL Errors

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb
@@ -135,7 +135,7 @@ module ManageIQ::Providers::Vmware::InfraManager::VimConnectMixin
 
     def validate_connection
       yield
-    rescue SocketError, Errno::EHOSTUNREACH, Errno::ENETUNREACH
+    rescue SocketError, Errno::EHOSTUNREACH, Errno::ENETUNREACH, OpenSSL::SSL::SSLError
       _log.warn($!.inspect)
       raise MiqException::MiqUnreachableError, $!.message
     rescue Handsoap::Fault

--- a/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager_spec.rb
@@ -47,68 +47,80 @@ describe ManageIQ::Providers::Vmware::InfraManager do
     let(:is_virtual_center) { true }
     let(:api_version) { '7.0.0' }
 
-    before do
-      miq_vim = double("VMwareWebService/MiqVim")
-      allow(miq_vim).to receive(:isVirtualCenter).and_return(is_virtual_center)
-      allow(miq_vim).to receive(:currentTime).and_return(current_time)
-      allow(miq_vim).to receive(:apiVersion).and_return(api_version)
-      allow(miq_vim).to receive(:disconnect)
+    context "returning a MiqVim object" do
+      before do
+        miq_vim = double("VMwareWebService/MiqVim")
+        allow(miq_vim).to receive(:isVirtualCenter).and_return(is_virtual_center)
+        allow(miq_vim).to receive(:currentTime).and_return(current_time)
+        allow(miq_vim).to receive(:apiVersion).and_return(api_version)
+        allow(miq_vim).to receive(:disconnect)
 
-      require "VMwareWebService/MiqVim"
-      expect(MiqVim).to receive(:new).and_return(miq_vim)
-    end
-
-    context "virtual-center" do
-      it "is successful" do
-        expect(described_class.verify_credentials(verify_params)).to be_truthy
-      end
-    end
-
-    context "esxi host" do
-      let(:is_virtual_center) { false }
-
-      it "returns a failure" do
-        expect { described_class.verify_credentials(verify_params) }
-          .to raise_error(MiqException::Error, "Adding ESX/ESXi Hosts is not supported")
+        require "VMwareWebService/MiqVim"
+        expect(MiqVim).to receive(:new).and_return(miq_vim)
       end
 
-      context "with allow_direct_hosts setting set to true" do
-        before { stub_settings_merge(:prototype => {:ems_vmware => {:allow_direct_hosts => true}}) }
-
+      context "virtual-center" do
         it "is successful" do
+          expect(described_class.verify_credentials(verify_params)).to be_truthy
+        end
+      end
+
+      context "esxi host" do
+        let(:is_virtual_center) { false }
+
+        it "returns a failure" do
+          expect { described_class.verify_credentials(verify_params) }
+            .to raise_error(MiqException::Error, "Adding ESX/ESXi Hosts is not supported")
+        end
+
+        context "with allow_direct_hosts setting set to true" do
+          before { stub_settings_merge(:prototype => {:ems_vmware => {:allow_direct_hosts => true}}) }
+
+          it "is successful" do
+            expect(described_class.verify_credentials(verify_params)).to be_truthy
+          end
+        end
+      end
+
+      context "vCenter currentTime out of sync" do
+        let(:current_time) { 1.hour.ago.utc.to_s }
+
+        it "returns a failure" do
+          expect { described_class.verify_credentials(verify_params) }
+            .to raise_error(MiqException::Error, "vCenter time is too far out of sync with the system time")
+        end
+      end
+
+      context "unsupported vCenter version" do
+        let(:api_version) { '5.5.0' }
+
+        it "returns a failure" do
+          expect { described_class.verify_credentials(verify_params) }
+            .to raise_error(MiqException::Error, "vCenter version #{api_version} is unsupported")
+        end
+      end
+
+      context "vCenter version below recommended minimum" do
+        let(:api_version) { '6.5.0' }
+
+        before do
+          stub_settings_merge(:ems => {:ems_vmware => {:minimum_supported_version => "6.0"}})
+        end
+
+        it "is successful but logs a warning" do
+          expect(described_class._log).to receive(:warn).with("vCenter version [6.5.0] is below the minimum supported version [7.0]")
           expect(described_class.verify_credentials(verify_params)).to be_truthy
         end
       end
     end
 
-    context "vCenter currentTime out of sync" do
-      let(:current_time) { 1.hour.ago.utc.to_s }
-
+    context "SSL certificate error" do
       it "returns a failure" do
+        require "VMwareWebService/MiqVim"
+        expect(MiqVim).to receive(:new).and_raise(OpenSSL::SSL::SSLError.new("certificate verify failed"))
+
         expect { described_class.verify_credentials(verify_params) }
-          .to raise_error(MiqException::Error, "vCenter time is too far out of sync with the system time")
-      end
-    end
-
-    context "unsupported vCenter version" do
-      let(:api_version) { '5.5.0' }
-
-      it "returns a failure" do
-        expect { described_class.verify_credentials(verify_params) }
-          .to raise_error(MiqException::Error, "vCenter version #{api_version} is unsupported")
-      end
-    end
-
-    context "vCenter version below recommended minimum" do
-      let(:api_version) { '6.5.0' }
-
-      before do
-        stub_settings_merge(:ems => {:ems_vmware => {:minimum_supported_version => "6.0"}})
-      end
-
-      it "is successful but logs a warning" do
-        expect(described_class._log).to receive(:warn).with("vCenter version [6.5.0] is below the minimum supported version [7.0]")
-        expect(described_class.verify_credentials(verify_params)).to be_truthy
+          .to raise_error(MiqException::MiqUnreachableError, "certificate verify failed")
       end
     end
   end


### PR DESCRIPTION
If credential validation fails due to SSL verification we were raising the fallback `"Unexpected response returned from Provider"` which isn't helpful in telling the user what needs to be fixed.

Catch `OpenSSL::SSL::SSLError` exception so that it is clear that the reason for the validation failure is clear to the user.

Before:
<img width="858" height="123" alt="Screenshot From 2026-05-28 09-12-51" src="https://github.com/user-attachments/assets/015efc73-80c6-4246-8785-78cef8400f1a" />

After:
<img width="858" height="123" alt="Screenshot From 2026-05-28 09-12-34" src="https://github.com/user-attachments/assets/dc9cc267-dabe-4f98-be6e-d50babab78b0" />

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
