### PR TITLE
Fix `Internal Error: unexpected return` in supports

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/host_esx.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/host_esx.rb
@@ -3,28 +3,46 @@ class ManageIQ::Providers::Vmware::InfraManager::HostEsx < ManageIQ::Providers::
   supports :refresh_firewall_rules
   supports :refresh_logs
   supports :start do
-    return _("The Host is not connected to an active Provider") unless has_active_ems?
-    return _("The host is not in standby")                      unless power_state == "standby"
+    if !has_active_ems?
+      _("The Host is not connected to an active Provider")
+    else
+      _("The host is not in standby") unless power_state == "standby"
+    end
   end
   supports :reboot do
-    return _("The Host is not connected to an active Provider") unless has_active_ems?
-    return _("The host is not running")                         unless power_state == "on"
+    if !has_active_ems?
+      _("The Host is not connected to an active Provider")
+    else
+      _("The host is not running") unless power_state == "on"
+    end
   end
   supports :shutdown do
-    return _("The Host is not connected to an active Provider") unless has_active_ems?
-    return _("The host is not running")                         unless power_state == "on"
+    if !has_active_ems?
+      _("The Host is not connected to an active Provider")
+    else
+      _("The host is not running") unless power_state == "on"
+    end
   end
   supports :standby do
-    return _("The Host is not connected to an active Provider") unless has_active_ems?
-    return _("The host is not running")                         unless power_state == "on"
+    if !has_active_ems?
+      _("The Host is not connected to an active Provider")
+    else
+      _("The host is not running") unless power_state == "on"
+    end
   end
   supports :enter_maint_mode do
-    return _("The Host is not connected to an active Provider") unless has_active_ems?
-    return _("The host is not running")                         unless power_state == "on"
+    if !has_active_ems?
+      _("The Host is not connected to an active Provider")
+    else
+      _("The host is not running") unless power_state == "on"
+    end
   end
   supports :exit_maint_mode do
-    return _("The Host is not connected to an active Provider") unless has_active_ems?
-    return _("The host is not in maintenance mode")             unless power_state == "maintenance"
+    if !has_active_ems?
+      _("The Host is not connected to an active Provider")
+    else
+      _("The host is not in maintenance mode") unless power_state == "maintenance"
+    end
   end
   supports :enable_vmotion do
     validate_active_with_power_state

--- a/spec/models/manageiq/providers/vmware/infra_manager/host_esx_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/host_esx_spec.rb
@@ -1,7 +1,9 @@
 describe ManageIQ::Providers::Vmware::InfraManager::HostEsx do
-  let(:ems)  { FactoryBot.create(:ems_vmware_with_authentication) }
-  let(:host) { FactoryBot.create(:host_vmware_esx, :ext_management_system => ems) }
+  include Spec::Support::SupportsHelper
 
+  let(:ems)          { FactoryBot.create(:ems_vmware_with_authentication) }
+  let(:host)         { FactoryBot.create(:host_vmware_esx, :ext_management_system => ems, :power_state => power_state) }
+  let(:power_state)  { "on" }
   let(:miq_vim)      { double("VMwareWebService/MiqVim") }
   let(:miq_vim_host) { MiqVimHost.new(miq_vim, "summary" => {"config" => {}}) }
 
@@ -12,6 +14,277 @@ describe ManageIQ::Providers::Vmware::InfraManager::HostEsx do
     allow(miq_vim).to receive(:sic)
     allow(miq_vim).to receive(:about).and_return("apiType" => "VirtualCenter")
     allow(miq_vim).to receive(:getVimHostByMor).and_return(miq_vim_host)
+  end
+
+  describe "supports features" do
+    before { EvmSpecHelper.local_miq_server }
+
+    describe ":refresh_advanced_settings" do
+      it "is supported" do
+        expect(host.supports?(:refresh_advanced_settings)).to be_truthy
+      end
+    end
+
+    describe ":refresh_firewall_rules" do
+      it "is supported" do
+        expect(host.supports?(:refresh_firewall_rules)).to be_truthy
+      end
+    end
+
+    describe ":refresh_logs" do
+      it "is supported" do
+        expect(host.supports?(:refresh_logs)).to be_truthy
+      end
+    end
+
+    describe ":start" do
+      context "when host is in standby" do
+        let(:power_state) { "standby" }
+
+        it "is supported" do
+          expect(host.supports?(:start)).to be_truthy
+        end
+      end
+
+      context "when host is on" do
+        let(:power_state) { "on" }
+
+        it "is not supported" do
+          expect(host.supports?(:start)).to be_falsey
+          expect(host.unsupported_reason(:start)).to eq("The host is not in standby")
+        end
+      end
+
+      context "when host has no active provider" do
+        let(:ems) { nil }
+
+        it "is not supported" do
+          expect(host.supports?(:start)).to be_falsey
+          expect(host.unsupported_reason(:start)).to eq("The Host is not connected to an active Provider")
+        end
+      end
+    end
+
+    describe ":reboot" do
+      context "when host is on" do
+        let(:power_state) { "on" }
+
+        it "is supported" do
+          expect(host.supports?(:reboot)).to be_truthy
+        end
+      end
+
+      context "when host is off" do
+        let(:power_state) { "off" }
+
+        it "is not supported" do
+          expect(host.supports?(:reboot)).to be_falsey
+          expect(host.unsupported_reason(:reboot)).to eq("The host is not running")
+        end
+      end
+
+      context "when host has no active provider" do
+        let(:ems) { nil }
+
+        it "is not supported" do
+          expect(host.supports?(:reboot)).to be_falsey
+          expect(host.unsupported_reason(:reboot)).to eq("The Host is not connected to an active Provider")
+        end
+      end
+    end
+
+    describe ":shutdown" do
+      context "when host is on" do
+        let(:power_state) { "on" }
+
+        it "is supported" do
+          expect(host.supports?(:shutdown)).to be_truthy
+        end
+      end
+
+      context "when host is off" do
+        let(:power_state) { "off" }
+
+        it "is not supported" do
+          expect(host.supports?(:shutdown)).to be_falsey
+          expect(host.unsupported_reason(:shutdown)).to eq("The host is not running")
+        end
+      end
+
+      context "when host has no active provider" do
+        let(:ems) { nil }
+
+        it "is not supported" do
+          expect(host.supports?(:shutdown)).to be_falsey
+          expect(host.unsupported_reason(:shutdown)).to eq("The Host is not connected to an active Provider")
+        end
+      end
+    end
+
+    describe ":standby" do
+      context "when host is on" do
+        let(:host) { FactoryBot.create(:host_vmware_esx, :ext_management_system => ems, :power_state => "on") }
+
+        it "is supported" do
+          expect(host.supports?(:standby)).to be_truthy
+        end
+      end
+
+      context "when host is off" do
+        let(:host) { FactoryBot.create(:host_vmware_esx, :ext_management_system => ems, :power_state => "off") }
+
+        it "is not supported" do
+          expect(host.supports?(:standby)).to be_falsey
+          expect(host.unsupported_reason(:standby)).to eq("The host is not running")
+        end
+      end
+
+      context "when host has no active provider" do
+        let(:host) { FactoryBot.create(:host_vmware_esx, :ext_management_system => nil, :power_state => "on") }
+
+        it "is not supported" do
+          expect(host.supports?(:standby)).to be_falsey
+          expect(host.unsupported_reason(:standby)).to eq("The Host is not connected to an active Provider")
+        end
+      end
+    end
+
+    describe ":enter_maint_mode" do
+      context "when host is on" do
+        let(:power_state) { "on" }
+
+        it "is supported" do
+          expect(host.supports?(:enter_maint_mode)).to be_truthy
+        end
+      end
+
+      context "when host is off" do
+        let(:power_state) { "off" }
+
+        it "is not supported" do
+          expect(host.supports?(:enter_maint_mode)).to be_falsey
+          expect(host.unsupported_reason(:enter_maint_mode)).to eq("The host is not running")
+        end
+      end
+
+      context "when host has no active provider" do
+        let(:ems) { nil }
+
+        it "is not supported" do
+          expect(host.supports?(:enter_maint_mode)).to be_falsey
+          expect(host.unsupported_reason(:enter_maint_mode)).to eq("The Host is not connected to an active Provider")
+        end
+      end
+    end
+
+    describe ":exit_maint_mode" do
+      context "when host is in maintenance mode" do
+        let(:power_state) { "maintenance" }
+
+        it "is supported" do
+          expect(host.supports?(:exit_maint_mode)).to be_truthy
+        end
+      end
+
+      context "when host is on but not in maintenance mode" do
+        let(:power_state) { "on" }
+
+        it "is not supported" do
+          expect(host.supports?(:exit_maint_mode)).to be_falsey
+          expect(host.unsupported_reason(:exit_maint_mode)).to eq("The host is not in maintenance mode")
+        end
+      end
+
+      context "when host has no active provider" do
+        let(:power_state) { "maintenance" }
+        let(:ems)         { nil }
+
+        it "is not supported" do
+          expect(host.supports?(:exit_maint_mode)).to be_falsey
+          expect(host.unsupported_reason(:exit_maint_mode)).to eq("The Host is not connected to an active Provider")
+        end
+      end
+    end
+
+    describe ":enable_vmotion" do
+      context "when host is on with active provider" do
+        it "is supported" do
+          expect(host.supports?(:enable_vmotion)).to be_truthy
+        end
+      end
+
+      context "when host is off" do
+        let(:power_state) { "off" }
+
+        it "is not supported" do
+          expect(host.supports?(:enable_vmotion)).to be_falsey
+          expect(host.unsupported_reason(:enable_vmotion)).to eq("The host is not powered 'on'")
+        end
+      end
+
+      context "when host has no active provider" do
+        let(:ems) { nil }
+
+        it "is not supported" do
+          expect(host.supports?(:enable_vmotion)).to be_falsey
+          expect(host.unsupported_reason(:enable_vmotion)).to eq("The Host is not connected to an active Provider")
+        end
+      end
+    end
+
+    describe ":disable_vmotion" do
+      context "when host is on with active provider" do
+        it "is supported" do
+          expect(host.supports?(:disable_vmotion)).to be_truthy
+        end
+      end
+
+      context "when host is off" do
+        let(:power_state) { "off" }
+
+        it "is not supported" do
+          expect(host.supports?(:disable_vmotion)).to be_falsey
+          expect(host.unsupported_reason(:disable_vmotion)).to eq("The host is not powered 'on'")
+        end
+      end
+
+      context "when host has no active provider" do
+        let(:ems) { nil }
+
+        it "is not supported" do
+          expect(host.supports?(:disable_vmotion)).to be_falsey
+          expect(host.unsupported_reason(:disable_vmotion)).to eq("The Host is not connected to an active Provider")
+        end
+      end
+    end
+
+    describe ":vmotion_enabled" do
+      context "when host is on with active provider" do
+        let(:power_state) { "on" }
+
+        it "is supported" do
+          expect(host.supports?(:vmotion_enabled)).to be_truthy
+        end
+      end
+
+      context "when host is off" do
+        let(:power_state) { "off" }
+
+        it "is not supported" do
+          expect(host.supports?(:vmotion_enabled)).to be_falsey
+          expect(host.unsupported_reason(:vmotion_enabled)).to eq("The host is not powered 'on'")
+        end
+      end
+
+      context "when host has no active provider" do
+        let(:ems) { nil }
+
+        it "is not supported" do
+          expect(host.supports?(:vmotion_enabled)).to be_falsey
+          expect(host.unsupported_reason(:vmotion_enabled)).to eq("The Host is not connected to an active Provider")
+        end
+      end
+    end
   end
 
   describe "#vim_firewall_rules" do


### PR DESCRIPTION
```
[----] E, [2026-06-11T08:17:42.663308#1507259:f76e8] ERROR -- evm: [LocalJumpError]: unexpected return  Method:[block in method_missing]
[----] E, [2026-06-11T08:17:42.663341#1507259:f76e8] ERROR -- evm: /home/grare/adam/src/manageiq/manageiq-providers-vmware/app/models/manageiq/providers/vmware/infra_manager/host_esx.rb:27:in `block in <class:HostEsx>'
/home/grare/adam/src/manageiq/manageiq/app/models/mixins/supports_feature_mixin.rb:93:in `instance_eval'
/home/grare/adam/src/manageiq/manageiq/app/models/mixins/supports_feature_mixin.rb:93:in `unsupported_reason'
/home/grare/adam/src/manageiq/manageiq/app/models/mixins/supports_feature_mixin.rb:60:in `unsupported_reason'
/home/grare/adam/src/manageiq/manageiq/app/models/mixins/supports_feature_mixin.rb:65:in `supports?'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/helpers/application_helper.rb:210:in `block in records_support_feature?'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/helpers/application_helper.rb:210:in `all?'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/helpers/application_helper.rb:210:in `records_support_feature?'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/helpers/application_helper/button/generic_feature_button.rb:12:in `visible?'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/helpers/application_helper/button/basic.rb:81:in `skipped?'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:69:in `toolbar_button'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:86:in `block in build_select_button'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:81:in `each'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:81:in `each_with_index'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:81:in `build_select_button'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:177:in `build_button'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:441:in `block (2 levels) in build_toolbar_from_class'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:440:in `each'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:440:in `block in build_toolbar_from_class'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:435:in `each'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:435:in `each_with_index'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:435:in `build_toolbar_from_class'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/helpers/application_helper/toolbar_builder.rb:16:in `build_toolbar'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/helpers/application_helper.rb:455:in `build_toolbar'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/helpers/toolbar_helper.rb:7:in `block in toolbar_from_hash'
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
